### PR TITLE
fix: wire classId through agent object creation + stop double class suffix

### DIFF
--- a/packages/webapp2/src/main/features/assistant/services/converters/ObjectDiagramConverter.ts
+++ b/packages/webapp2/src/main/features/assistant/services/converters/ObjectDiagramConverter.ts
@@ -29,16 +29,21 @@ export class ObjectDiagramConverter implements DiagramConverter {
       objectName = `${spec.className.charAt(0).toLowerCase()}${spec.className.slice(1)}1`;
     }
 
+    // When classId is set, the ObjectName component (uml-object-name-component.tsx)
+    // automatically appends " : ClassName" from diagramBridge.getClassById(), so
+    // `.name` must hold ONLY the instance name. Embedding the suffix here would
+    // double-render as "author2: Author : Author". Fall back to the explicit
+    // suffix when there's no classId so the label is still meaningful.
     const objectElement: any = {
       type: "ObjectName",
       id: objectId,
-      name: `${objectName}: ${spec.className}`,
+      name: spec.classId ? objectName : `${objectName}: ${spec.className}`,
       owner: null,
       bounds: { x: pos.x, y: pos.y, width: 240, height: totalHeight },
       attributes: [] as string[],
       methods: []
     };
-    
+
     // Add classId reference if provided
     if (spec.classId) {
       objectElement.classId = spec.classId;

--- a/packages/webapp2/src/main/features/assistant/services/modifiers/ObjectDiagramModifier.ts
+++ b/packages/webapp2/src/main/features/assistant/services/modifiers/ObjectDiagramModifier.ts
@@ -77,16 +77,27 @@ export class ObjectDiagramModifier implements DiagramModifier {
     const attrHeight = attrs.length * 30;
     const totalHeight = baseHeight + attrHeight;
 
-    // Create ObjectName element
+    // Create ObjectName element. Propagate classId from the agent so the
+    // update panel can link this object to its class definition (otherwise
+    // the "class:" dropdown in the object popup shows nothing).
+    //
+    // When classId is set, store ONLY the instance name in `.name`; the
+    // component at uml-object-name-component.tsx appends " : ClassName"
+    // automatically via diagramBridge.getClassById(). Embedding the suffix
+    // here would double-render as "author2: Author : Author".
+    const displayName = changes.classId ? objectName : `${objectName}: ${className}`;
     const objectElement: any = {
       type: 'ObjectName',
       id: objectId,
-      name: `${objectName}: ${className}`,
+      name: displayName,
       owner: null,
       bounds: { x: pos.x, y: pos.y, width: 240, height: totalHeight },
       attributes: [] as string[],
       methods: []
     };
+    if (changes.classId) {
+      objectElement.classId = changes.classId;
+    }
 
     // Create ObjectAttribute children
     let currentY = pos.y + 60;
@@ -94,7 +105,7 @@ export class ObjectDiagramModifier implements DiagramModifier {
       const attrId = ModifierHelpers.generateUniqueId('attr');
       objectElement.attributes.push(attrId);
 
-      model.elements[attrId] = {
+      const attributeElement: any = {
         id: attrId,
         name: `${attr.name} = ${attr.value || ''}`,
         type: 'ObjectAttribute',
@@ -102,6 +113,12 @@ export class ObjectDiagramModifier implements DiagramModifier {
         bounds: { x: pos.x + 1, y: currentY, width: 238, height: 30 },
         attributeType: attr.type || 'str'
       };
+      // Library attribute id — the update panel uses this to tie the
+      // object attribute back to its class-diagram definition.
+      if (attr.attributeId) {
+        attributeElement.attributeId = attr.attributeId;
+      }
+      model.elements[attrId] = attributeElement;
       currentY += 30;
     }
 

--- a/packages/webapp2/src/main/features/assistant/services/modifiers/base.ts
+++ b/packages/webapp2/src/main/features/assistant/services/modifiers/base.ts
@@ -49,9 +49,10 @@ export interface ModificationChanges {
   target?: string;
   label?: string;
   value?: string;
-  // add_class fields
+  // add_class / add_object fields
   className?: string;
-  attributes?: Array<{ name: string; type?: string; visibility?: string; value?: string }>;
+  classId?: string;
+  attributes?: Array<{ name: string; type?: string; visibility?: string; value?: string; attributeId?: string }>;
   methods?: Array<{ name: string; returnType?: string; visibility?: string; parameters?: Array<{ name: string; type: string }> }>;
   // add_state fields
   stateType?: string;


### PR DESCRIPTION
Companion to BESSER main repo release **v7.1.3** (PR [BESSER-PEARL/BESSER#497](https://github.com/BESSER-PEARL/BESSER/pull/497)).

## Summary

The modeling agent creates Object Diagram elements via the `add_object` path. Two bugs made the linked class invisible to the user:

1. `ObjectDiagramModifier.addObject` dropped `classId` entirely. It concatenated the class name into the display string (`"author2: Author"`) but never wrote `classId` or `attributeId` as real fields, so the `uml-object-name-update` panel's *"class:"* dropdown showed nothing selected even though the title read `": Author"`.

2. After wiring `classId` through, the object rendered as `"author2: Author : Author"` because `uml-object-name-component.tsx` blindly appends `" : ClassName"` whenever `classId` resolves via `diagramBridge.getClassById`, while `.name` still carried the legacy `": Author"` suffix.

## Changes

- **`modifiers/ObjectDiagramModifier.ts`** — read `changes.classId` and set it on the created `ObjectName` element; read `attr.attributeId` on each child and set it on `ObjectAttribute`. When `classId` is set, store only the instance name in `.name` so the component appends `" : ClassName"` exactly once; fall back to the legacy suffix format when no `classId`.
- **`converters/ObjectDiagramConverter.ts`** — same display-name fix for the `inject_element` / `inject_complete_system` paths used by the agent's complete-system generation.
- **`modifiers/base.ts`** — add `classId` (top-level) and per-attribute `attributeId` to `ModificationChanges` so TypeScript lets the modifier read them.

## Note on the backend half

This PR only wires the classId **through the frontend**. The LLM-side of the fix (making sure the modeling agent actually emits `classId` in the `add_object` modification) lives in the separate `modeling-agent` repo:

- `schemas/object_diagram.py` — new `classId` field on `ObjectModificationChanges` (Pydantic was stripping it before).
- `diagram_handlers/types/object_diagram_handler.py` — server-side `_resolve_class_references` post-processor that deterministically fills `classId` / `attributeId` / `attributeType` from the reference class catalog regardless of whether the LLM remembered to emit them.

Deploy the latest `modeling-agent` alongside the BESSER backend to get the end-to-end fix.

## Test plan

- [x] In the web editor, ask the modeling agent to *"add an object user2 of class User"* in an Object Diagram — inspect the created object: update panel's "class:" dropdown should show **User** selected, title should render as `user2: User` (single suffix, not double).
- [x] Ask the agent for a complete system (*"create a library with books and authors"*) — every generated object should have the same correct behavior.
- [x] Regression: manually create an object via the palette, pick a class from the dropdown — should still work exactly as before.