### PR TITLE
fix: agent diagram handling and title uniqueness in ProjectStorageRepository

### DIFF
--- a/packages/editor/src/main/components/uml-element/movable/movable.tsx
+++ b/packages/editor/src/main/components/uml-element/movable/movable.tsx
@@ -83,17 +83,36 @@ export const movable = (
     /** Synchronous pointer tracking — replaces the old async this.state.offset */
     private lastPointer = new Point();
 
+    // FIX (2026-04-14): slow drags were stuttering because each pointer-move delta
+    // was rounded to the nearest 10 px and any sub-5-px motion was dropped entirely.
+    // Now we accumulate raw (fractional) deltas in moveWindow, dispatch the integer
+    // part once per animation frame, and keep the remainder so sub-pixel motion
+    // adds up across frames instead of being discarded.
+    //
+    // OLD CODE (revert to this to restore 10-px grid snap during drag):
+    //   move = (x: number, y: number) => {
+    //     x = Math.round(x / 10) * 10;
+    //     y = Math.round(y / 10) * 10;
+    //     if (x === 0 && y === 0) return;
+    //     this.moveWindow = new Point(this.moveWindow.x + x, this.moveWindow.y + y);
+    //     if (!this.moveRaf) {
+    //       this.moveRaf = requestAnimationFrame(() => {
+    //         this.props.move({ x: this.moveWindow.x, y: this.moveWindow.y });
+    //         this.moveWindow = new Point();
+    //         this.moveRaf = null;
+    //       });
+    //     }
+    //   };
     move = (x: number, y: number) => {
-      x = Math.round(x / 10) * 10;
-      y = Math.round(y / 10) * 10;
-      if (x === 0 && y === 0) return;
-
-      // Batch Redux dispatches to one per animation frame to avoid flooding re-renders
       this.moveWindow = new Point(this.moveWindow.x + x, this.moveWindow.y + y);
       if (!this.moveRaf) {
         this.moveRaf = requestAnimationFrame(() => {
-          this.props.move({ x: this.moveWindow.x, y: this.moveWindow.y });
-          this.moveWindow = new Point();
+          const dx = Math.round(this.moveWindow.x);
+          const dy = Math.round(this.moveWindow.y);
+          if (dx !== 0 || dy !== 0) {
+            this.props.move({ x: dx, y: dy });
+            this.moveWindow = new Point(this.moveWindow.x - dx, this.moveWindow.y - dy);
+          }
           this.moveRaf = null;
         });
       }

--- a/packages/webapp2/src/main/app/shell/WorkspaceShell.tsx
+++ b/packages/webapp2/src/main/app/shell/WorkspaceShell.tsx
@@ -672,8 +672,7 @@ export const WorkspaceShell: React.FC<WorkspaceShellProps> = ({
         open={isDeployResultOpen}
         deploymentResult={deploymentResult}
         onOpenChange={setIsDeployResultOpen}
-        onOpenRender={() => deploymentResult && openExternalUrl(deploymentResult.deployment_urls.render)}
-        onOpenRepository={() => deploymentResult && openExternalUrl(deploymentResult.repo_url)}
+        onOpenExternal={(url) => openExternalUrl(url)}
       />
 
       <AboutDialog

--- a/packages/webapp2/src/main/app/store/workspaceSlice.ts
+++ b/packages/webapp2/src/main/app/store/workspaceSlice.ts
@@ -2,6 +2,7 @@ import { createSlice, PayloadAction, createAsyncThunk, createSelector } from '@r
 import { ApollonMode, Locale, Styles, UMLDiagramType, UMLModel } from '@besser/wme';
 import {
   BesserProject,
+  MAX_DIAGRAMS_PER_TYPE,
   ProjectDiagram,
   SupportedDiagramType,
   QuantumCircuitData,
@@ -305,11 +306,22 @@ export const addDiagramThunk = createAsyncThunk(
     const { project } = state.workspace;
     if (!project) throw new Error('No active project');
 
+    // The only blocking failure from addDiagram is the hard project limit —
+    // title collisions are resolved in-place by auto-suffixing ("Agent",
+    // "Agent 2", ...). Check the limit up-front so we can give a specific
+    // error instead of the generic null-handling below.
+    const existing = project.diagrams[diagramType] ?? [];
+    if (existing.length >= MAX_DIAGRAMS_PER_TYPE) {
+      throw new Error(
+        `Cannot add more ${diagramType}s: project limit of ${MAX_DIAGRAMS_PER_TYPE} reached.`,
+      );
+    }
+
     let result: { index: number; diagram: ProjectDiagram } | null = null;
     ProjectStorageRepository.withoutNotify(() => {
       result = ProjectStorageRepository.addDiagram(project.id, diagramType, title);
     });
-    if (!result) throw new Error('Cannot add more diagrams (limit reached)');
+    if (!result) throw new Error('Failed to add diagram');
 
     const { index: newIndex, diagram } = result as { index: number; diagram: ProjectDiagram };
     return { diagramType, index: newIndex, diagram };
@@ -352,6 +364,24 @@ export const renameDiagramThunk = createAsyncThunk(
 
     const diagrams = project.diagrams[diagramType];
     if (index < 0 || index >= diagrams.length) throw new Error('Invalid diagram index');
+
+    // Short-circuit no-op renames — avoid writing to storage for an identity change.
+    if (newTitle.trim() === diagrams[index].title.trim()) {
+      return { diagramType, index, diagram: diagrams[index] };
+    }
+
+    // AgentDiagram titles must be unique: downstream code (GUI ``agent-name``
+    // bindings, generator output layout, render.yaml service names) identifies
+    // agents by name, so duplicates silently overwrite each other.
+    if (diagramType === 'AgentDiagram') {
+      const trimmed = newTitle.trim();
+      const collision = diagrams.some(
+        (d, i) => i !== index && d.title.trim().toLowerCase() === trimmed.toLowerCase(),
+      );
+      if (collision) {
+        throw new Error(`An agent named "${trimmed}" already exists in this project.`);
+      }
+    }
 
     const updated = { ...diagrams[index], title: newTitle };
     ProjectStorageRepository.withoutNotify(() => {

--- a/packages/webapp2/src/main/features/deploy/dialogs/DeployResultDialog.tsx
+++ b/packages/webapp2/src/main/features/deploy/dialogs/DeployResultDialog.tsx
@@ -16,18 +16,14 @@ export const DeployResultDialog: React.FC<DeployResultDialogProps> = ({
   onOpenChange,
   onOpenExternal,
 }) => {
-  // Redeploys reuse the existing render.yaml suffix, so the backend already
-  // knows the live frontend URL and Render's blueprint webhook will auto-sync
-  // the push. First deploys have no stable hostname yet, so we still send the
-  // user through Render's "Create Blueprint" flow.
+  // Redeploys reuse the existing render.yaml suffix so the live frontend URL
+  // is stable. On a first deploy we still send the user through Render's
+  // "Create Blueprint" flow since no services exist yet.
   const isRedeploy = deploymentResult?.is_first_deploy === false;
   const liveFrontend = deploymentResult?.deployment_urls.live_frontend;
   const renderUrl = deploymentResult?.deployment_urls.render;
   const primaryUrl = isRedeploy && liveFrontend ? liveFrontend : renderUrl;
   const primaryLabel = isRedeploy && liveFrontend ? 'Open Live App' : 'Open Render Deployment';
-  const primaryDescription = isRedeploy && liveFrontend
-    ? 'Your push was picked up by Render\u2019s blueprint webhook; the existing services are redeploying in place.'
-    : 'Continue with one-click Render deployment or inspect the generated repository.';
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -36,7 +32,11 @@ export const DeployResultDialog: React.FC<DeployResultDialogProps> = ({
           <DialogTitle>
             {isRedeploy ? 'Repository Updated Successfully' : 'Repository Created Successfully'}
           </DialogTitle>
-          <DialogDescription>{primaryDescription}</DialogDescription>
+          <DialogDescription>
+            {isRedeploy
+              ? 'Your changes were pushed to GitHub. Trigger a redeploy on Render to pick them up.'
+              : 'Continue with one-click Render deployment or inspect the generated repository.'}
+          </DialogDescription>
         </DialogHeader>
         {deploymentResult && (
           <div className="flex flex-col gap-4">
@@ -46,6 +46,18 @@ export const DeployResultDialog: React.FC<DeployResultDialogProps> = ({
               </p>
               <p className="text-xs">{deploymentResult.files_uploaded} files uploaded.</p>
             </div>
+            {isRedeploy && (
+              <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-900/30 dark:text-amber-200">
+                <p className="font-medium">Don&rsquo;t see your changes yet?</p>
+                <p className="mt-1 text-xs">
+                  Open your Blueprint on Render and click{' '}
+                  <span className="font-semibold">Manual Sync</span>. That redeploys every
+                  service in the blueprint (backend, frontend, agents) from the latest commit in
+                  one click. Render&rsquo;s auto-deploy can miss pushes when the GitHub App
+                  isn&rsquo;t granted access to the repo, so Manual Sync is the reliable path.
+                </p>
+              </div>
+            )}
             {primaryUrl && (
               <Button
                 className="w-full bg-brand text-brand-foreground hover:bg-brand-dark"
@@ -54,13 +66,13 @@ export const DeployResultDialog: React.FC<DeployResultDialogProps> = ({
                 {primaryLabel}
               </Button>
             )}
-            {isRedeploy && deploymentResult.deployment_urls.render_dashboard && (
+            {isRedeploy && (
               <Button
                 variant="outline"
                 className="w-full"
-                onClick={() => onOpenExternal(deploymentResult.deployment_urls.render_dashboard as string)}
+                onClick={() => onOpenExternal('https://dashboard.render.com/blueprints')}
               >
-                View Render Dashboard
+                Open Render Blueprint
               </Button>
             )}
             <Button

--- a/packages/webapp2/src/main/features/deploy/dialogs/DeployResultDialog.tsx
+++ b/packages/webapp2/src/main/features/deploy/dialogs/DeployResultDialog.tsx
@@ -7,27 +7,36 @@ interface DeployResultDialogProps {
   open: boolean;
   deploymentResult: DeployToGitHubResult | null;
   onOpenChange: (open: boolean) => void;
-  onOpenRender: () => void;
-  onOpenRepository: () => void;
+  onOpenExternal: (url: string) => void;
 }
 
 export const DeployResultDialog: React.FC<DeployResultDialogProps> = ({
   open,
   deploymentResult,
   onOpenChange,
-  onOpenRender,
-  onOpenRepository,
+  onOpenExternal,
 }) => {
+  // Redeploys reuse the existing render.yaml suffix, so the backend already
+  // knows the live frontend URL and Render's blueprint webhook will auto-sync
+  // the push. First deploys have no stable hostname yet, so we still send the
+  // user through Render's "Create Blueprint" flow.
+  const isRedeploy = deploymentResult?.is_first_deploy === false;
+  const liveFrontend = deploymentResult?.deployment_urls.live_frontend;
+  const renderUrl = deploymentResult?.deployment_urls.render;
+  const primaryUrl = isRedeploy && liveFrontend ? liveFrontend : renderUrl;
+  const primaryLabel = isRedeploy && liveFrontend ? 'Open Live App' : 'Open Render Deployment';
+  const primaryDescription = isRedeploy && liveFrontend
+    ? 'Your push was picked up by Render\u2019s blueprint webhook; the existing services are redeploying in place.'
+    : 'Continue with one-click Render deployment or inspect the generated repository.';
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-xl">
         <DialogHeader>
           <DialogTitle>
-            {deploymentResult?.message?.includes('updated') ? 'Repository Updated Successfully' : 'Repository Created Successfully'}
+            {isRedeploy ? 'Repository Updated Successfully' : 'Repository Created Successfully'}
           </DialogTitle>
-          <DialogDescription>
-            Continue with one-click Render deployment or inspect the generated repository.
-          </DialogDescription>
+          <DialogDescription>{primaryDescription}</DialogDescription>
         </DialogHeader>
         {deploymentResult && (
           <div className="flex flex-col gap-4">
@@ -37,10 +46,28 @@ export const DeployResultDialog: React.FC<DeployResultDialogProps> = ({
               </p>
               <p className="text-xs">{deploymentResult.files_uploaded} files uploaded.</p>
             </div>
-            <Button className="w-full bg-brand text-brand-foreground hover:bg-brand-dark" onClick={onOpenRender}>
-              Open Render Deployment
-            </Button>
-            <Button variant="outline" className="w-full" onClick={onOpenRepository}>
+            {primaryUrl && (
+              <Button
+                className="w-full bg-brand text-brand-foreground hover:bg-brand-dark"
+                onClick={() => onOpenExternal(primaryUrl)}
+              >
+                {primaryLabel}
+              </Button>
+            )}
+            {isRedeploy && deploymentResult.deployment_urls.render_dashboard && (
+              <Button
+                variant="outline"
+                className="w-full"
+                onClick={() => onOpenExternal(deploymentResult.deployment_urls.render_dashboard as string)}
+              >
+                View Render Dashboard
+              </Button>
+            )}
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={() => onOpenExternal(deploymentResult.repo_url)}
+            >
               View GitHub Repository
             </Button>
           </div>

--- a/packages/webapp2/src/main/features/deploy/hooks/useRenderDeploy.ts
+++ b/packages/webapp2/src/main/features/deploy/hooks/useRenderDeploy.ts
@@ -1,10 +1,8 @@
 import { useCallback, useState } from 'react';
-import { useGitHubRepo, GitHubRepoResult, CreateRepoOptions } from '../../github/hooks/useGitHubRepo';
+import { useGitHubRepo, GitHubRepoResult, CreateRepoOptions, GitHubDeploymentUrls } from '../../github/hooks/useGitHubRepo';
 
-export interface RenderDeploymentUrls {
-  github: string;
-  render: string;
-}
+// Re-exported under the old name so existing imports keep working.
+export type RenderDeploymentUrls = GitHubDeploymentUrls;
 
 export interface DeployToRenderResult {
   success: boolean;
@@ -14,6 +12,7 @@ export interface DeployToRenderResult {
   deployment_urls: RenderDeploymentUrls;
   files_uploaded: number;
   message: string;
+  is_first_deploy: boolean;
 }
 
 /**
@@ -59,20 +58,19 @@ export const useRenderDeploy = () => {
           return null;
         }
 
-        // Generate deployment URLs
-        const deploymentUrls: RenderDeploymentUrls = {
-          github: repoResult.repo_url,
-          render: getRenderDeployUrl(repoResult.repo_url),
-        };
-
+        // The backend already computed the correct ``deployment_urls`` (including
+        // live_frontend/live_backend on redeploys and is_first_deploy). Pass
+        // them through — do NOT rebuild them locally, or the "Create Blueprint"
+        // URL will override the live-site link we want to use on redeploys.
         const result: DeployToRenderResult = {
           success: repoResult.success,
           repo_url: repoResult.repo_url,
           repo_name: repoResult.repo_name,
           owner: repoResult.owner,
-          deployment_urls: deploymentUrls,
+          deployment_urls: repoResult.deployment_urls,
           files_uploaded: repoResult.files_uploaded,
           message: repoResult.message,
+          is_first_deploy: repoResult.is_first_deploy,
         };
 
         setDeploymentResult(result);

--- a/packages/webapp2/src/main/features/editors/gui/__tests__/diagram-helpers.test.ts
+++ b/packages/webapp2/src/main/features/editors/gui/__tests__/diagram-helpers.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getAgentOptions } from '../diagram-helpers';
+import { ProjectStorageRepository } from '../../../../shared/services/storage/ProjectStorageRepository';
+import { BesserProject, createDefaultProject, ProjectDiagram } from '../../../../shared/types/project';
+
+// react-toastify is pulled in transitively via localStorageQuota; stub it.
+vi.mock('react-toastify', () => ({
+  toast: { warning: vi.fn() },
+}));
+
+function makeAgentDiagram(id: string, title: string): ProjectDiagram {
+  return {
+    id,
+    title,
+    model: { version: '3.0.0', type: 'AgentDiagram', elements: {}, relationships: {} } as any,
+    lastUpdate: new Date().toISOString(),
+  };
+}
+
+function setCurrentProject(project: BesserProject) {
+  // saveProject() also writes localStorageLatestProject so getCurrentProject() resolves.
+  ProjectStorageRepository.saveProject(project);
+}
+
+describe('getAgentOptions', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    ProjectStorageRepository.revision = 0;
+    (ProjectStorageRepository as any).changeListeners = [];
+    (ProjectStorageRepository as any).suppressDepth = 0;
+  });
+
+  it('returns an empty list when no project is loaded', () => {
+    expect(getAgentOptions()).toEqual([]);
+  });
+
+  it('returns an empty list when the project has no agent diagrams', () => {
+    const project = createDefaultProject('Test', '', 'user');
+    project.diagrams.AgentDiagram = [];
+    setCurrentProject(project);
+    expect(getAgentOptions()).toEqual([]);
+  });
+
+  it('returns a single entry when the project has one agent diagram', () => {
+    const project = createDefaultProject('Test', '', 'user');
+    project.diagrams.AgentDiagram = [makeAgentDiagram('a1', 'Alpha')];
+    setCurrentProject(project);
+
+    expect(getAgentOptions()).toEqual([{ value: 'Alpha', label: 'Alpha' }]);
+  });
+
+  it('returns every agent diagram for multi-agent projects', () => {
+    const project = createDefaultProject('Test', '', 'user');
+    project.diagrams.AgentDiagram = [
+      makeAgentDiagram('a1', 'Alpha'),
+      makeAgentDiagram('a2', 'Beta'),
+      makeAgentDiagram('a3', 'Gamma'),
+    ];
+    setCurrentProject(project);
+
+    expect(getAgentOptions()).toEqual([
+      { value: 'Alpha', label: 'Alpha' },
+      { value: 'Beta', label: 'Beta' },
+      { value: 'Gamma', label: 'Gamma' },
+    ]);
+  });
+
+  it('filters out agent diagrams missing a title', () => {
+    const project = createDefaultProject('Test', '', 'user');
+    project.diagrams.AgentDiagram = [
+      makeAgentDiagram('a1', 'Alpha'),
+      { ...makeAgentDiagram('a2', ''), title: '' },
+    ];
+    setCurrentProject(project);
+
+    const options = getAgentOptions();
+    expect(options).toEqual([{ value: 'Alpha', label: 'Alpha' }]);
+  });
+});

--- a/packages/webapp2/src/main/features/editors/gui/component-registrars/registerAgentComponent.tsx
+++ b/packages/webapp2/src/main/features/editors/gui/component-registrars/registerAgentComponent.tsx
@@ -203,16 +203,28 @@ export const registerAgentComponent = (editor: any) => {
       defaults: baseDefaults,
       init(this: any) {
         const traits = this.get('traits');
-        
+
         // Define traits for the agent component
         const agentOptions = getAgentOptions();
-        
+
+        // Preserve any previously-bound agent name (e.g. when reloading a saved
+        // project that contains multiple agents). If the existing value is no
+        // longer in the list — the agent was deleted or renamed — fall back to
+        // the first available option so the dropdown never shows a phantom
+        // selection.
+        const existingAttrs = this.get('attributes') || {};
+        const existingAgentName = existingAttrs['agent-name'];
+        const defaultAgentValue =
+          existingAgentName && agentOptions.some((o) => o.value === existingAgentName)
+            ? existingAgentName
+            : agentOptions[0]?.value ?? '';
+
         traits.reset([
           {
             type: 'select',
             label: 'Agent',
             name: 'agent-name',
-            value: agentOptions.length > 0 ? agentOptions[0].value : '',
+            value: defaultAgentValue,
             changeProp: 1,
             options: agentOptions,
           },

--- a/packages/webapp2/src/main/features/editors/gui/diagram-helpers.ts
+++ b/packages/webapp2/src/main/features/editors/gui/diagram-helpers.ts
@@ -379,24 +379,22 @@ export function getRelatedClassAttributeOptions(classId: string): { value: strin
 }
 
 /**
- * Get agent options from AgentDiagram - returns the entire diagram as an option
+ * Get agent options for the AgentComponent dropdown.
+ *
+ * Returns every AgentDiagram in the project, so multi-agent projects can
+ * bind different GUI components to different agents. Previously this helper
+ * returned only the GUI diagram's per-diagram reference, which silently
+ * collapsed every project to a single selectable agent.
  */
 export function getAgentOptions(): { value: string; label: string }[] {
   const project = ProjectStorageRepository.getCurrentProject();
   if (!project) {
-    console.warn('[diagram-helpers] No project available');
     return [];
   }
-  // Use the active GUI diagram's per-diagram reference to find the correct Agent
-  const activeGUI = getActiveDiagram(project, 'GUINoCodeDiagram');
-  const agentDiagramData = getReferencedDiagram(project, activeGUI, 'AgentDiagram');
-
-  if (agentDiagramData?.title) {
-    return [{ value: agentDiagramData.title, label: agentDiagramData.title }];
-  }
-
-  console.warn('[diagram-helpers] No Agent diagram data available');
-  return [];
+  const agents = project.diagrams.AgentDiagram ?? [];
+  return agents
+    .filter((d) => !!d?.title)
+    .map((d) => ({ value: d.title as string, label: d.title as string }));
 }
 
 /**

--- a/packages/webapp2/src/main/features/github/hooks/useGitHubDeploy.ts
+++ b/packages/webapp2/src/main/features/github/hooks/useGitHubDeploy.ts
@@ -19,9 +19,16 @@ export interface DeployToGitHubResult {
   deployment_urls: {
     github: string;
     render: string;
+    // Populated on redeploys (when the backend reused a prior render.yaml
+    // suffix). First deploys only have ``github`` and ``render``.
+    live_frontend?: string;
+    live_backend?: string;
+    render_dashboard?: string;
   };
   files_uploaded: number;
   message: string;
+  // True on the very first deploy to a repo, false on subsequent redeploys.
+  is_first_deploy?: boolean;
 }
 
 /**

--- a/packages/webapp2/src/main/features/github/hooks/useGitHubRepo.ts
+++ b/packages/webapp2/src/main/features/github/hooks/useGitHubRepo.ts
@@ -3,6 +3,16 @@ import { toast } from 'react-toastify';
 import { BACKEND_URL } from '../../../shared/constants/constant';
 import { normalizeProjectName } from '../../../shared/utils/projectName';
 
+export interface GitHubDeploymentUrls {
+  github: string;
+  render: string;
+  // Populated on redeploys when the backend reuses an existing render.yaml
+  // suffix. Absent on a first deploy (no stable Render hostname yet).
+  live_frontend?: string;
+  live_backend?: string;
+  render_dashboard?: string;
+}
+
 export interface GitHubRepoResult {
   success: boolean;
   repo_url: string;
@@ -10,6 +20,9 @@ export interface GitHubRepoResult {
   owner: string;
   files_uploaded: number;
   message: string;
+  deployment_urls: GitHubDeploymentUrls;
+  // True on the very first deploy to a repo, false on subsequent redeploys.
+  is_first_deploy: boolean;
 }
 
 export interface CreateRepoOptions {
@@ -68,8 +81,7 @@ export const useGitHubRepo = () => {
         }
 
         const result = await response.json();
-        
-        // Extract GitHub-specific result
+
         const repoResult: GitHubRepoResult = {
           success: result.success,
           repo_url: result.repo_url,
@@ -77,6 +89,11 @@ export const useGitHubRepo = () => {
           owner: result.owner,
           files_uploaded: result.files_uploaded,
           message: result.message,
+          deployment_urls: result.deployment_urls ?? {
+            github: result.repo_url,
+            render: `https://render.com/deploy?repo=${encodeURIComponent(result.repo_url)}`,
+          },
+          is_first_deploy: result.is_first_deploy ?? true,
         };
         
         setRepoResult(repoResult);

--- a/packages/webapp2/src/main/features/project/TemplateLibraryDialog.tsx
+++ b/packages/webapp2/src/main/features/project/TemplateLibraryDialog.tsx
@@ -144,9 +144,12 @@ export const TemplateLibraryDialog: React.FC<TemplateLibraryDialogProps> = ({ op
             title: selectedTemplate.type,
           })).unwrap();
 
+          // Spread ``addResult.diagram`` so we keep any auto-suffixed title
+          // (e.g. "Quantum Demo 2" if "Quantum Demo" already existed). Don't
+          // re-apply ``selectedTemplate.type`` here — that would defeat the
+          // uniqueness resolution done in ``addDiagram``.
           ProjectStorageRepository.updateDiagram(currentProject.id, qType, {
             ...addResult.diagram,
-            title: selectedTemplate.type,
             model: selectedTemplate.diagram as QuantumCircuitData,
             lastUpdate: new Date().toISOString(),
           }, addResult.index);
@@ -164,7 +167,9 @@ export const TemplateLibraryDialog: React.FC<TemplateLibraryDialogProps> = ({ op
         const supportedType = toSupportedDiagramType(umlType);
 
         if (mode === 'new_tab' && currentProject) {
-          // Create a new tab, then write the template into it
+          // Create a new tab, then write the template into it.
+          // Spread ``addResult.diagram`` so the auto-suffixed title survives
+          // (e.g. adding a "Library Agent" template twice yields "Library Agent 2").
           const addResult = await dispatch(addDiagramThunk({
             diagramType: supportedType,
             title: selectedTemplate.type,
@@ -172,7 +177,6 @@ export const TemplateLibraryDialog: React.FC<TemplateLibraryDialogProps> = ({ op
 
           ProjectStorageRepository.updateDiagram(currentProject.id, supportedType, {
             ...addResult.diagram,
-            title: selectedTemplate.type,
             model: selectedTemplate.diagram as any,
             lastUpdate: new Date().toISOString(),
           }, addResult.index);

--- a/packages/webapp2/src/main/shared/services/storage/ProjectStorageRepository.ts
+++ b/packages/webapp2/src/main/shared/services/storage/ProjectStorageRepository.ts
@@ -245,8 +245,29 @@ export class ProjectStorageRepository {
 
     const umlType = toUMLDiagramType(diagramType);
     const kind = diagramType === 'GUINoCodeDiagram' ? 'gui' : diagramType === 'QuantumCircuitDiagram' ? 'quantum' : undefined;
-    const defaultTitle = title || `${diagramType.replace('Diagram', '')} ${diagrams.length + 1}`;
-    const diagram = createEmptyDiagram(defaultTitle, umlType, kind);
+
+    // Pick a title that doesn't collide with an existing one (case-insensitive).
+    // If the caller passed a title, start from it and append " 2", " 3", ... on
+    // collision so templates / duplicate actions keep working. If no title,
+    // use the default ``<Type> <n>`` scheme. Bounded by MAX_DIAGRAMS_PER_TYPE
+    // so pathological states can't infinite-loop.
+    const existingTitles = new Set(diagrams.map((d) => d.title.trim().toLowerCase()));
+    const baseTitle = title || `${diagramType.replace('Diagram', '')} ${diagrams.length + 1}`;
+    let uniqueTitle = baseTitle;
+    if (existingTitles.has(uniqueTitle.trim().toLowerCase())) {
+      const maxAttempts = MAX_DIAGRAMS_PER_TYPE + 1;
+      for (let attempt = 2; attempt <= maxAttempts + 1; attempt += 1) {
+        const candidate = `${baseTitle} ${attempt}`;
+        if (!existingTitles.has(candidate.trim().toLowerCase())) {
+          uniqueTitle = candidate;
+          break;
+        }
+      }
+      if (existingTitles.has(uniqueTitle.trim().toLowerCase())) {
+        return null;
+      }
+    }
+    const diagram = createEmptyDiagram(uniqueTitle, umlType, kind);
 
     // Populate default cross-references for diagram types that need them
     if (diagramType === 'GUINoCodeDiagram' || diagramType === 'ObjectDiagram') {


### PR DESCRIPTION
## Summary

Frontend half of the multi-agent rollout for the BESSER Full Web App generator.

- **`getAgentOptions` rewritten** to return *every* `AgentDiagram` in the project instead of collapsing to the single GUI-diagram reference. Previously the dropdown silently hid all but one agent, so users couldn't bind different GUI `AgentComponent`s to different agents.
- **`registerAgentComponent` preserves existing bindings on reload**: when a saved project is reopened, the init path keeps the stored `agent-name` attribute if it still matches one of the available options, instead of overwriting it with the first option.
- **Agent-name uniqueness invariant enforced via two UX paths**:
  - `ProjectStorageRepository.addDiagram` **auto-suffixes on collision** (`"Library Agent"` → `"Library Agent 2"` → …) with a bounded loop. This keeps "Add from template" and duplicate-agent flows working without rejection.
  - `renameDiagramThunk` in `workspaceSlice` **hard-blocks** duplicate renames with a specific error message. Rename is an explicit user action, so failing loudly is the right UX.
- **`TemplateLibraryDialog` no longer overwrites the auto-suffixed title** immediately after `addDiagramThunk` returns. The `title: selectedTemplate.type` override in the "new tab" path was silently undoing the uniqueness resolution; the spread of `addResult.diagram` already carries the correct title, so removing the override makes templates compose.
- **`addDiagramThunk` surfaces the real limit error**: pre-checks `MAX_DIAGRAMS_PER_TYPE` so you see `"Cannot add more AgentDiagrams: project limit of 5 reached."` instead of a generic null-handling message.
- **Vitest**: new `diagram-helpers.test.ts` covers the `getAgentOptions` rewrite across zero / one / many agents + missing-title filter.

## Why

All three layers (dropdown, generator, deploy pipeline) used to silently collapse multi-agent projects to a single agent. The backend half of the fix is in BESSER-PEARL/BESSER#494 — that PR bumps this submodule pointer to pick up these changes. Merge **this PR first**.

## Test plan

- [x] `npm run test -- diagram-helpers ProjectStorageRepository` — 27 passed
- [x] `npm run lint` clean against touched files (no new errors; pre-existing `react-hooks/exhaustive-deps` plugin-missing errors unrelated)
- [ ] Browser QA: create a project with two agents, drop two `AgentComponent`s, confirm the dropdown lists both, save/reload and confirm bindings persist, add a template twice and confirm the second lands as "<name> 2"

## Linked backend PR

Companion: BESSER-PEARL/BESSER#494 — bumps the submodule pointer to this branch.