### PR TITLE
feat: add attributeType and visibility to UMLObjectAttribute

### DIFF
--- a/packages/editor/src/main/packages/uml-object-diagram/object-preview.ts
+++ b/packages/editor/src/main/packages/uml-object-diagram/object-preview.ts
@@ -81,6 +81,7 @@ const composeIconObjectPreview = (
       classInfo.attributes.forEach((attr, index) => {
         const objectAttribute = new UMLObjectAttribute({
           name: `${attr.name} = `,
+          attributeType: attr.attributeType || 'str',
           owner: instanceObject.id,
           bounds: {
             x: 0,
@@ -189,6 +190,7 @@ const composeNormalObjectPreview = (
       classInfo.attributes.forEach((attr, index) => {
         const objectAttribute = new UMLObjectAttribute({
           name: `${attr.name} = `,
+          attributeType: attr.attributeType || 'str',
           owner: instanceObject.id,
           bounds: {
             x: 0,

--- a/packages/editor/src/main/packages/uml-object-diagram/uml-object-attribute/uml-object-attribute.ts
+++ b/packages/editor/src/main/packages/uml-object-diagram/uml-object-attribute/uml-object-attribute.ts
@@ -8,17 +8,19 @@ import { IUMLElement } from '../../../services/uml-element/uml-element';
 
 export interface IUMLObjectAttribute extends IUMLElement {
   attributeId?: string; // ID of the attribute from the library class
+  attributeType?: string; // Type of the attribute (str, int, float, etc.)
 }
 
 export class UMLObjectAttribute extends UMLClassifierAttribute {
   type: UMLElementType = ObjectElementType.ObjectAttribute;
   attributeId?: string; // Store the ID of the attribute from the library class
 
-  constructor(values?: DeepPartial<IUMLElement & { attributeId?: string }>) {
+  constructor(values?: DeepPartial<IUMLElement & { attributeId?: string; attributeType?: string }>) {
     super(values);
     if (values?.attributeId) {
       this.attributeId = values.attributeId;
     }
+    // attributeType is already handled by the parent class constructor via assign()
   }
   serialize() {
     return {


### PR DESCRIPTION
This pull request enhances the handling of attribute types in UML object diagrams by introducing explicit support for attribute types and improving compatibility with both new and legacy data formats. The main changes involve updating data structures and parsing logic to ensure attribute types are consistently extracted and represented.

**Support for attribute types and improved parsing:**

* Added an optional `attributeType` property to the `IAttributeInfo` and `IUMLObjectAttribute` interfaces, and updated the `UMLObjectAttribute` class constructor to accept this property. [[1]](diffhunk://#diff-fb5e5fcbd67834bb129735f838f7111d4e21c8295fa848d34bcfe98e9f3138d8R32-R33) [[2]](diffhunk://#diff-5db438f946c8f0371b45cfcf2046e8c9a8df4206a8a532c270f38abe9af8a5c6R11-R23)
* Updated the logic in `DiagramBridgeService` to parse and extract attribute types from legacy attribute names (e.g., "+ name: int") and to prefer the explicit `attributeType` property when available. This includes new helper methods `parseAttributeType` and improved `cleanAttributeName`. [[1]](diffhunk://#diff-fb5e5fcbd67834bb129735f838f7111d4e21c8295fa848d34bcfe98e9f3138d8L153-R178) [[2]](diffhunk://#diff-fb5e5fcbd67834bb129735f838f7111d4e21c8295fa848d34bcfe98e9f3138d8R268-R276)
* Ensured that attribute type and visibility information is preserved and passed through when collecting unique attributes, supporting both new and legacy formats.

**UI and object preview updates:**

* Modified the object preview functions (`composeIconObjectPreview` and `composeNormalObjectPreview`) to default the attribute type to `'str'` if not specified, ensuring consistent display. [[1]](diffhunk://#diff-c326c2506a40e359b38c993bdf2129088bbd0c1f8eaba1145303aa65a031a25bR84) [[2]](diffhunk://#diff-c326c2506a40e359b38c993bdf2129088bbd0c1f8eaba1145303aa65a031a25bR193)…te parsing logic