### PR TITLE
Expand and reorganize Read the Docs content

### DIFF
--- a/docs/appendix/faq.rst
+++ b/docs/appendix/faq.rst
@@ -1,0 +1,43 @@
+Frequently asked questions
+==========================
+
+**Do I need an account to use the editor?**
+  No. All modelling features are available without authentication. Collaboration
+  features require deploying the server but do not require user accounts.
+
+**Where are my diagrams stored?**
+  In static mode, diagrams are stored in browser local storage. With the server,
+  diagrams persist in the filesystem (``diagrams/``) or Redis depending on
+  configuration.
+
+**Can I export diagrams to SVG/PDF?**
+  Yes. Use ``File → Export``. The server provides endpoints for automated exports.
+
+**How do I enable collaboration?**
+  Set ``APPLICATION_SERVER_VERSION=1`` and deploy the server. Share links become
+  available in the application bar.
+
+**What browsers are supported?**
+  Modern Chromium-based browsers and Firefox. The UI warns about known
+  limitations (``FirefoxIncompatibilityHint``) when necessary.
+
+**Is there an API?**
+  Yes. The server exposes REST endpoints under ``/api`` for retrieving diagrams,
+  publishing versions, and exporting PDFs.
+
+**Can I customise templates?**
+  Add or edit templates under :file:`packages/webapp/src/main/templates` and run
+  ``npm run build:webapp``.
+
+**How do I report a bug?**
+  Use GitHub issues or the bug report link in the application bar (see
+  ``bugReportURL`` in :file:`packages/webapp/src/main/constant.ts`). Include steps
+  to reproduce and exported diagrams if possible.
+
+**How do I upgrade?**
+  Pull the latest changes, run ``npm install``, rebuild (``npm run build``), and
+  review :doc:`../getting-started/upgrading` for migration notes.
+
+**Can I integrate with the broader BESSER platform?**
+  Yes. Export diagram JSON and feed it into BESSER low-code workflows or backend
+  services.

--- a/docs/appendix/glossary.rst
+++ b/docs/appendix/glossary.rst
@@ -1,0 +1,18 @@
+Glossary
+========
+
+Apollon
+    The underlying modelling toolkit powering ``@besser/wme`` and the editor.
+Diagram token
+    A randomly generated string identifying a shared diagram. Used in URLs and
+    storage keys.
+RedisJSON
+    Redis module that enables storing JSON documents and manipulating them with
+    JSONPath queries. Required when using Redis storage.
+Version history
+    Timeline of saved diagram revisions managed by ``DiagramService``.
+WebSocket
+    Bidirectional communication channel used by ``CollaborationService`` to share
+    edits in real time.
+Workspace
+    The npm workspace containing editor, server, shared, and webapp packages.

--- a/docs/appendix/index.rst
+++ b/docs/appendix/index.rst
@@ -1,0 +1,11 @@
+Appendix
+========
+
+Reference materials, frequently asked questions, and troubleshooting steps.
+
+.. toctree::
+   :maxdepth: 2
+
+   faq
+   glossary
+   troubleshooting

--- a/docs/appendix/troubleshooting.rst
+++ b/docs/appendix/troubleshooting.rst
@@ -1,0 +1,50 @@
+Troubleshooting
+===============
+
+Common issues and how to resolve them.
+
+Editor fails to load
+--------------------
+
+* Verify static assets are served correctly and that the SPA fallback rewrites
+  unknown routes to ``index.html``.
+* Check browser console for missing environment variables or blocked requests.
+
+Share links return 404
+----------------------
+
+* Ensure the collaboration server is running and has access to the ``diagrams``
+  directory or Redis instance.
+* Confirm ``DEPLOYMENT_URL`` matches the origin used to generate links.
+
+WebSocket connection errors
+---------------------------
+
+* Verify reverse proxies forward ``Upgrade`` and ``Connection`` headers.
+* Check firewall rules and load balancer settings for port 8080 (or custom port).
+* Review server logs for heartbeat timeouts triggered by ``CollaborationService``.
+
+PDF export fails
+----------------
+
+* Confirm the server has ``node-canvas`` dependencies installed (libcairo,
+  pango, etc.).
+* Ensure the export payload includes ``width`` and ``height``.
+
+Redis errors
+------------
+
+* Verify RedisJSON module is enabled.
+* Check credentials and network access in ``APOLLON_REDIS_URL``.
+* Inspect TTL values when diagrams expire earlier than expected.
+
+UI glitches after upgrade
+-------------------------
+
+* Clear browser cache or use hard reload (``Ctrl+Shift+R``).
+* Rebuild the webapp to ensure template and style changes are bundled.
+
+Need more help?
+---------------
+
+Reach out via the support channels listed in :doc:`../operations/support`.

--- a/docs/backend/background-jobs.rst
+++ b/docs/backend/background-jobs.rst
@@ -1,0 +1,49 @@
+Background jobs
+===============
+
+Routine maintenance ensures collaboration data remains healthy. The repository
+includes cron job examples and guidance for managing scheduled work.
+
+Deleting stale diagrams
+-----------------------
+
+* ``delete-stale-diagrams.cronjob.txt`` defines a cron entry that removes shared
+  diagrams older than 12 weeks from the filesystem.
+* Update the target path inside the cron file to match your ``diagrams``
+  directory.
+* Install the cron job under the service user::
+
+    crontab -u besser_wme_standalone delete-stale-diagrams.cronjob.txt
+
+* Logs are written to ``/var/log/cron.log`` by default. Create the file and set
+  permissions before scheduling the job.
+
+Redis retention
+---------------
+
+* Configure ``APOLLON_REDIS_DIAGRAM_TTL`` to expire diagrams automatically.
+* Use Redis keyspace notifications if you want to trigger clean-up workflows when
+  diagrams expire.
+
+Other scheduled tasks
+---------------------
+
+Consider adding the following automation depending on your deployment:
+
+* **Backups** – scheduled sync of the ``diagrams`` directory or Redis snapshots.
+* **Metrics export** – cron jobs that push health metrics to monitoring systems.
+* **Dependency updates** – periodic ``npm run update`` executed in CI to keep
+  packages fresh.
+
+Operational tips
+----------------
+
+* Run background jobs as the dedicated ``besser_wme_standalone`` system user to
+  avoid permission issues.
+* Document scheduling windows to avoid running maintenance during peak usage.
+
+Next steps
+----------
+
+Proceed to the :doc:`../frontend/index` section for front-end implementation
+details.

--- a/docs/backend/collaboration-services.rst
+++ b/docs/backend/collaboration-services.rst
@@ -1,0 +1,69 @@
+Collaboration services
+======================
+
+The WebSocket layer enables real-time editing, presence tracking, and selection
+broadcasting. ``CollaborationService`` orchestrates these capabilities.
+
+WebSocket server
+----------------
+
+* ``CollaborationService`` initialises a ``ws`` server in no-server mode so that
+  ``server.ts`` can upgrade HTTP requests when required.
+* Client sockets receive a generated ``apollonId`` and heartbeat ping every
+  2 seconds. Idle sockets are terminated to free resources.
+
+Connection lifecycle
+--------------------
+
+* ``onConnection`` associates a client socket with a diagram token and broadcasts
+  collaborator lists to other clients working on the same token.
+* ``onConnectionLost`` removes disconnected clients and notifies remaining peers.
+* ``onCollaboratorUpdate`` propagates metadata changes (name, colour) to peers.
+
+Patch distribution
+------------------
+
+* ``onDiagramPatch`` persists the JSON patch via ``DiagramStorageService`` and
+  broadcasts the change, including the originating collaborator.
+* ``onSelection`` sends live cursor/selection updates to peers without persisting
+  them.
+* Rate-limited storage ensures patch bursts do not overwhelm the backend.
+
+Payload structure
+-----------------
+
+Messages exchanged between client and server follow this structure::
+
+  {
+    "token": "diagram-token",
+    "collaborator": { "name": "Alice", "color": "#FF0000" },
+    "patch": { ... },
+    "selection": { ... }
+  }
+
+Security and validation
+-----------------------
+
+* Tokens are validated client-side before establishing WebSocket connections.
+* Add authentication by verifying cookies or headers within ``handleUpgrade``.
+* Consider rate limiting or bounding message sizes to mitigate abuse.
+
+Extensibility
+-------------
+
+* Extend collaboration metadata by updating the ``Collaborator`` interface in
+  :file:`packages/shared` and adjusting message handlers.
+* Integrate presence indicators in the UI by consuming collaborator lists from
+  broadcast messages.
+
+Monitoring
+----------
+
+* Log connection counts and patch rates to detect hot diagrams.
+* Capture WebSocket errors via Sentry by wrapping message handlers in ``try``/``catch``.
+
+Next steps
+----------
+
+Continue with :doc:`security-and-observability` to harden and monitor your server
+deployment.

--- a/docs/backend/index.rst
+++ b/docs/backend/index.rst
@@ -1,0 +1,16 @@
+Backend
+=======
+
+The collaboration server is an Express application that exposes REST APIs,
+WebSocket endpoints, and background services. These pages document the runtime
+behaviour and extension points.
+
+.. toctree::
+   :maxdepth: 2
+
+   server-overview
+   rest-api
+   storage
+   collaboration-services
+   security-and-observability
+   background-jobs

--- a/docs/backend/rest-api.rst
+++ b/docs/backend/rest-api.rst
@@ -1,0 +1,69 @@
+REST API
+========
+
+The collaboration server exposes a small REST surface under the ``/api``
+namespace. All endpoints accept and respond with JSON unless otherwise noted.
+
+Authentication
+--------------
+
+* The default deployment does not enforce authentication.
+* Apply additional middleware (JWT, OAuth) by extending
+  :file:`packages/server/src/main/routes.ts`.
+
+Endpoints
+---------
+
+``GET /api/diagrams/:token``
+    Retrieves a diagram by share token. When ``?type=svg`` is provided, the server
+    converts the diagram to SVG using ``ConversionService`` and returns it with a
+    white background.
+``POST /api/diagrams/publish``
+    Creates or updates a diagram version. Payload structure::
+
+        {
+          "diagram": { ... },
+          "token": "optional-existing-token"
+        }
+
+    Delegates to ``DiagramService.saveDiagramVersion`` which stores the diagram
+    and returns the canonical payload with updated metadata.
+``DELETE /api/diagrams/:token``
+    Removes a specific version from a diagram. Provide ``versionIndex`` in the
+    request body. Errors are returned when the index does not exist.
+``POST /api/diagrams/:token``
+    Updates the metadata (title, description) of a diagram version.
+``POST /api/diagrams/pdf``
+    Converts an SVG payload to PDF using ``pdfmake``. Expect ``svg``, ``width``,
+    and ``height`` in the JSON body. Returns a streamed PDF document.
+
+Headers and CORS
+----------------
+
+* CORS is enabled with a permissive configuration allowing standard headers and
+  HTTP verbs.
+* Clients may send ``Content-Type: application/json`` when posting diagrams.
+
+Error responses
+---------------
+
+* ``404`` – diagram token not found.
+* ``400`` – validation failure (for example, missing PDF dimensions).
+* ``503`` – storage errors or downstream conversion failures.
+
+Rate limiting
+-------------
+
+* Storage adapters apply debouncing to reduce write frequency. Add Express-level
+  throttling if your deployment requires stricter limits.
+
+Versioning strategy
+-------------------
+
+* The API surface is stable. Introduce breaking changes by versioning the path
+  (e.g., ``/api/v2``) and updating the webapp accordingly.
+
+Next steps
+----------
+
+Read :doc:`storage` to learn how diagrams are persisted behind these endpoints.

--- a/docs/backend/security-and-observability.rst
+++ b/docs/backend/security-and-observability.rst
@@ -1,0 +1,56 @@
+Security and observability
+==========================
+
+Harden the collaboration server and capture actionable telemetry to keep the
+service reliable.
+
+Security controls
+-----------------
+
+Authentication
+    Deploy behind an authentication proxy or add middleware to
+    :file:`packages/server/src/main/routes.ts` to check session tokens before
+    accessing APIs.
+TLS termination
+    Terminate TLS at a reverse proxy (nginx, Traefik) and forward traffic to the
+    Node.js server via HTTP. Update ``DEPLOYMENT_URL`` to use ``https`` so the
+    webapp generates secure WebSocket URLs.
+Token management
+    Share tokens are 20-character random strings generated via ``randomString``
+    (see :file:`packages/server/src/main/utils.ts`). Rotate ``tokenLength`` if
+    your policies require shorter/longer identifiers.
+Input validation
+    ``DiagramResource`` verifies token format (alphanumeric). Extend validation to
+    enforce payload size limits or schema compliance.
+Rate limiting
+    Introduce middleware such as ``express-rate-limit`` to control API abuse.
+
+Observability
+-------------
+
+Logging
+    Use a structured logger (pino, Winston) to capture request metadata. By
+    default, the server logs to stdout.
+Metrics
+    Export metrics via Prometheus or StatsD when running in container platforms.
+    Capture request counts, latency, and storage adapter performance.
+Tracing
+    Enable Sentry traces by configuring ``SENTRY_DSN`` and adjusting the sample
+    rate in ``server.ts``.
+Error reporting
+    ``SENTRY_DSN`` initialises server-side error reporting. Combine with client
+    instrumentation via PostHog for end-to-end visibility.
+
+Operational runbooks
+--------------------
+
+* Document recovery procedures for Redis outages (fail over, warm caches).
+* Keep the ``diagrams`` directory on resilient storage (EBS, NFS) when using the
+  filesystem adapter.
+* Monitor disk usage and prune stale diagrams using the cron job documented in
+  :doc:`background-jobs`.
+
+Next steps
+----------
+
+Read :doc:`background-jobs` to automate maintenance tasks.

--- a/docs/backend/server-overview.rst
+++ b/docs/backend/server-overview.rst
@@ -1,0 +1,64 @@
+Server overview
+===============
+
+The collaboration server (:file:`packages/server/src/main/server.ts`) is an
+Express.js application compiled with Webpack. It serves the static webapp bundle
+and registers APIs for diagram persistence and export.
+
+Key responsibilities
+--------------------
+
+* Serve the built webapp assets from ``build/webapp``.
+* Rewrite static asset URLs during build to respect ``DEPLOYMENT_URL``.
+* Register REST endpoints and WebSocket handlers for collaboration features.
+* Initialise telemetry (Sentry) when ``SENTRY_DSN`` is configured.
+
+Bootstrap sequence
+------------------
+
+#. Load ``DEPLOYMENT_URL`` and other environment variables.
+#. Replace hard-coded ``http://localhost:8080`` references in the webapp bundle
+   with the configured deployment URL.
+#. Mount static middleware and JSON body parsers.
+#. Call ``register(app)`` from :file:`routes.ts` to attach API endpoints.
+#. Start listening on port 8080 and pass upgrade events to the
+   ``CollaborationService`` for WebSocket support.
+
+Port configuration
+------------------
+
+* Default HTTP port: **8080** (defined in ``server.ts``).
+* Use reverse proxies (nginx, Traefik) or environment-specific process managers to
+  expose the service on alternative ports.
+
+Error handling
+--------------
+
+* Express-level errors propagate to Sentry when available.
+* ``ErrorPanel`` in the front-end surfaces server-side errors returned via JSON
+  responses.
+* Build-time replacements ensure share links display correct origins to avoid
+  mixed content issues.
+
+Extending the server
+--------------------
+
+* Add new routes by editing :file:`packages/server/src/main/routes.ts` and
+  attaching controllers.
+* Introduce middleware (authentication, rate limiting) by wrapping the Express
+  instance prior to route registration.
+* Integrate additional services under ``packages/server/src/main/services`` and
+  inject them where required.
+
+Deployment artifacts
+--------------------
+
+* ``Dockerfile`` and ``Dockerfile.redis`` build production images.
+* ``docker-compose.yml`` orchestrates the server alongside Redis for local
+  testing.
+* ``BESSER_WME_Standalone.service`` defines a systemd unit for Linux hosts.
+
+Next steps
+----------
+
+Review :doc:`rest-api` for endpoint documentation.

--- a/docs/backend/storage.rst
+++ b/docs/backend/storage.rst
@@ -1,0 +1,70 @@
+Storage
+=======
+
+Diagram persistence is abstracted behind ``DiagramStorageService`` with swappable
+adapters for filesystem and Redis backends. The ``DiagramStorageFactory`` selects
+the appropriate implementation based on environment variables.
+
+Filesystem storage
+------------------
+
+Implementation: ``DiagramFileStorageService`` (:file:`packages/server/src/main/services/diagram-storage/diagram-file-storage-service.ts`)
+
+* Persists JSON blobs to ``diagrams/<token>.json``.
+* Uses ``DiagramStorageRateLimiter`` to debounce save operations and batch patch
+  requests. Configurable intervals ensure data is flushed at least every
+  3 seconds.
+* Requires the ``diagrams`` directory to exist and be writable by the server
+  process.
+
+Redis storage
+-------------
+
+Implementation: ``DiagramRedisStorageService`` (:file:`packages/server/src/main/services/diagram-storage/diagram-redis-storage-service.ts`)
+
+* Stores diagrams using RedisJSON at keys ``apollon_diagram:<token>``.
+* Supports TTL via ``APOLLON_REDIS_DIAGRAM_TTL`` using the ``ms`` package.
+* Debounces save operations for high-frequency collaboration scenarios (interval
+  100 ms).
+* Lazily connects to Redis using ``createClient`` and caches the connection.
+
+Migration support
+-----------------
+
+``MigratingStorageService`` composes two storage adapters. When
+``APOLLON_REDIS_MIGRATE_FROM_FILE`` is set, it reads diagrams from disk on first
+access and writes them to Redis. Use this during one-time migrations.
+
+Rate limiting internals
+-----------------------
+
+``DiagramStorageRateLimiter`` groups operations per diagram token to avoid race
+conditions. It supports:
+
+* Debouncing multiple requests within ``SAVE_DEBOUNCE_TIME``.
+* Maximum save interval ``SAVE_INTERVAL`` to guarantee eventual persistence.
+* Group TTL ``SAVE_GROUP_TTL`` after which idle tokens are released.
+
+Error handling
+--------------
+
+* File storage throws if a non-shared token already exists during creation.
+* Redis storage logs failures to load or save diagrams. Check server logs for
+  connectivity issues.
+* All adapters return promises, allowing ``DiagramService`` to surface meaningful
+  HTTP responses.
+
+Backups and retention
+---------------------
+
+* For filesystem storage, schedule regular backups of the ``diagrams`` directory
+  and prune outdated files manually or via cron (see
+  :doc:`background-jobs`).
+* For Redis, use built-in persistence (AOF/RDB) or managed snapshots depending on
+  your hosting provider.
+
+Next steps
+----------
+
+Read :doc:`collaboration-services` to understand how storage interacts with
+WebSocket sessions.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,77 @@
+"""Sphinx configuration for BESSER WME Standalone documentation."""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime
+
+# -- Path setup --------------------------------------------------------------
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".", ".."))
+
+sys.path.insert(0, REPO_ROOT)
+
+# -- Project information -----------------------------------------------------
+
+project = "BESSER Web Modeling Editor"
+copyright = f"{datetime.now():%Y}, BESSER"
+author = "BESSER"
+
+# The short X.Y version and the full version, including alpha/beta/rc tags
+release = "1.0.0"
+version = release
+
+# -- General configuration ---------------------------------------------------
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "sphinx.ext.viewcode",
+]
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", {}),
+    "node": ("https://nodejs.org/api", {}),
+}
+
+# Templates path
+templates_path = ["_templates"]
+
+# List of patterns to ignore when looking for source files.
+exclude_patterns: list[str] = [
+    "_build",
+    "Thumbs.db",
+    ".DS_Store",
+]
+
+# -- Options for HTML output -------------------------------------------------
+
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]
+
+# If true, `todo` and `todoList` produce output, else they produce nothing.
+todo_include_todos = True
+
+# -- Options for Napoleon ----------------------------------------------------
+
+napoleon_google_docstring = True
+napoleon_numpy_docstring = True
+
+# -- Options for source files ------------------------------------------------
+
+source_suffix = {
+    ".rst": "restructuredtext",
+}
+
+master_doc = "index"
+
+# -- Project-specific settings ----------------------------------------------
+
+primary_domain = "js"
+
+# Provide commonly used replacements
+rst_epilog = "\n.. |project| replace:: BESSER Web Modeling Editor\n"

--- a/docs/deployment/docker.rst
+++ b/docs/deployment/docker.rst
@@ -1,0 +1,72 @@
+Docker deployment
+=================
+
+Container images simplify packaging and scaling the standalone editor. The
+repository includes Dockerfiles and Compose manifests for common scenarios.
+
+Dockerfiles
+-----------
+
+``Dockerfile``
+    Builds the webapp and server into a single image with filesystem storage.
+``Dockerfile.redis``
+    Extends the base image with Redis configuration and environment defaults.
+
+Building an image
+-----------------
+
+::
+
+  docker build -t besser-wme-standalone .
+
+Run with filesystem storage
+---------------------------
+
+::
+
+  docker run -d --name besser-wme \
+    -e APPLICATION_SERVER_VERSION=1 \
+    -e DEPLOYMENT_URL=http://localhost:8080 \
+    -p 8080:8080 \
+    besser-wme-standalone
+
+Mount a host directory at ``/app/diagrams`` to persist diagram data::
+
+  docker run -d --name besser-wme \
+    -v /srv/diagrams:/app/diagrams \
+    -p 8080:8080 besser-wme-standalone
+
+Docker Compose with Redis
+-------------------------
+
+Use :file:`docker-compose.yml` to run the server and Redis stack::
+
+  docker compose up -d
+
+Environment variables can be set in a ``.env`` file::
+
+  DEPLOYMENT_URL=https://editor.example.com
+  APOLLON_REDIS_DIAGRAM_TTL=30d
+
+Production Compose (:file:`docker-compose.prod.yml`) configures named volumes and
+network segmentation for hardened deployments.
+
+Kubernetes
+----------
+
+* Build and push the image to your container registry.
+* Create deployments for the server and Redis, expose them via services, and
+  configure ingress with TLS termination.
+* Mount persistent volumes for diagrams or rely on Redis persistence mechanisms.
+
+Operational tips
+----------------
+
+* Monitor container logs with ``docker logs`` or ``kubectl logs``.
+* Configure health checks to restart unhealthy containers.
+* Set resource limits to prevent noisy neighbour issues.
+
+Next steps
+----------
+
+For autoscaling and high availability, review :doc:`scaling`.

--- a/docs/deployment/full-stack.rst
+++ b/docs/deployment/full-stack.rst
@@ -1,0 +1,77 @@
+Full-stack deployment
+=====================
+
+Deploy the webapp and collaboration server together to unlock sharing, version
+history, and export pipelines.
+
+Manual setup on Linux
+---------------------
+
+#. Clone the repository and install dependencies::
+
+     git clone https://github.com/BESSER-PEARL/BESSER-WEB-MODELING-EDITOR.git
+     cd BESSER-WEB-MODELING-EDITOR
+     npm install
+
+#. Configure environment variables::
+
+     export APPLICATION_SERVER_VERSION=1
+     export DEPLOYMENT_URL=https://editor.example.com
+
+#. Build the workspace::
+
+     npm run build
+
+#. Create a system user and diagram directory::
+
+     sudo useradd -r -s /bin/false besser_wme_standalone
+     mkdir -p /var/lib/besser-wme/diagrams
+     chown -R besser_wme_standalone /var/lib/besser-wme
+
+#. Copy build artefacts to a deployment directory and adjust permissions.
+#. Install the systemd unit (:file:`BESSER_WME_Standalone.service`) and update
+   paths to match your installation.
+#. Start the service::
+
+     sudo systemctl daemon-reload
+     sudo systemctl enable besser_wme_standalone
+     sudo systemctl start besser_wme_standalone
+
+Cron jobs
+---------
+
+* Install ``delete-stale-diagrams.cronjob.txt`` to remove outdated diagrams.
+* Tail ``/var/log/cron.log`` to verify execution.
+
+Reverse proxy configuration
+---------------------------
+
+* Place nginx or Traefik in front of the Node.js server to terminate TLS and
+  route traffic.
+* Proxy WebSocket upgrades by forwarding ``Upgrade`` and ``Connection`` headers.
+* Enable gzip compression for static assets.
+
+Redis-backed deployments
+------------------------
+
+* Install Redis with RedisJSON enabled.
+* Set ``APOLLON_REDIS_URL`` (and optionally ``APOLLON_REDIS_DIAGRAM_TTL``) before
+  starting the server.
+* Use ``APOLLON_REDIS_MIGRATE_FROM_FILE`` during the first start to migrate
+  existing filesystem diagrams.
+
+Testing the deployment
+----------------------
+
+* Visit ``https://editor.example.com`` and verify login-free access to the
+  editor.
+* Publish a diagram and confirm that share links load successfully in a private
+  browser window.
+* Run ``npm run lint`` and ``npm run build`` locally before promoting changes to
+  production.
+
+Next steps
+----------
+
+Use the :doc:`docker` guide for container-based deployments or
+:doc:`scaling` for larger installations.

--- a/docs/deployment/index.rst
+++ b/docs/deployment/index.rst
@@ -1,0 +1,15 @@
+Deployment
+==========
+
+Choose the deployment strategy that matches your use case. This section covers
+static hosting, full-stack deployments, container-based setups, scaling, and
+monitoring.
+
+.. toctree::
+   :maxdepth: 2
+
+   static-hosting
+   full-stack
+   docker
+   scaling
+   monitoring

--- a/docs/deployment/monitoring.rst
+++ b/docs/deployment/monitoring.rst
@@ -1,0 +1,54 @@
+Monitoring
+==========
+
+Reliable deployments require monitoring across infrastructure, application, and
+user experience layers.
+
+Logs
+----
+
+* Capture container logs with ``docker logs`` or systemd's ``journalctl``.
+* Forward logs to aggregators (ELK, Loki) and index on token, request path, and
+  error type.
+
+Metrics
+-------
+
+* Expose Node.js metrics via Prometheus exporters or integrate with cloud
+  monitoring agents.
+* Track request latency, error rate, WebSocket connections, and Redis command
+  timings.
+* Monitor disk usage of the ``diagrams`` directory or Redis memory footprint.
+
+Tracing
+-------
+
+* Configure Sentry or OpenTelemetry to trace API requests and background jobs.
+* Sample WebSocket message flows to identify bottlenecks during collaborative
+  sessions.
+
+User experience
+---------------
+
+* Use PostHog dashboards to measure session counts, export frequency, and share
+  link usage.
+* Collect user feedback via the built-in share modes and triage it alongside
+  telemetry data.
+
+Alerting
+--------
+
+* Define alerts for high error rates, CPU spikes, or storage exhaustion.
+* Route alerts to on-call channels (email, Slack, PagerDuty) with runbook links.
+
+Synthetic checks
+----------------
+
+* Schedule health checks that load the editor, create a diagram, and publish a
+  share link to validate end-to-end functionality.
+* Use automated tests to exercise PDF export and Redis-backed persistence.
+
+Next steps
+----------
+
+Move on to the :doc:`../development/index` section for contributor workflows.

--- a/docs/deployment/scaling.rst
+++ b/docs/deployment/scaling.rst
@@ -1,0 +1,55 @@
+Scaling
+=======
+
+Plan for growth by architecting the deployment to handle increased traffic,
+collaborators, and diagram volume.
+
+Horizontal scaling
+------------------
+
+* Run multiple server instances behind a load balancer (nginx, HAProxy, cloud
+  load balancers).
+* Use Redis storage for shared persistence and configure sticky sessions if
+  WebSocket affinity is required.
+* Container orchestrators (Kubernetes, ECS) simplify rolling updates and health
+  checks.
+
+Vertical scaling
+----------------
+
+* Increase CPU and memory on single-node deployments to support large diagrams or
+  high concurrent collaboration sessions.
+* Ensure filesystem storage resides on fast disks (SSD) to reduce save latency.
+
+Caching
+-------
+
+* Enable CDN caching for static assets to reduce load on the origin server.
+* Cache frequently requested diagrams (SVG exports) using edge caches or reverse
+  proxies with short TTLs.
+
+Disaster recovery
+-----------------
+
+* Backup Redis snapshots or the ``diagrams`` directory regularly.
+* Store backups in geographically separate locations.
+* Test restoration procedures to guarantee recovery point objectives.
+
+Observability at scale
+----------------------
+
+* Collect metrics (CPU, memory, WebSocket connections) via Prometheus or cloud
+  monitoring suites.
+* Alert on abnormal error rates or spikes in save failures.
+
+Security considerations
+-----------------------
+
+* Restrict share token lifetimes using Redis TTLs.
+* Rotate TLS certificates automatically (Let's Encrypt, cert-manager).
+* Apply network policies to limit access to Redis and the Node.js service.
+
+Next steps
+----------
+
+Review :doc:`monitoring` for detailed observability guidance.

--- a/docs/deployment/static-hosting.rst
+++ b/docs/deployment/static-hosting.rst
@@ -1,0 +1,47 @@
+Static hosting
+==============
+
+Serve the web application as static assets when collaboration features are not
+required. This approach is suitable for training sessions, documentation, or
+self-hosted installations focused on offline work.
+
+Build assets
+------------
+
+1. Install dependencies with ``npm install``.
+2. Set ``APPLICATION_SERVER_VERSION=0`` to signal a front-end-only build.
+3. Run ``npm run build:webapp``.
+4. The compiled assets appear in :file:`build/webapp`.
+
+Hosting options
+---------------
+
+* **Static file servers** – Use ``npx http-server``, nginx, Apache, or Caddy to
+  serve the bundle. Point the server root to :file:`build/webapp`.
+* **Object storage** – Upload the directory to Amazon S3, Google Cloud Storage,
+  or Azure Blob Storage with static website hosting enabled.
+* **Content delivery networks** – Pair object storage with CloudFront, Cloudflare,
+  or Fastly for global caching.
+
+Configuration tips
+------------------
+
+* Set ``DEPLOYMENT_URL`` during build to the final public URL. Example::
+
+    DEPLOYMENT_URL=https://editor.example.com APPLICATION_SERVER_VERSION=0 npm run build:webapp
+
+* Ensure the hosting provider rewrites requests to ``index.html`` (SPA fallback).
+* Enable HTTPS to avoid mixed content warnings when embedding diagrams elsewhere.
+
+Limitations
+-----------
+
+* Sharing, collaboration, and version history are unavailable without the
+  backend.
+* Diagram persistence relies on browser storage; clearing the cache removes
+  drafts.
+
+Next steps
+----------
+
+For collaboration features, follow the :doc:`full-stack` deployment guide.

--- a/docs/development/coding-standards.rst
+++ b/docs/development/coding-standards.rst
@@ -1,0 +1,59 @@
+Coding standards
+================
+
+Consistent code style improves readability and maintainability. The project
+adheres to the following standards.
+
+TypeScript and JavaScript
+-------------------------
+
+* Use ES2022+ features supported by the configured TypeScript target.
+* Prefer ``const`` and ``let`` over ``var``.
+* Avoid default exports when named exports are clearer.
+* Provide explicit return types for exported functions.
+* Handle asynchronous code with ``async``/``await`` and propagate errors
+  meaningfully.
+
+React
+-----
+
+* Functional components with hooks are preferred over class components.
+* Co-locate component-specific styles and tests.
+* Break down large components into smaller, reusable pieces.
+* Use ``PropTypes`` or TypeScript interfaces for component props.
+
+Server code
+-----------
+
+* Follow Express best practices: middleware ordering, error handling, and
+  security headers.
+* Avoid blocking operations on the event loop; use async I/O for file and Redis
+  interactions.
+* Centralise configuration in environment variables and constants.
+
+Linting and formatting
+----------------------
+
+* ``npm run lint`` runs ESLint/Stylelint across the workspace.
+* ``npm run prettier:check`` enforces formatting. Use ``npm run prettier:write``
+  to auto-format.
+* Configure your editor to respect ``.editorconfig`` (if present) and TypeScript
+  formatting settings.
+
+Documentation
+-------------
+
+* Update Sphinx docs alongside code changes.
+* Use ``.. note::`` and ``.. warning::`` directives for important caveats.
+* Ensure tables and code blocks render correctly in both HTML and Read the Docs.
+
+Commit conventions
+------------------
+
+* Use imperative tense (``add support for...``).
+* Prefix commits with scope when helpful (``server:``, ``webapp:``).
+
+Next steps
+----------
+
+Read :doc:`testing` for verification strategies.

--- a/docs/development/contributing.rst
+++ b/docs/development/contributing.rst
@@ -1,0 +1,46 @@
+Contributing
+============
+
+We welcome contributions from the community. This page summarises expectations
+and links to essential resources.
+
+Community standards
+-------------------
+
+* Review the repository-wide :file:`CONTRIBUTING.md` for coding guidelines,
+  branching strategy, and pull request conventions.
+* Adhere to the :file:`CODE_OF_CONDUCT.md` to foster a respectful environment.
+* Familiarise yourself with :file:`GOVERNANCE.md` for decision-making processes.
+
+How to contribute
+-----------------
+
+1. Discuss significant changes via GitHub issues to gather feedback early.
+2. Fork the repository or create a feature branch.
+3. Follow the :doc:`environment` and :doc:`workflows` guides to set up and begin
+   development.
+4. Update documentation and tests alongside code.
+5. Submit a pull request with a clear summary, testing notes, and screenshots if
+   applicable.
+6. Address review feedback promptly and keep the conversation constructive.
+
+Reporting issues
+----------------
+
+* Use GitHub issues to report bugs or request features.
+* Include reproduction steps, environment details, and expected vs actual
+  behaviour.
+* Attach screenshots or exported diagrams when relevant.
+
+Staying informed
+----------------
+
+* Subscribe to repository notifications to stay updated on discussions.
+* Join community communication channels listed in the README for announcements
+  and support.
+
+Next steps
+----------
+
+Explore the :doc:`../operations/index` section to understand day-two operational
+responsibilities.

--- a/docs/development/environment.rst
+++ b/docs/development/environment.rst
@@ -1,0 +1,67 @@
+Environment setup
+=================
+
+Follow these steps to prepare a development environment.
+
+Prerequisites
+-------------
+
+* Node.js 22.10+
+* npm 10+
+* Git
+* Optional: Redis with RedisJSON for backend development
+* Optional: Docker for container testing
+
+Initial setup
+-------------
+
+::
+
+  git clone https://github.com/BESSER-PEARL/BESSER-WEB-MODELING-EDITOR.git
+  cd BESSER-WEB-MODELING-EDITOR
+  npm install
+
+Running services
+----------------
+
+Start both the webapp and server::
+
+  npm run dev
+
+This command runs ``npm run start:webapp`` (webpack dev server on port 8888) and
+``npm run start:server`` (Express server on port 8080).
+
+Alternative scripts
+-------------------
+
+* ``npm run start:webapp`` – launch only the webapp for UI development.
+* ``npm run start:server`` – run the server independently.
+* ``npm run build:local`` – produce local builds of webapp and server for manual
+  testing.
+
+Environment variables
+---------------------
+
+Set the following variables in your shell or ``.env`` file:
+
+* ``APPLICATION_SERVER_VERSION`` – ``0`` for webapp-only development, ``1`` when
+  testing collaboration flows.
+* ``DEPLOYMENT_URL`` – base URL used by the webapp (``http://localhost:8080`` by
+  default).
+* ``APOLLON_REDIS_URL`` – optional Redis connection string.
+
+Redis in development
+--------------------
+
+Run Redis with RedisJSON locally::
+
+  docker run -p 6379:6379 -it redis/redis-stack-server:latest
+
+Then start the server with Redis persistence::
+
+  APOLLON_REDIS_URL="" npm run start:server
+
+Next steps
+----------
+
+Proceed to :doc:`workflows` for day-to-day development practices.

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -1,0 +1,15 @@
+Development
+===========
+
+Contribute to the project by following the workflows and standards described in
+this section.
+
+.. toctree::
+   :maxdepth: 2
+
+   environment
+   workflows
+   coding-standards
+   testing
+   release
+   contributing

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -1,0 +1,49 @@
+Release management
+==================
+
+Plan and execute releases using the following checklist.
+
+Pre-release checklist
+---------------------
+
+* Ensure ``main`` is green in CI and documentation is up to date.
+* Review dependency updates and address security advisories.
+* Verify translation and template assets are bundled correctly.
+
+Versioning
+----------
+
+* Follow semantic versioning (MAJOR.MINOR.PATCH).
+* Update the version in :file:`package.json` and any relevant package manifests.
+* Tag releases using ``git tag vX.Y.Z`` and push tags to origin.
+
+Release artifacts
+-----------------
+
+* Build the workspace::
+
+    npm run build
+
+* Package Docker images if applicable::
+
+    docker build -t besser-wme-standalone:vX.Y.Z .
+
+* Publish documentation updates to Read the Docs or your hosting provider.
+
+Changelog
+---------
+
+* Summarise user-visible changes, bug fixes, and migration steps.
+* Link to relevant GitHub issues and pull requests.
+
+Post-release
+------------
+
+* Monitor error reporting and analytics dashboards for regressions.
+* Respond to community feedback and document known issues.
+* Begin planning the next iteration based on backlog priorities.
+
+Next steps
+----------
+
+Refer to :doc:`contributing` for guidance on community engagement and support.

--- a/docs/development/testing.rst
+++ b/docs/development/testing.rst
@@ -1,0 +1,47 @@
+Testing strategy
+================
+
+Quality assurance combines automated checks and manual verification.
+
+Automated checks
+----------------
+
+* ``npm run lint`` – runs ESLint and Stylelint across webapp and server.
+* ``npm run prettier:check`` – validates formatting.
+* Package-specific test suites (Jest, integration tests) live under each package
+  and can be executed via ``npm test --workspace=<package>``.
+
+Backend tests
+-------------
+
+* Add unit tests for services under ``packages/server/src/main/services`` to
+  validate storage adapters, conversion pipelines, and resource controllers.
+* Use supertest to exercise Express routes in isolation.
+* Mock Redis or file storage for deterministic behaviour.
+
+Frontend tests
+--------------
+
+* See :doc:`../frontend/frontend-testing` for component and integration testing
+  guidelines.
+
+Manual verification
+-------------------
+
+* Smoke test collaboration flows: create a diagram, share it, edit from another
+  browser, and verify version history updates.
+* Validate export formats (PNG, SVG, PDF) after major rendering changes.
+* Test on multiple browsers (Chrome, Firefox, Safari) and devices.
+
+Continuous integration
+----------------------
+
+* Configure CI pipelines (GitHub Actions, GitLab CI) to run linting, testing, and
+  production builds on pull requests.
+* Cache dependencies to speed up builds and add job matrices for multiple Node
+  versions if required.
+
+Next steps
+----------
+
+Proceed to :doc:`release` for guidance on packaging and publishing updates.

--- a/docs/development/workflows.rst
+++ b/docs/development/workflows.rst
@@ -1,0 +1,50 @@
+Workflows
+=========
+
+Adopt these practices for efficient collaboration and high-quality contributions.
+
+Branching model
+---------------
+
+* Fork the repository or create feature branches from ``main``.
+* Use descriptive branch names (``feature/share-modal-enhancements``).
+* Keep branches focused and short-lived to ease reviews.
+
+Coding workflow
+---------------
+
+1. Create or update tests as you implement features.
+2. Run ``npm run lint`` and package-specific tests before committing.
+3. Use ``npm run build:local`` to validate build output.
+4. Commit with meaningful messages (``feat: support Redis TTL``).
+
+Code review
+-----------
+
+* Submit pull requests with clear descriptions, screenshots, and testing notes.
+* Respond to review feedback promptly and keep commit history clean.
+* Update documentation alongside code changes to maintain parity.
+
+Documentation-first approach
+----------------------------
+
+* Update the docs in ``docs/`` whenever behaviour changes.
+* Use Sphinx directives to cross-link related sections and keep navigation
+  intuitive.
+
+Issue tracking
+--------------
+
+* Reference GitHub issues in commit messages and pull requests (``Fixes #123``).
+* Label issues with ``bug``, ``enhancement``, ``documentation``, etc. to aid triage.
+
+Release cadence
+---------------
+
+* Follow semantic versioning for tagged releases.
+* Coordinate release notes with the :doc:`release` guide.
+
+Next steps
+----------
+
+Review :doc:`coding-standards` for style and linting expectations.

--- a/docs/frontend/app-architecture.rst
+++ b/docs/frontend/app-architecture.rst
@@ -1,0 +1,69 @@
+Application architecture
+========================
+
+``packages/webapp`` hosts the React single-page application. Build configuration
+lives under ``webpack/`` while TypeScript source code is organised in
+``src/main``.
+
+Entry points
+------------
+
+:index:`index.tsx`
+    Bootstraps React, wraps the application in providers (PostHog, routing), and
+    mounts ``RoutedApplication``.
+:index:`application.tsx`
+    Defines the primary layout, registers routes, and orchestrates modals,
+    sidebars, and the editor component.
+:index:`application-constants.ts`
+    Exposes constants shared across the application (menus, environment
+    configuration).
+
+Routing
+-------
+
+* ``BrowserRouter`` provides client-side routing.
+* ``Routes`` include the main canvas, project settings, team page, and future
+  collaboration routes keyed by token.
+* ``SidebarLayout`` wraps routes to ensure consistent UI chrome around the
+  editor.
+
+Providers and context
+---------------------
+
+* ``ApollonEditorProvider`` supplies the ``ApollonEditor`` instance and setter to
+  child components.
+* ``ApplicationStore`` coordinates global state such as current project, active
+  diagram, and notifications.
+* ``PostHogProvider`` enables analytics when ``POSTHOG_KEY`` is defined.
+
+Supporting infrastructure
+-------------------------
+
+* ``hooks/`` – custom hooks (``useProject``, etc.) encapsulate data fetching and
+  state synchronisation.
+* ``services/`` – modules for API communication, local storage, and helper
+  utilities.
+* ``utils/`` – shared helper functions, formatting utilities, and constants.
+
+Build targets
+-------------
+
+* ``webpack.common.js`` defines shared configuration, including environment
+  variable injection via ``DefinePlugin``.
+* ``webpack.dev.js`` configures the webpack dev server with hot module replacement
+  and API proxying.
+* ``webpack.prod.js`` optimises bundles for production, minifies assets, and
+  outputs to ``build/webapp``.
+
+Testing
+-------
+
+* Unit tests can be colocated next to components under ``__tests__`` directories.
+* Use React Testing Library or Jest to validate UI behaviour. See
+  :doc:`frontend-testing` for patterns.
+
+Next steps
+----------
+
+Continue with :doc:`state-management` to understand data flow within the
+application.

--- a/docs/frontend/component-catalog.rst
+++ b/docs/frontend/component-catalog.rst
@@ -1,0 +1,80 @@
+Component catalog
+=================
+
+Key React components live under :file:`packages/webapp/src/main/components`.
+This catalog highlights the most important modules and their responsibilities.
+
+Layout
+------
+
+``ApplicationBar``
+    Global navigation bar with menus for files, templates, sharing, export, and
+    settings.
+``SidebarLayout``
+    Wraps the canvas with auxiliary panels such as version management and project
+    settings.
+``VersionManagementSidebar``
+    Displays version history, metadata editing forms, and share link shortcuts.
+
+Editor integration
+------------------
+
+``ApollonEditorComponent``
+    Hosts the modelling canvas, manages initialisation, and syncs with Redux
+    state.
+``ApollonEditorComponentWithConnection``
+    Extends the base component with server-backed collaboration and WebSocket
+    handling.
+``ApollonEditorProvider``
+    Context provider exposing the ``ApollonEditor`` instance to children.
+
+Modals
+------
+
+``HomeModal``
+    Entry point for selecting templates, creating projects, and resuming recent
+    work.
+``ShareModal``
+    Generates share links, toggles share modes, and displays embed snippets.
+``ApplicationModal``
+    Container for global modals triggered by menu commands.
+
+Supporting views
+----------------
+
+``ProjectSettingsScreen``
+    Manages project metadata, default diagram types, and team settings.
+``TeamPage``
+    Static page for listing contributors, support channels, and collaboration
+    guidelines.
+``ErrorPanel``
+    Persistent component surfacing backend or UI errors from the Redux store.
+
+Integration widgets
+-------------------
+
+``UMLBotWidget``
+    Interfaces with ``UML_BOT_WS_URL`` to provide AI-assisted modelling features.
+``FirefoxIncompatibilityHint``
+    Offers alternative workflows when browser compatibility issues are detected.
+``ToastContainer``
+    Renders toast notifications triggered throughout the application.
+
+Styling
+-------
+
+* Components import CSS modules or global styles from :file:`styles.css`.
+* Theme-aware components respect ``localStorageUserThemePreference`` and
+  ``localStorageSystemThemePreference``.
+
+Extending the catalog
+---------------------
+
+* Follow existing folder conventions when adding components (co-locate tests and
+  storybook docs if used).
+* Export new components via index files for easier imports elsewhere in the app.
+
+Next steps
+----------
+
+Visit :doc:`styling-and-theming` for details on the styling pipeline.

--- a/docs/frontend/external-integrations.rst
+++ b/docs/frontend/external-integrations.rst
@@ -1,0 +1,51 @@
+External integrations
+=====================
+
+Several services can be plugged into the webapp to provide analytics, telemetry,
+and intelligent assistance.
+
+Analytics
+---------
+
+PostHog
+    Configure ``POSTHOG_HOST`` and ``POSTHOG_KEY`` to enable event capture.
+    ``PostHogProvider`` in :file:`application.tsx` wraps the app when keys are
+    provided. Use PostHog dashboards to understand feature adoption.
+
+Error tracking
+--------------
+
+Sentry
+    Configure ``SENTRY_DSN`` to instrument server-side and optionally client-side
+    errors. Pair with ``@sentry/react`` if you plan to extend client telemetry.
+
+Intelligent assistance
+----------------------
+
+UML Bot
+    ``UMLBotWidget`` connects to ``UML_BOT_WS_URL`` (defaulting to the deployment
+    origin). Provide your own WebSocket endpoint to generate diagrams from
+    natural language prompts or to offer tutoring features.
+
+Backend APIs
+------------
+
+* The webapp communicates with the collaboration server via ``BASE_URL`` derived
+  from ``DEPLOYMENT_URL``.
+* ``BACKEND_URL`` can point to auxiliary services when running in development.
+* Use ``LocalStorageRepository`` and ``ProjectStorageRepository`` to bridge with
+  other systems through background sync jobs.
+
+Embedding contexts
+------------------
+
+* Integrate the webapp inside other applications via iframes. Provide
+  ``DEPLOYMENT_URL`` that matches the host origin to avoid mixed content issues.
+* Expose configuration via query parameters or local storage seeds to tailor the
+  experience per host application.
+
+Next steps
+----------
+
+Check :doc:`frontend-testing` to verify integrations continue to work across
+releases.

--- a/docs/frontend/frontend-testing.rst
+++ b/docs/frontend/frontend-testing.rst
@@ -1,0 +1,50 @@
+Frontend testing
+================
+
+Adopt a layered testing strategy to maintain confidence in UI changes.
+
+Unit tests
+----------
+
+* Use Jest and React Testing Library to test component rendering and interaction.
+* Co-locate tests within ``__tests__`` directories or alongside components.
+* Mock ``@besser/wme`` dependencies when isolating UI behaviour.
+
+Integration tests
+-----------------
+
+* Spin up the development server (``npm run start:webapp``) and interact with the
+  UI using Playwright or Cypress.
+* Verify collaboration flows by mocking WebSocket responses or running the server
+  in parallel.
+
+Snapshot tests
+--------------
+
+* Capture critical layouts (application bar, share modal) using testing-library's
+  snapshot utilities. Update intentionally when visual changes occur.
+
+Linting and formatting
+----------------------
+
+* Run ``npm run lint`` to enforce ESLint and Stylelint rules across the webapp.
+* Use ``npm run prettier:check`` to ensure consistent formatting.
+
+Accessibility tests
+-------------------
+
+* Integrate tools like Axe or Lighthouse to detect accessibility regressions.
+* Focus on keyboard navigation, ARIA labels, and contrast when updating themes or
+  modal flows.
+
+Continuous integration
+----------------------
+
+* Configure CI pipelines to run linting, unit tests, and production builds.
+* Cache ``node_modules`` between runs for faster feedback.
+
+Next steps
+----------
+
+Continue to :doc:`../deployment/index` to move from local development to
+production deployments.

--- a/docs/frontend/index.rst
+++ b/docs/frontend/index.rst
@@ -1,0 +1,16 @@
+Frontend
+========
+
+The standalone web application is a React + TypeScript SPA compiled with
+Webpack. These pages describe its architecture, state management, component
+library, and integration points.
+
+.. toctree::
+   :maxdepth: 2
+
+   app-architecture
+   state-management
+   component-catalog
+   styling-and-theming
+   external-integrations
+   frontend-testing

--- a/docs/frontend/state-management.rst
+++ b/docs/frontend/state-management.rst
@@ -1,0 +1,61 @@
+State management
+================
+
+The web application uses Redux Toolkit to manage global state. ``ApplicationStore``
+(:file:`packages/webapp/src/main/components/store/application-store.tsx`) wraps
+the app in a Redux provider with multiple feature slices.
+
+Slices
+------
+
+``diagramSlice``
+    Tracks the active diagram, editor options, loading flags, and unpublished
+    state. Provides async thunks (``updateDiagramThunk``) to synchronise diagram
+    changes with project storage.
+``projectSlice``
+    Manages project metadata, diagrams grouped by type, and active selections.
+``errorManagementSlice``
+    Collects errors surfaced by API calls or UI interactions so ``ErrorPanel`` can
+    display them.
+``modalSlice``
+    Controls visibility of modal dialogs (share, templates, settings).
+``shareSlice``
+    Stores share link metadata, tokens, and collaboration options.
+``versionManagementSlice``
+    Handles retrieval and manipulation of diagram version histories.
+
+Asynchronous workflows
+----------------------
+
+* ``updateDiagramThunk`` merges updates, timestamps changes, and dispatches
+  ``updateCurrentDiagramThunk`` to keep project storage in sync.
+* Additional thunks fetch diagrams by token, publish versions, and delete
+  versions via the REST API.
+* Error handling uses rejected actions to populate ``errorManagementSlice``.
+
+Local storage integration
+-------------------------
+
+* ``ProjectStorageRepository`` persists projects in browser storage, enabling the
+  home modal to list recent diagrams.
+* ``LocalStorageRepository`` tracks published tokens for quick export and share
+  operations.
+
+Selector patterns
+-----------------
+
+* Use ``useSelector`` hooks to pull slices into components.
+* Memoise derived state (diagram counts, filtered versions) with ``createSelector``
+  when necessary.
+
+Debugging tools
+---------------
+
+* Redux DevTools are enabled in non-production builds.
+* Log asynchronous flows by attaching middleware or leveraging Redux Toolkit's
+  built-in development warnings.
+
+Next steps
+----------
+
+Explore :doc:`component-catalog` to see how state is consumed across the UI.

--- a/docs/frontend/styling-and-theming.rst
+++ b/docs/frontend/styling-and-theming.rst
@@ -1,0 +1,57 @@
+Styling and theming
+===================
+
+Styling is handled via global CSS, component-specific styles, and theme
+configuration files.
+
+Global styles
+-------------
+
+* :file:`packages/webapp/src/main/styles.css` defines base styles, typography,
+  layout primitives, and CSS variables.
+* Webpack processes CSS via ``style-loader`` and ``css-loader`` (see
+  :file:`packages/webapp/webpack/webpack.common.js`).
+
+Theme configuration
+-------------------
+
+* ``themings.json`` stores palette definitions and editor theme overrides.
+* ``localStorageUserThemePreference`` and ``localStorageSystemThemePreference``
+  determine the active theme at runtime.
+* The application bar exposes a toggle to switch between light and dark modes.
+
+Component styles
+----------------
+
+* Many components import CSS modules or styled utilities alongside their
+  TypeScript files. Keep styles colocated to simplify maintenance.
+* Use CSS variables for colours and spacing to ensure theme compatibility.
+
+Custom theming
+--------------
+
+* Extend ``themings.json`` with additional entries for corporate branding.
+* Inject environment-specific CSS via host applications by loading extra
+  stylesheets in :file:`index.html` before building.
+* When integrating with design systems, consider wrapping components with your
+  own style providers to override default tokens.
+
+Responsive design
+-----------------
+
+* Layout components use flexbox to adapt to different resolutions.
+* Ensure new components respect responsive breakpoints and test across common
+  screen sizes.
+
+Accessibility
+-------------
+
+* Maintain sufficient colour contrast when customising themes.
+* Provide focus states for interactive elements and ensure they remain visible in
+  both light and dark modes.
+
+Next steps
+----------
+
+Continue with :doc:`external-integrations` to learn how the webapp interacts with
+external services.

--- a/docs/getting-started/configuration.rst
+++ b/docs/getting-started/configuration.rst
@@ -1,0 +1,90 @@
+Configuration
+=============
+
+BESSER WME Standalone exposes a number of environment variables and filesystem
+locations that customise how the editor behaves in development and production.
+This page summarises the knobs you are most likely to tune.
+
+Environment variables
+---------------------
+
+``APPLICATION_SERVER_VERSION``
+    Controls whether the front-end should expect a backend. Set to ``0`` when
+    serving static assets only. Set to ``1`` to enable collaboration features in
+    the UI. The value is read in :file:`packages/webapp/src/main/constant.ts` and
+    injected at build time through Webpack.
+``DEPLOYMENT_URL``
+    Public base URL for the deployment. The value is used by the React
+    application to compose API endpoints and WebSocket URLs and by the server to
+    rewrite static assets with the correct origin.
+``SENTRY_DSN``
+    Optional. Enables error and performance telemetry for the collaboration
+    server via `Sentry <https://sentry.io>`_. When present, the DSN is passed to
+    :mod:`@sentry/node` during server bootstrap.
+``APOLLON_REDIS_URL``
+    Optional. When set, the server persists diagrams in Redis instead of the
+    filesystem. The value must include credentials and port when applicable
+    (example: ``redis://user:password@redis-host:6379``). Leaving the variable
+    undefined switches to the filesystem storage adapter.
+``APOLLON_REDIS_DIAGRAM_TTL``
+    Optional. Human-readable TTL (``30d``, ``12h``) parsed using the ``ms``
+    package. Diagrams expire automatically after the configured duration when
+    stored in Redis.
+``APOLLON_REDIS_MIGRATE_FROM_FILE``
+    Optional flag that triggers the `MigratingStorageService` to seed Redis with
+    diagrams stored in the filesystem on startup.
+
+Filesystem locations
+--------------------
+
+``build/webapp``
+    Output of the webapp bundle. Serve the :file:`index.html` file from this
+    directory when hosting the application statically.
+``build/server``
+    Contains the compiled Express server once ``npm run build:server`` completes.
+    The entrypoint is :file:`server.js`.
+``diagrams``
+    Default directory for filesystem-based storage. Ensure the collaboration
+    server process can read and write to this path.
+``packages/webapp/src/main/templates``
+    Houses the template metadata and assets surfaced by the "Start from
+    Template" dialog. New templates can be added here.
+
+Runtime flags
+-------------
+
+The following npm scripts accept environment overrides:
+
+``npm run build``
+    Respects ``APPLICATION_SERVER_VERSION`` and ``DEPLOYMENT_URL`` to prepare the
+    bundle for static or full-stack deployments.
+``npm run start:server``
+    Loads ``SENTRY_DSN`` and the Redis-related variables when initialising the
+    Express app. The script also reads ``DEPLOYMENT_URL`` to adjust share links in
+    the generated HTML bundle.
+``npm run start:webapp``
+    Uses ``DEPLOYMENT_URL`` to proxy API calls while in development. When unset,
+    ``http://localhost:8080`` is assumed.
+
+Configuration profiles
+----------------------
+
+* **Local evaluation** – set ``APPLICATION_SERVER_VERSION=0`` and leave Redis
+  variables unset. Serve :file:`build/webapp` via ``npm run build:webapp``.
+* **Full-stack development** – export ``APPLICATION_SERVER_VERSION=1`` and
+  ``DEPLOYMENT_URL=http://localhost:8080``. Create a :file:`.env` file with the
+  same values to avoid re-exporting variables.
+* **Redis-backed production** – configure ``APOLLON_REDIS_URL`` and optionally
+  ``APOLLON_REDIS_DIAGRAM_TTL``. Combine with reverse proxies that expose the
+  ``DEPLOYMENT_URL`` you expect users to reach.
+
+Advanced integrations
+---------------------
+
+For CI/CD pipelines, export the variables inline when invoking npm scripts::
+
+  APPLICATION_SERVER_VERSION=1 DEPLOYMENT_URL=https://editor.example.com npm run build
+
+Container deployments can copy environment variables into :file:`docker-compose.yml`
+using the provided ``.env`` file template. See :doc:`../deployment/docker` for
+examples.

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -1,0 +1,16 @@
+Getting started
+===============
+
+The BESSER Web Modeling Editor (WME) Standalone can be run entirely as a static
+web application or paired with the optional collaboration server. This section
+introduces the platform from a user's point of view and sets up everything you
+need to explore or evaluate the editor.
+
+.. toctree::
+   :maxdepth: 2
+
+   overview
+   installation
+   quickstart
+   configuration
+   upgrading

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -1,0 +1,81 @@
+Installation
+============
+
+The repository is a npm workspace that bundles the standalone web application,
+collaboration server, shared DTOs, and reusable editor assets. The workspace
+requires a modern Node.js runtime and system libraries for building native
+modules used by the server.
+
+Prerequisites
+-------------
+
+* **Node.js 22.10 or newer** (see ``"engines"`` in :file:`package.json`).
+* **npm 10+** (included with Node.js releases from the 22.x line).
+* **Python 3 and build tools** such as ``make`` and a C/C++ compiler. These are
+  required by transitive dependencies like ``node-canvas`` when the server build
+  is enabled.
+* **Redis 7 with the RedisJSON module** if you plan to back the server with a
+  Redis store.
+* **Git** for cloning the repository and managing updates.
+
+On macOS you can install the toolchain via Homebrew::
+
+  brew install node@22 git python3
+  xcode-select --install  # command line developer tools
+
+On Ubuntu/Debian systems::
+
+  sudo apt update
+  sudo apt install -y curl git build-essential python3
+  curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+  sudo apt install -y nodejs
+
+Cloning the repository
+----------------------
+
+Clone the project together with its sub-packages::
+
+  git clone https://github.com/BESSER-PEARL/BESSER-WEB-MODELING-EDITOR.git
+  cd BESSER-WEB-MODELING-EDITOR
+
+Installing dependencies
+-----------------------
+
+Install workspace dependencies once inside the repository::
+
+  npm install
+
+The workspace pulls the following notable packages:
+
+* ``@besser/wme`` – the modelling engine consumed by the webapp.
+* ``@sentry/node`` – optional error telemetry for the server.
+* ``concurrently`` – utility to orchestrate multiple npm scripts during
+  development builds.
+* ``webpack`` and ``ts-loader`` – bundlers for the TypeScript front-end and
+  server.
+
+Optional native dependencies
+----------------------------
+
+The server bundles conversion and canvas features that rely on ``node-canvas``.
+Consult the `node-canvas installation guide <https://github.com/Automattic/node-canvas#compiling>`_
+for OS-specific dependencies (``libcairo``, ``pango``, ``jpeg``, ``giflib``).
+You only need these libraries when building or running ``npm run build:server``
+or ``npm run start:server``.
+
+Keeping the workspace up to date
+--------------------------------
+
+To fetch upstream changes::
+
+  git pull origin main
+  npm install
+
+When dependencies change, the repository exposes ``npm run update`` to apply
+`npm-check-updates <https://www.npmjs.com/package/npm-check-updates>`_ across all
+packages and regenerate the lockfile.
+
+Next steps
+----------
+
+Continue with :doc:`quickstart` to build and run the editor locally.

--- a/docs/getting-started/overview.rst
+++ b/docs/getting-started/overview.rst
@@ -1,0 +1,77 @@
+Product overview
+================
+
+BESSER WME Standalone is the browser-based edition of the BESSER modelling
+experience. It packages the reusable `@besser/wme` modelling engine together
+with an opinionated user interface, template gallery, import/export tooling, and
+optional collaboration backend.
+
+Edition highlights
+------------------
+
+* **No mandatory sign-up** – users can model diagrams immediately after loading
+the web application.
+* **Rich editor surface** – drag-and-drop placement, keyboard shortcuts, theme
+switching, auto-layout, and inline styling controls provide a familiar diagram
+editing experience.
+* **Template and asset management** – curated diagram templates, custom assets,
+and palette management are available out of the box.
+* **Collaboration-ready** – optional server features unlock shared editing,
+feedback reviews, version history, embedding, and secure share links.
+* **Multiple deployment models** – run the editor as static assets, serve it via
+Node.js, or host both editor and server via Docker or container orchestration.
+
+Platform building blocks
+------------------------
+
+The repository is organised as a multi-package workspace:
+
+``packages/editor``
+    Contains reusable UI primitives, domain models, and shared utilities that
+    are consumed by both the standalone web application and the server.
+``packages/webapp``
+    Hosts the React single-page application that renders the modelling
+    workspace, integrates template assets, and orchestrates session state.
+``packages/server``
+    Implements the Express-based collaboration server. It serves the static
+    webapp bundle, exposes REST APIs for diagram persistence, and manages live
+    collaboration via websockets.
+``packages/shared``
+    Provides TypeScript DTOs and helpers that are shared between front-end and
+    backend packages to keep transport contracts in sync.
+
+Core capabilities at a glance
+-----------------------------
+
+* **Diagram editing** with BPMN, UML, and domain-specific notation palettes.
+* **File management** via local browser storage, downloadable exports (PNG,
+  SVG, PDF, JSON), and template imports.
+* **Sharing workflows** supporting edit, embed, feedback collection, and review
+  modes through secure share tokens.
+* **Customisation** including dark/light mode, custom CSS overrides, and
+  optional analytics hooks.
+* **Automation hooks** for build pipelines through the exposed npm scripts and
+  CLI utilities documented later in this guide.
+
+Use cases
+---------
+
+BESSER WME Standalone is suitable for:
+
+* Teaching and workshops that require a zero-install modelling environment.
+* Design sessions in agile teams where diagrams evolve quickly and need
+  shareable history.
+* Integration into low-code delivery pipelines that require programmatic export
+  of diagram artefacts.
+* Embedding interactive diagrams into documentation, issue trackers, or
+  knowledge bases via the embed mode.
+
+What's next
+-----------
+
+* Visit :doc:`installation <installation>` to install dependencies and fetch the
+  workspace.
+* Jump to :doc:`quickstart <quickstart>` for a guided walkthrough of running the
+  editor locally.
+* Continue with :doc:`configuration <configuration>` when you are ready to tune
+  environment variables and integration endpoints.

--- a/docs/getting-started/quickstart.rst
+++ b/docs/getting-started/quickstart.rst
@@ -1,0 +1,78 @@
+Quickstart
+==========
+
+This walkthrough demonstrates how to run the editor locally, first as a
+front-end-only experience and then together with the Node.js collaboration
+server. Each scenario uses npm scripts from the workspace root.
+
+Front-end only
+--------------
+
+This mode is ideal for evaluating the editor UI, exporting diagrams, or hosting
+the application as static files.
+
+#. Install dependencies using ``npm install``.
+#. Build the shared DTO package and the webapp bundle::
+
+     npm run build:shared
+     npm run build:webapp
+
+#. The compiled assets live under :file:`build/webapp`. Serve the
+   :file:`index.html` with any static web server (``python3 -m http.server`` or
+   ``npx http-server``).
+#. Open ``http://localhost:8000`` (or the port you chose) and start modelling.
+
+Combined webapp and server
+--------------------------
+
+Use this workflow to unlock sharing, collaboration, and version history.
+
+#. Ensure the prerequisites from :doc:`installation` are satisfied, including
+   native build dependencies for ``node-canvas`` if you need export pipelines.
+#. Configure environment variables for the build. The most important ones are::
+
+     export APPLICATION_SERVER_VERSION=1
+     export DEPLOYMENT_URL=http://localhost:8080
+
+#. Build both the client and server::
+
+     npm run build
+
+#. Create a directory for persisted diagrams when using the filesystem storage::
+
+     mkdir -p diagrams
+
+#. Start the server::
+
+     npm run start:server
+
+   The server listens on port 8080 by default (see :file:`packages/server/src/main/server.ts`).
+#. In another terminal start the webapp dev server with hot reloading::
+
+     npm run start:webapp
+
+   The webpack dev server proxies API calls to the Node.js backend and serves the
+   React application on ``http://localhost:8888``.
+#. Navigate to ``http://localhost:8888`` to confirm the editor loads and the
+   share menu offers collaboration modes.
+
+All-in-one development loop
+---------------------------
+
+To run both servers concurrently during development, use the dedicated script::
+
+  npm run dev
+
+This command spawns the webpack development server (port 8888) and the Express
+server (port 8080). Changes to the TypeScript source trigger live reloads.
+
+Smoke testing the build
+-----------------------
+
+After building, run the following checks to verify the bundle integrity::
+
+  npm run lint
+  npm run prettier:check
+
+The :doc:`development/testing <../development/testing>` guide explains the full
+test matrix, including unit tests in package-specific directories.

--- a/docs/getting-started/upgrading.rst
+++ b/docs/getting-started/upgrading.rst
@@ -1,0 +1,64 @@
+Upgrading
+========
+
+Keep your installation in sync with upstream releases to benefit from bug fixes
+and new modelling capabilities. This guide explains how to update both the code
+and persistent state.
+
+Updating source code
+--------------------
+
+#. Stash or commit local changes to avoid merge conflicts.
+#. Pull the latest changes::
+
+     git fetch origin
+     git checkout main
+     git pull --ff-only origin main
+
+#. Re-install dependencies to pick up updated workspace lockfiles::
+
+     npm install
+
+#. Rebuild the packages::
+
+     npm run build
+
+Migrating stored diagrams
+-------------------------
+
+File-based storage
+    Diagrams stored under :file:`diagrams/` remain compatible across versions
+    because they persist JSON representations created by ``DiagramService``.
+    Back up the directory before upgrading.
+Redis storage
+    When switching from filesystem to Redis, export existing diagrams by
+    enabling the ``APOLLON_REDIS_MIGRATE_FROM_FILE`` variable for a single server
+    start. The `MigratingStorageService` copies diagrams from disk to Redis and
+    then disables itself.
+
+Database schema
+    The collaboration server does not manage a relational database. No schema
+    migrations are required between releases.
+
+Revisiting configuration
+------------------------
+
+New releases may introduce additional environment variables or templates. Review
+:doc:`configuration` after upgrading and update any infrastructure automation
+(such as ``docker-compose`` files or Kubernetes manifests).
+
+Regression testing
+------------------
+
+After an upgrade, run the local verification suite::
+
+  npm run lint
+  npm run prettier:check
+  npm run build
+
+Optionally smoke test the server::
+
+  npm run start:server
+
+Open ``http://localhost:8080`` to ensure diagrams load, share links resolve, and
+export actions succeed.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,75 @@
+.. BESSER WME documentation master file
+
+BESSER Web Modeling Editor documentation
+=========================================
+
+The **BESSER Web Modeling Editor (WME) Standalone** is a complete toolkit for
+modelling BESSER-compliant diagrams in the browser and sharing them through an
+optional collaboration server. It builds on the `@besser/wme <https://www.npmjs.com/package/@besser/wme>`_
+engine and augments it with workflow automation, template management, an
+extensible front-end, and production-ready deployment artifacts.
+
+This documentation set is organised into thematic collections so that readers
+can quickly deep-dive into the area that matters most:
+
+* **Getting started** walks through installation, configuration, and a guided
+  tour of the editor.
+* **User guides** cover everyday modelling tasks, keyboard shortcuts, sharing
+  flows, and ways to extend the workspace.
+* **Platform internals** describe how packages in this repository compose the
+  standalone experience and how data flows through the system.
+* **Backend** documentation explains the Express-based collaboration server,
+  REST APIs, storage adapters, and operational tooling.
+* **Frontend** documentation details the React application, store management,
+  theming approach, and integration with the modelling engine.
+* **Deployment** topics outline reference topologies for static hosting,
+  multi-service setups, and observability.
+* **Development** guides provide contributor onboarding, coding standards,
+  release management, and quality gates.
+* **Operations and Reference** sections cover CLI scripts, environment
+  variables, and day-two responsibilities.
+* **Appendix** gathers FAQs, glossaries, and troubleshooting recipes.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Getting started
+
+   getting-started/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: User guides
+
+   user-guide/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Platform internals
+
+   platform/index
+   backend/index
+   frontend/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Deploy, operate, and contribute
+
+   deployment/index
+   development/index
+   operations/index
+   reference/index
+   appendix/index
+
+Project resources
+-----------------
+
+* Source code: `<https://github.com/BESSER-PEARL/BESSER-WEB-MODELING-EDITOR>`_
+* Online editor: `<https://editor.besser-pearl.org>`_
+* BESSER low-code platform: `<https://github.com/BESSER-PEARL/BESSER>`_
+
+Indices and tables
+------------------
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/operations/backups-and-dr.rst
+++ b/docs/operations/backups-and-dr.rst
@@ -1,0 +1,40 @@
+Backups and disaster recovery
+=============================
+
+Protect critical assets and recover quickly from failures.
+
+What to back up
+---------------
+
+* Filesystem diagrams stored under ``diagrams/``.
+* Redis data (AOF/RDB snapshots) when using Redis storage.
+* Configuration files (``.env``, systemd units, reverse proxy configs).
+* Documentation build artefacts if hosting docs statically.
+
+Backup schedule
+---------------
+
+* Nightly incremental backups with weekly full backups for diagrams or Redis
+  dumps.
+* Store backups in off-site or cloud storage with encryption.
+* Test restoration quarterly to validate procedures.
+
+Recovery steps
+--------------
+
+1. Provision replacement infrastructure (VM, container, Redis instance).
+2. Restore backups to the target environment.
+3. Update DNS or load balancer entries to point to the restored service.
+4. Monitor for errors and confirm collaboration features operate normally.
+
+Documentation
+-------------
+
+* Record backup locations, retention policies, and contact points in operational
+  runbooks.
+* Update stakeholders when backup policies change.
+
+Next steps
+----------
+
+Head to the :doc:`../appendix/index` for reference materials and FAQs.

--- a/docs/operations/ci-cd.rst
+++ b/docs/operations/ci-cd.rst
@@ -1,0 +1,45 @@
+CI/CD
+=====
+
+Automate builds, tests, and deployments to deliver updates reliably.
+
+Pipeline stages
+---------------
+
+1. **Install dependencies** – cache ``node_modules`` to speed up subsequent runs.
+2. **Lint and test** – execute ``npm run lint`` and package-specific tests.
+3. **Build** – run ``npm run build`` to produce production assets.
+4. **Publish** – push Docker images or deploy static assets.
+5. **Notify** – send release summaries to stakeholders.
+
+Recommended tooling
+-------------------
+
+* GitHub Actions (``.github/workflows``) or GitLab CI pipelines.
+* Use matrix builds to test across Node.js versions and operating systems.
+* Cache ``~/.npm`` and ``node_modules`` directories using pipeline caching.
+
+Secrets management
+------------------
+
+* Store ``SENTRY_DSN``, ``POSTHOG_KEY``, and registry credentials in CI secrets.
+* Avoid committing sensitive information to the repository.
+
+Deployment automation
+---------------------
+
+* Trigger Docker builds and push to your registry after tests pass.
+* Use infrastructure-as-code (Terraform, Pulumi) to manage hosting environments.
+* Integrate with Read the Docs or similar services to publish updated
+  documentation automatically.
+
+Rollback strategy
+-----------------
+
+* Tag Docker images and static assets with version numbers for quick rollback.
+* Maintain database backups or Redis snapshots to restore state if required.
+
+Next steps
+----------
+
+Read :doc:`incident-response` to prepare for operational issues.

--- a/docs/operations/incident-response.rst
+++ b/docs/operations/incident-response.rst
@@ -1,0 +1,40 @@
+Incident response
+=================
+
+Prepare for outages or degraded performance by following this response plan.
+
+Preparation
+-----------
+
+* Maintain runbooks for common failure modes (Redis outage, disk full, build
+  failures).
+* Configure alerting thresholds (see :doc:`../deployment/monitoring`).
+* Ensure access to production systems is limited and auditable.
+
+Triage
+------
+
+1. Assess impact – which features or users are affected?
+2. Collect logs, metrics, and recent deployment history.
+3. Communicate status via incident channels (Slack, status page).
+
+Mitigation
+----------
+
+* Scale resources or restart services using container orchestrator commands.
+* Roll back to a known good release if the incident correlates with a recent
+  deployment.
+* Disable non-essential features (e.g., collaboration) by setting
+  ``APPLICATION_SERVER_VERSION=0`` temporarily if it reduces load.
+
+Post-incident
+-------------
+
+* Document root cause, mitigation steps, and follow-up actions.
+* Create GitHub issues for remediation tasks.
+* Update runbooks and monitoring thresholds based on lessons learned.
+
+Next steps
+----------
+
+See :doc:`support` for day-to-day user support practices.

--- a/docs/operations/index.rst
+++ b/docs/operations/index.rst
@@ -1,0 +1,12 @@
+Operations
+==========
+
+Day-two operations encompass CI/CD, incident response, support, and maintenance.
+
+.. toctree::
+   :maxdepth: 2
+
+   ci-cd
+   incident-response
+   support
+   backups-and-dr

--- a/docs/operations/support.rst
+++ b/docs/operations/support.rst
@@ -1,0 +1,37 @@
+Support
+=======
+
+Provide responsive support to users and contributors.
+
+Channels
+--------
+
+* Email: ``info@besser-pearl.org`` (see README).
+* GitHub issues for bug reports and feature requests.
+* Community forums or chat channels as established by the project.
+
+Support process
+---------------
+
+1. Acknowledge new requests within one business day.
+2. Triage issues by severity (critical, major, minor).
+3. Link issues to relevant GitHub tickets and assign owners.
+4. Provide status updates until resolution.
+
+Knowledge base
+--------------
+
+* Keep FAQs and troubleshooting guides up to date (see :doc:`../appendix/faq`).
+* Document known limitations and workarounds in the user guide.
+* Encourage users to include exported diagrams when reporting modelling issues.
+
+Feedback loop
+-------------
+
+* Aggregate feedback to inform roadmap planning.
+* Share insights with maintainers and update documentation accordingly.
+
+Next steps
+----------
+
+Consult :doc:`backups-and-dr` for maintenance of critical data.

--- a/docs/platform/architecture.rst
+++ b/docs/platform/architecture.rst
@@ -1,0 +1,66 @@
+System architecture
+===================
+
+BESSER WME Standalone is a monorepo of TypeScript packages orchestrated through
+a npm workspace (:file:`package.json`). The architecture is divided into three
+primary layers.
+
+1. **Core modelling engine** – consumed from the ``@besser/wme`` npm package. It
+   delivers diagram rendering, palette management, and editing operations.
+2. **Web application** – housed under :file:`packages/webapp`. A React
+   single-page application integrates the engine, templates, analytics, and
+   routing. Webpack handles bundling and environment injection.
+3. **Collaboration server** – located in :file:`packages/server`. An Express
+   application serves the static assets, exposes REST APIs, and manages storage
+   adapters for collaboration features.
+
+Shared infrastructure
+---------------------
+
+* :file:`packages/shared` defines DTOs, validation helpers, and type guards. It
+  ensures the webapp and server use the same contracts when exchanging diagrams.
+* Root-level npm scripts orchestrate builds, linting, and development workflows
+  across all packages (``npm run build``, ``npm run lint``, ``npm run dev``).
+* ``tsconfig.json`` in each package extends the root configuration to align
+  compiler options.
+
+Data persistence
+----------------
+
+* File-based storage (``DiagramFileStorageService``) writes JSON blobs under the
+  ``diagrams`` directory using a rate-limited queue.
+* Redis-backed storage (``DiagramRedisStorageService``) leverages RedisJSON for
+  structured persistence and optional TTL enforcement.
+* ``MigratingStorageService`` bridges filesystem and Redis when migrating data.
+
+Messaging and collaboration
+---------------------------
+
+* ``CollaborationService`` manages WebSocket upgrades, distributing JSON patches
+  between clients.
+* ``DiagramService`` handles version creation, metadata updates, and deletion
+  requests, delegating persistence to the selected storage adapter.
+* ``conversion-service`` pipelines export requests into image/PDF assets.
+
+Front-end integration
+---------------------
+
+* ``ApplicationStore`` coordinates state across components via React context.
+* ``ApollonEditorProvider`` exposes the underlying editor instance to nested
+  components, allowing share modals and toolbars to interact with the canvas.
+* Routing is implemented with ``react-router-dom`` to support multi-page flows.
+
+Operational concerns
+--------------------
+
+* Dockerfiles for static hosting and Redis-backed deployments live at the root.
+* ``docker-compose.yml`` spins up the webapp, server, and Redis services for
+  local integration testing.
+* Systemd service templates (``BESSER_WME_Standalone.service``) and cron jobs
+  (``delete-stale-diagrams.cronjob.txt``) support traditional VM deployments.
+
+Next steps
+----------
+
+Consult :doc:`package-map` for a closer look at each workspace package, or jump
+to :doc:`../backend/index` for backend implementation details.

--- a/docs/platform/data-flow.rst
+++ b/docs/platform/data-flow.rst
@@ -1,0 +1,61 @@
+Data flow
+=========
+
+This section traces how information moves through the system during common
+scenarios.
+
+Diagram creation and persistence
+--------------------------------
+
+1. A user creates or edits elements in ``ApollonEditorComponent``.
+2. The component serialises the diagram and stores it in local storage while the
+   user remains offline.
+3. When the user clicks *Save* (or auto-save triggers), the webapp calls the
+   server's ``/api/diagrams`` endpoint.
+4. ``routes.ts`` delegates to ``DiagramService.saveDiagramVersion`` which either
+   creates a new token or appends a version to an existing diagram.
+5. The configured storage adapter (filesystem or Redis) persists the diagram via
+   ``DiagramStorageService``.
+6. The server responds with the canonical diagram payload and share token, which
+   is cached client-side for quick access.
+
+Real-time collaboration
+-----------------------
+
+* Clients connect to the ``CollaborationService`` WebSocket endpoint (upgraded in
+  ``server.ts``).
+* Diagram changes are broadcast as JSON patches. Storage adapters (``DiagramStorageRateLimiter``)
+  debounce write operations to avoid overwhelming the backing store.
+* New clients replay the latest persisted model before subscribing to live
+  updates.
+
+Export pipeline
+---------------
+
+* When a user requests an export, the webapp sends the diagram payload to the
+  conversion service.
+* ``conversion-service`` orchestrates rendering to PNG, SVG, or PDF, relying on
+  native libraries bundled via ``node-canvas``.
+* The resulting binary is streamed back to the client for download.
+
+Template bootstrapping
+----------------------
+
+* Selecting a template loads JSON from the ``templates`` directory.
+* ``ApollonEditorComponent`` initialises the modelling engine with the template
+  state and metadata.
+* Version history records the template origin to maintain traceability.
+
+Monitoring and analytics
+------------------------
+
+* Client events flow to PostHog when ``POSTHOG_KEY`` is configured.
+* Server-side exceptions are captured by Sentry when ``SENTRY_DSN`` is set.
+* Infrastructure metrics (CPU, memory) can be collected by the hosting platform
+  or container orchestrator.
+
+Next steps
+----------
+
+Dive into :doc:`../backend/index` for API surface details or :doc:`../frontend/index`
+for the React component architecture.

--- a/docs/platform/index.rst
+++ b/docs/platform/index.rst
@@ -1,0 +1,12 @@
+Platform internals
+==================
+
+Understand how the workspace packages compose the standalone editor. These
+chapters document high-level architecture, package boundaries, and data flows.
+
+.. toctree::
+   :maxdepth: 2
+
+   architecture
+   package-map
+   data-flow

--- a/docs/platform/package-map.rst
+++ b/docs/platform/package-map.rst
@@ -1,0 +1,60 @@
+Package map
+===========
+
+The workspace is divided into four primary packages. Understanding their
+responsibilities helps contributors locate source files quickly.
+
+``packages/editor``
+-------------------
+
+* Houses reusable components, domain models, and services that augment the
+  ``@besser/wme`` engine.
+* Provides TypeScript source under :file:`src/` with build targets defined in
+  :file:`tsconfig.json` and :file:`tsconfig.es5.json` for compatibility bundles.
+* Publishes artefacts consumed by both the standalone webapp and server via npm
+  workspaces.
+
+``packages/webapp``
+-------------------
+
+* Contains the React SPA entrypoints in :file:`src/main/`.
+* ``components/`` – UI building blocks such as the application bar, share modal,
+  sidebar layouts, and integration widgets.
+* ``services/`` – wrappers around APIs, local storage, and analytics providers.
+* ``store/`` and ``hooks/`` – state management utilities.
+* ``templates/`` – curated diagram starters and their metadata.
+* ``webpack/`` – shared, production, and development Webpack configurations.
+
+``packages/server``
+-------------------
+
+* ``src/main/server.ts`` – Express bootstrap that serves the webapp bundle and
+  registers routes.
+* ``services/`` – collaboration, conversion, diagram persistence, and storage
+  adapters. Includes Redis and filesystem implementations plus migration support.
+* ``resources/`` – handlebars templates and static assets served alongside the
+  API.
+* ``routes.ts`` – centralises REST endpoint registration.
+* ``utils.ts`` – helper functions such as ``randomString`` and token utilities.
+
+``packages/shared``
+-------------------
+
+* ``src/main/`` – shared DTOs, validation schemas, and type definitions used by
+  the other packages.
+* ``package.json`` – exposes a build script to compile TypeScript into CommonJS
+  modules consumed by the server and webapp.
+
+Build artefacts
+---------------
+
+* Each package outputs compiled code into :file:`build/` when ``npm run build``
+  is executed from the workspace root.
+* The root ``node_modules`` contains hoisted dependencies while package-specific
+  dependencies reside under ``packages/*/node_modules``.
+
+Next steps
+----------
+
+Review :doc:`data-flow` to understand how information moves between these
+packages during runtime.

--- a/docs/reference/environment-variables.rst
+++ b/docs/reference/environment-variables.rst
@@ -1,0 +1,47 @@
+Environment variables
+=====================
+
+Reference for environment variables used by the workspace.
+
+Core variables
+--------------
+
+``APPLICATION_SERVER_VERSION``
+    Toggle collaboration features in the webapp.
+``DEPLOYMENT_URL``
+    Public base URL for API calls, share links, and WebSocket connections.
+``BACKEND_URL``
+    Optional endpoint for auxiliary backends when running in development mode.
+``SENTRY_DSN``
+    Enables Sentry telemetry on the server and optionally in the client.
+``POSTHOG_HOST`` / ``POSTHOG_KEY``
+    Configure PostHog analytics.
+``UML_BOT_WS_URL``
+    Set the WebSocket endpoint for the UML Bot widget.
+
+Storage
+-------
+
+``APOLLON_REDIS_URL``
+    Redis connection string. When set, enables Redis storage.
+``APOLLON_REDIS_DIAGRAM_TTL``
+    TTL for diagrams stored in Redis (parsed via ``ms``).
+``APOLLON_REDIS_MIGRATE_FROM_FILE``
+    Enable one-time migration from filesystem to Redis storage.
+
+Build-time
+----------
+
+* Webpack injects these variables at compile time using ``DefinePlugin``. Update
+  values before running ``npm run build``.
+
+Server runtime
+--------------
+
+* Ensure environment variables are set for the process manager (systemd,
+  Docker, Kubernetes) before launching ``server.js``.
+
+Next steps
+----------
+
+Consult :doc:`file-structure` for directory layout.

--- a/docs/reference/file-structure.rst
+++ b/docs/reference/file-structure.rst
@@ -1,0 +1,55 @@
+File structure
+==============
+
+A high-level overview of important directories and files.
+
+Root
+----
+
+``package.json``
+    Workspace configuration, scripts, and dependency versions.
+``docker-compose.yml``
+    Development compose file for server + Redis.
+``Dockerfile`` / ``Dockerfile.redis``
+    Container build definitions.
+``docs/``
+    Sphinx documentation source.
+``packages/``
+    Workspace packages (editor, server, shared, webapp).
+``BESSER_WME_Standalone.service``
+    Example systemd service file for Linux deployments.
+``delete-stale-diagrams.cronjob.txt``
+    Cron job definition for cleaning old diagrams.
+
+Packages
+--------
+
+``packages/editor``
+    Shared editor modules.
+``packages/server``
+    Express server source, services, and build configuration.
+``packages/shared``
+    DTOs and shared utilities.
+``packages/webapp``
+    React web application source and build scripts.
+
+Build output
+------------
+
+``build/webapp``
+    Compiled static assets for the webapp.
+``build/server``
+    Compiled Express server ready for deployment.
+
+Miscellaneous
+-------------
+
+``entrypoint.sh``
+    Container entrypoint script.
+``root_config.ts``
+    Configuration entry for Nx or tooling integrations (if used).
+
+Next steps
+----------
+
+Review the :doc:`../appendix/index` for FAQs, glossary, and troubleshooting.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,0 +1,11 @@
+Reference
+=========
+
+Quick reference material for scripts, environment variables, and file structure.
+
+.. toctree::
+   :maxdepth: 2
+
+   npm-scripts
+   environment-variables
+   file-structure

--- a/docs/reference/npm-scripts.rst
+++ b/docs/reference/npm-scripts.rst
@@ -1,0 +1,63 @@
+npm scripts
+===========
+
+The root :file:`package.json` defines scripts for common tasks.
+
+Development
+-----------
+
+``npm run dev``
+    Start both webapp and server concurrently.
+``npm run start:webapp``
+    Launch the webpack development server on port 8888.
+``npm run start:server``
+    Start the Express server on port 8080.
+
+Build
+-----
+
+``npm run build``
+    Build shared DTOs, webapp, and server for production.
+``npm run build:local``
+    Build assets tailored for local testing.
+``npm run build:webapp``
+    Build only the webapp bundle.
+``npm run build:server``
+    Build only the server bundle.
+``npm run build:shared``
+    Compile shared DTOs.
+
+Quality
+-------
+
+``npm run lint``
+    Run ESLint/Stylelint across packages.
+``npm run prettier:check``
+    Verify formatting.
+``npm run prettier:write``
+    Auto-format supported files.
+
+Maintenance
+-----------
+
+``npm run update``
+    Use ``npm-check-updates`` to bump dependencies interactively.
+``npm run lint:webapp``
+    Lint only the webapp package.
+``npm run lint:server``
+    Lint only the server package.
+``npm run build:webapp:local``
+    Produce a webapp build optimised for local server integration.
+
+Workspaces
+----------
+
+Scripts can be executed per package::
+
+  npm run <script> --workspace=webapp
+  npm run <script> --workspace=server
+
+Next steps
+----------
+
+Refer to :doc:`environment-variables` for runtime configuration options.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx>=7.0
+sphinx-rtd-theme>=2.0

--- a/docs/user-guide/automation-and-shortcuts.rst
+++ b/docs/user-guide/automation-and-shortcuts.rst
@@ -1,0 +1,67 @@
+Automation and shortcuts
+========================
+
+Speed up your modelling sessions by mastering keyboard shortcuts, automation
+hooks, and reusable configurations.
+
+Keyboard shortcuts
+------------------
+
+Global
+    ``Ctrl+N`` create new diagram, ``Ctrl+S`` save, ``Ctrl+Shift+S`` publish a new
+    version, ``Ctrl+P`` open the export dialog.
+Navigation
+    ``Ctrl+Mouse Wheel`` zoom, ``Space+Drag`` pan, ``Ctrl+0`` reset zoom.
+Editing
+    ``Ctrl+D`` duplicate selection, ``Alt+Drag`` clone, ``Shift+Arrow`` nudge,
+    ``Ctrl+G`` group, ``Ctrl+Shift+G`` ungroup.
+Collaboration
+    ``Ctrl+Shift+C`` copy share link, ``Ctrl+Alt+F`` toggle feedback view.
+
+Command palette
+---------------
+
+Use ``Ctrl+Shift+P`` (``Cmd+Shift+P`` on macOS) to open the command palette for
+searchable access to actions such as diagram conversion, template switching, and
+preference toggles.
+
+Automating repetitive work
+--------------------------
+
+Templates
+    Save frequently used diagram structures as templates (:doc:`templates-and-assets`).
+Workflows
+    Use ``LocalStorageRepository`` to pre-populate default projects on startup.
+Scripting
+    Export diagrams as JSON and feed them into scripts that validate naming
+    conventions, generate documentation, or trigger downstream builds.
+
+Analytics and instrumentation
+-----------------------------
+
+* Enable PostHog by setting ``POSTHOG_HOST`` and ``POSTHOG_KEY``. The analytics
+  provider measures shortcut usage and identifies opportunities for custom
+  automations.
+* Configure ``SENTRY_DSN`` to capture client-side errors and performance metrics
+  relevant to automation features.
+
+Custom keyboard mappings
+------------------------
+
+Advanced users can extend shortcuts by editing the React components under
+:file:`packages/webapp/src/main/components`. Follow the existing pattern in the
+application bar to register new listeners.
+
+Troubleshooting
+---------------
+
+* If shortcuts stop responding, confirm the canvas has focus and that browser
+  extensions are not intercepting key combinations.
+* In non-US keyboard layouts, re-map shortcuts via browser-level overrides or
+  update the key handlers in the source.
+
+Next steps
+----------
+
+Wrap up with :doc:`customization-and-accessibility` to tailor the editor to your
+team's preferences.

--- a/docs/user-guide/collaboration.rst
+++ b/docs/user-guide/collaboration.rst
@@ -1,0 +1,75 @@
+Collaboration
+=============
+
+Pairing the web application with the collaboration server enables shared editing
+sessions, persistent version history, and feedback workflows. This page covers
+the user-facing features built on top of :mod:`packages/server`.
+
+Share modes
+-----------
+
+Open the share dialog from the application bar to generate secure links for the
+current diagram. The following modes mirror the behaviour of the production
+service:
+
+``Edit``
+    Recipients can edit the diagram collaboratively. Changes are persisted as
+    new versions through :class:`DiagramService <packages.server.src.main.services.diagram-service.diagram-service.DiagramService>`.
+``Embed``
+    Produces an embeddable URL suitable for documentation, Git issues, or other
+    portals. The embed always renders the latest version.
+``Give Feedback``
+    Allows reviewers to annotate and comment without altering the canonical
+    diagram.
+``See Feedback``
+    Displays collected feedback for review sessions.
+
+Version history
+---------------
+
+Every save operation creates a new entry in the version sidebar. Versions store
+metadata such as title, description, timestamp, and share tokens. Users can:
+
+* Browse previous versions and restore them to the canvas.
+* Edit metadata inline to document design rationale.
+* Delete superseded versions. The server enforces data integrity when removing
+  entries (see ``deleteDiagramVersion`` in ``DiagramService``).
+
+Real-time collaboration
+-----------------------
+
+The server hosts a ``CollaborationService`` that upgrades HTTP connections to
+WebSockets. Clients synchronise changes through patch streams handled by the
+storage adapters. Ensure that port 8080 (or your customised port) is reachable by
+participants.
+
+Notifications and presence
+--------------------------
+
+When connected to the backend, the application bar shows collaborator presence
+and connection health. Toast notifications indicate when someone else modifies
+the diagram or when version history is updated remotely.
+
+Security considerations
+-----------------------
+
+* Share tokens are generated using ``randomString`` with a configurable length
+  (see ``tokenLength`` in :file:`packages/server/src/main/constants.ts`).
+* Expire tokens automatically by configuring Redis with
+  ``APOLLON_REDIS_DIAGRAM_TTL``.
+* Enable ``SENTRY_DSN`` to capture audit trails and error reporting.
+
+Troubleshooting
+---------------
+
+* If share links open but do not load the diagram, confirm that the server has
+  access to the ``diagrams`` directory or Redis instance.
+* For WebSocket issues, verify reverse proxy configurations forward ``Upgrade``
+  and ``Connection`` headers.
+* Check server logs for rate limiter messages when saving large diagrams.
+
+Next steps
+----------
+
+Continue with :doc:`exporting-and-integration` to learn how to publish diagrams
+outside of the application.

--- a/docs/user-guide/customization-and-accessibility.rst
+++ b/docs/user-guide/customization-and-accessibility.rst
@@ -1,0 +1,66 @@
+Customization and accessibility
+===============================
+
+Tailor the editor to your preferences and ensure an inclusive experience for all
+team members.
+
+Themes and appearance
+---------------------
+
+* Toggle dark/light mode from the application bar. Preferences are stored in
+  local storage under ``localStorageUserThemePreference``.
+* Override colours using custom CSS loaded via the deployment host. Inject
+  additional stylesheets in the HTML template located at
+  :file:`packages/webapp/src/main/index.html` before building.
+* Replace the favicon or branding assets in :file:`packages/webapp/src/main/assets`.
+
+Localization
+------------
+
+* The UI copies strings from the ``@besser/wme`` engine. Extend localisation
+  bundles by editing translation files under :file:`packages/editor`.
+* Expose ``DEPLOYMENT_URL``-specific configuration to toggle languages via query
+  parameters or user profiles.
+
+Accessibility features
+----------------------
+
+Keyboard navigation
+    Primary actions are accessible via keyboard shortcuts and the command
+    palette. Focus states are visible and follow WCAG contrast guidelines.
+Screen readers
+    Toolbar buttons, menus, and modals include ``aria-label`` attributes. Test in
+    NVDA, VoiceOver, or JAWS to verify your customisations.
+High contrast
+    Combine the dark theme with custom CSS to increase contrast for low-vision
+    users. Ensure iconography remains legible.
+
+Assistive integrations
+----------------------
+
+* Configure ``UML_BOT_WS_URL`` to enable conversational assistance that generates
+  diagram scaffolds or narrates changes.
+* Use the feedback share mode to allow reviewers to leave textual or audio notes
+  without editing the diagram.
+
+Performance tuning
+------------------
+
+* Enable ``POSTHOG_KEY`` to capture performance metrics and identify accessibility
+  regressions.
+* Lazy-load optional panels by adjusting React routes when serving audiences with
+  limited connectivity.
+
+Testing your customisations
+---------------------------
+
+* Use browser accessibility inspectors (Lighthouse, Axe) to audit contrast,
+  keyboard navigation, and ARIA labelling.
+* Run ``npm run build:webapp`` after updating assets to ensure they are bundled
+  correctly.
+
+Next steps
+----------
+
+Proceed to the :doc:`../platform/index` section to understand how the webapp,
+server, and shared packages work together.

--- a/docs/user-guide/diagramming-basics.rst
+++ b/docs/user-guide/diagramming-basics.rst
@@ -1,0 +1,86 @@
+Diagramming basics
+==================
+
+The modelling canvas is powered by ``@besser/wme`` and exposes a familiar set of
+interaction patterns. This guide covers navigation, creation, editing, and
+validation workflows.
+
+Navigating the canvas
+---------------------
+
+* **Pan** by dragging the background with the left mouse button or holding the
+  space bar.
+* **Zoom** using the mouse wheel, trackpad pinch, or ``Ctrl +`` / ``Ctrl -``.
+* **Reset view** through the view controls in the application bar.
+
+Creating elements
+-----------------
+
+Palettes
+    Each diagram type exposes a tailored palette containing nodes, edges, and
+    annotations. Select ``File → New`` to switch diagram types; the palette will
+    refresh automatically.
+Drag and drop
+    Drag items from the palette onto the canvas to instantiate them. ``@besser/wme``
+    auto-places connectors and manages default sizing.
+Keyboard shortcuts
+    Use ``Ctrl+C`` / ``Ctrl+V`` to duplicate elements, ``Delete`` to remove, and
+    ``Shift`` plus arrow keys to nudge positions precisely.
+
+Connecting shapes
+-----------------
+
+* Hover over an element to reveal connection handles.
+* Drag from a handle to another element to create a relationship.
+* Auto-layout rules position the edge using orthogonal routing. Adjust via
+  waypoints if manual control is required.
+
+Formatting and styling
+----------------------
+
+Inline editors
+    Double-click on labels to edit text in place. The formatting toolbar allows
+    emphasis, alignment, and colour adjustments.
+Theme switching
+    Toggle between light and dark theme from the application bar. The preference
+    is persisted in local storage (see constants in
+    :file:`packages/webapp/src/main/constant.ts`).
+Custom colours
+    Select elements and use the inspector to change fill, stroke, and text
+    colours. Styles update in real time on the canvas.
+
+Managing layers and selections
+------------------------------
+
+Multi-select
+    Hold ``Shift`` while clicking to select multiple items. Dragging with the
+    marquee tool selects all elements within the bounding box.
+Grouping
+    Group related elements to move them together. The context menu exposes group
+    and ungroup options.
+Alignment guides
+    Smart guides appear during drag operations to help align shapes. Use the
+    alignment tools to snap to grid or evenly distribute nodes.
+
+Validation and feedback
+-----------------------
+
+* Inline validation markers appear when relationships violate notation rules.
+* The notification tray lists unresolved issues with quick navigation links.
+* Use ``Ctrl+Z`` / ``Ctrl+Y`` for undo and redo support when experimenting.
+
+Saving work
+-----------
+
+Local storage
+    The editor periodically saves diagrams to browser storage, keyed by
+    ``localStorageDiagramPrefix``. Recent diagrams are listed in ``HomeModal``.
+Server persistence
+    When collaboration is enabled, diagrams are saved through the REST API
+    (:doc:`../backend/rest-api`). Version history is managed automatically.
+
+Next steps
+----------
+
+Continue with :doc:`templates-and-assets` to explore reusable starting points
+and asset libraries.

--- a/docs/user-guide/exporting-and-integration.rst
+++ b/docs/user-guide/exporting-and-integration.rst
@@ -1,0 +1,64 @@
+Exporting and integration
+=========================
+
+BESSER WME Standalone provides multiple export formats and automation hooks so
+you can embed diagrams in other systems or pipelines.
+
+Export formats
+--------------
+
+Use ``File → Export`` to download the active diagram in the following formats:
+
+``PNG``
+    Choose between transparent or white backgrounds. Suitable for slide decks and
+    documents.
+``SVG``
+    Vector exports that preserve layers and text for downstream editing.
+``PDF``
+    High-fidelity format ideal for documentation packages.
+``JSON``
+    Serialises the diagram model for re-importing or processing with custom
+    scripts.
+
+Programmatic exports
+--------------------
+
+* The collaboration server exposes REST endpoints under ``/api/diagrams`` for
+  retrieving diagrams as JSON or SVG. Use these endpoints in CI pipelines to
+  capture artefacts automatically.
+* Use ``LocalStorageRepository`` helpers to pull the latest published token when
+  constructing automated export URLs.
+* Pair the webapp with the ``@besser/wme`` CLI to transform diagram JSON into
+  code generators in your build steps.
+
+Embedding diagrams
+------------------
+
+The ``Embed`` sharing mode produces URLs that can be embedded in markdown, wikis,
+or dashboards. The embed renders the latest version and respects read-only
+constraints. Combine with iframes or image proxies depending on your host.
+
+Third-party integrations
+------------------------
+
+* **Issue trackers** – Link to ``Give Feedback`` share URLs in GitHub or GitLab
+  issues to collect contextual reviews.
+* **Documentation portals** – Export SVGs or use embed links for living
+  diagrams.
+* **Low-code platform** – Synchronise diagrams with the broader BESSER platform
+  by consuming the JSON representation.
+
+Automation tips
+---------------
+
+* Expose ``DEPLOYMENT_URL`` as an environment variable in CI jobs so scripts can
+  build the correct export URLs.
+* Combine exports with static site generators to publish diagram collections.
+* Use the ``POSTHOG_KEY`` analytics integration to measure export usage and
+  adoption.
+
+Next steps
+----------
+
+Continue with :doc:`automation-and-shortcuts` to streamline repetitive actions
+inside the editor.

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -1,0 +1,17 @@
+User guide
+==========
+
+Master the day-to-day modelling experience with these guides. Each chapter digs
+into a specific area of the editor—from navigating the workspace to exporting
+production-ready assets.
+
+.. toctree::
+   :maxdepth: 2
+
+   workspace-tour
+   diagramming-basics
+   templates-and-assets
+   collaboration
+   exporting-and-integration
+   automation-and-shortcuts
+   customization-and-accessibility

--- a/docs/user-guide/templates-and-assets.rst
+++ b/docs/user-guide/templates-and-assets.rst
@@ -1,0 +1,65 @@
+Templates and assets
+====================
+
+Kick-start diagrams using the curated template gallery and custom asset support.
+This section explains how templates are organised in the repository and how to
+augment them.
+
+Template gallery
+----------------
+
+* Access the gallery via ``File → Start from Template``.
+* Templates are defined under :file:`packages/webapp/src/main/templates` as JSON
+  descriptors pointing to preview images and initial diagram payloads.
+* Choosing a template creates a new diagram populated with canonical elements,
+  layout, and metadata.
+
+Managing templates
+------------------
+
+Adding a new template
+    1. Place preview images in :file:`packages/webapp/src/main/templates/assets`.
+    2. Create a JSON descriptor containing ``title``, ``description``, ``preview``
+       path, and ``model`` reference.
+    3. Export the descriptor from ``templates/index.ts`` so it appears in the
+       gallery.
+    4. Run ``npm run build:webapp`` to bundle updated assets.
+Updating templates
+    Modify the JSON descriptor or source diagram and rebuild. The build pipeline
+    copies template assets into the final bundle.
+
+Custom palette assets
+---------------------
+
+The editor leverages ``@besser/wme`` palettes. To customise icons or element
+metadata:
+
+* Extend the palette definitions in :file:`packages/editor`.
+* Update the React components under ``packages/webapp/src/main/components`` to
+  surface new controls.
+* Rebuild the shared package (``npm run build:shared``) so the changes propagate
+  to both the webapp and server.
+
+Asset storage considerations
+----------------------------
+
+* Static assets (images, fonts) are bundled via Webpack. Importing them in
+  components ensures they are hashed and cached efficiently.
+* Template previews should remain lightweight (PNG or JPEG) to minimise bundle
+  size.
+* When using external asset CDNs, reference absolute URLs in the template
+  descriptors.
+
+Syncing with the backend
+------------------------
+
+Templates do not require server-side configuration. The collaboration server
+stores and serves diagrams agnostic of their origin. However, when introducing
+new notation types, ensure backend validation logic (if any) recognises the new
+shapes to avoid rejection during persistence.
+
+Next steps
+----------
+
+Continue with :doc:`collaboration` to learn how diagrams can be shared, reviewed,
+and versioned via the server.

--- a/docs/user-guide/workspace-tour.rst
+++ b/docs/user-guide/workspace-tour.rst
@@ -1,0 +1,81 @@
+Workspace tour
+==============
+
+The editor interface is built around a React single-page application
+(:file:`packages/webapp/src/main/application.tsx`). The layout balances the
+canvas, navigation bars, context-sensitive sidebars, and modals.
+
+Global navigation
+-----------------
+
+Application bar
+    The application bar (:file:`packages/webapp/src/main/components/application-bar/application-bar.tsx`)
+    collects project-level actions such as creating diagrams, switching themes,
+    exporting assets, and invoking the share modal. The bar reflects the current
+    connection mode. When ``APPLICATION_SERVER_VERSION`` is defined, share link
+    generators appear directly in the menu.
+Sidebar layout
+    ``SidebarLayout`` wraps the main routes and injects contextual panels such as
+    the version history sidebar and collaboration roster.
+Home modal
+    First-time visitors are greeted by ``HomeModal`` which offers quick entry
+    points to templates, recently used diagrams, and onboarding tips.
+
+Primary canvas
+--------------
+
+Apollon editor
+    ``ApollonEditorComponent`` hosts the ``@besser/wme`` canvas. It is responsible
+    for loading templates, synchronising local state with persistent storage, and
+    forwarding toolbar events to the underlying modelling engine.
+Version management
+    ``VersionManagementSidebar`` displays the list of diagram revisions, their
+    timestamps, and associated metadata. It integrates with the server's
+    ``DiagramService`` to fetch and prune versions.
+
+Supporting widgets
+------------------
+
+Error panel
+    ``ErrorPanel`` aggregates client-side errors and connection issues. It
+    surfaces problems such as failed save operations or template load failures.
+UML Bot widget
+    ``UMLBotWidget`` connects to ``UML_BOT_WS_URL`` to enable AI-assisted diagram
+    generation and feedback. Configure the WebSocket endpoint via environment
+    variables.
+Firefox hint
+    ``FirefoxIncompatibilityHint`` warns about browser-specific limitations and
+    suggests alternative workflows when necessary.
+Toast notifications
+    ``ToastContainer`` provides transient success and failure messages across the
+    application.
+
+Routing and pages
+-----------------
+
+The application uses React Router to expose several routes:
+
+``/``
+    Main modelling workspace.
+``/project-settings``
+    Accessed through the sidebar, this view configures metadata such as project
+    names, descriptions, and share permissions.
+``/teampage``
+    Lists team members, onboarding instructions, and ways to request access.
+``/:token`` (planned)
+    Collaboration routes that load diagrams by share token. This route is wired
+    in ``ApollonEditorComponentWithConnection`` and activated when the backend is
+    available.
+
+Keyboard shortcuts and help
+---------------------------
+
+* Press ``Ctrl+/`` (``Cmd+/`` on macOS) to open the built-in shortcut overlay.
+* Use ``?`` within the application bar to access documentation links and the bug
+  report template defined in :file:`packages/webapp/src/main/constant.ts`.
+
+Next steps
+----------
+
+Continue to :doc:`diagramming-basics` to explore palettes, selection tools, and
+editing workflows.


### PR DESCRIPTION
## Summary
- reorganize the Sphinx documentation into dedicated sections for getting started, user guidance, platform internals, deployment, development, operations, reference, and appendices
- detailed pages covering the collaboration server, webapp architecture, storage adapters, deployment topologies, contributor workflows, and troubleshooting resources
- update the documentation index to highlight the new multi-level structure and remove the previous single-page guides

