### PR TITLE
feat: is_id + is_external_id checkboxes on class attributes

### DIFF
--- a/packages/editor/src/main/components/style-pane/style-pane.tsx
+++ b/packages/editor/src/main/components/style-pane/style-pane.tsx
@@ -28,6 +28,8 @@ type OwnProps = {
   onOptionalChange?: (checked: boolean) => void;
   isDerived?: boolean;
   onDerivedChange?: (checked: boolean) => void;
+  isId?: boolean;
+  onIdChange?: (checked: boolean) => void;
   defaultValue?: any;
   onDefaultValueChange?: (value: string) => void;
   attributeType?: string;
@@ -251,7 +253,7 @@ class StylePaneComponent extends Component<Props, State> {
 
   render() {
     const { fillSelectOpen, strokeSelectOpen, textSelectOpen } = this.state;
-    const { open, element, fillColor, lineColor, textColor, showDescription, showUri, showIcon, isOptional, onOptionalChange, isDerived, onDerivedChange, defaultValue, onDefaultValueChange, enumerationLiterals } = this.props;
+    const { open, element, fillColor, lineColor, textColor, showDescription, showUri, showIcon, isOptional, onOptionalChange, isDerived, onDerivedChange, isId, onIdChange, defaultValue, onDefaultValueChange, enumerationLiterals } = this.props;
     const noneOpen = !fillSelectOpen && !strokeSelectOpen && !textSelectOpen;
 
     if (!open) return null;
@@ -283,6 +285,20 @@ class StylePaneComponent extends Component<Props, State> {
                 type="checkbox"
                 checked={isDerived || false}
                 onChange={(e) => onDerivedChange(e.target.checked)}
+              />
+            </CheckboxRow>
+            <Divider />
+          </>
+        )}
+        {onIdChange && (
+          <>
+            <CheckboxRow as="label" htmlFor={`id-${element?.id}`}>
+              <span>ID</span>
+              <input
+                id={`id-${element?.id}`}
+                type="checkbox"
+                checked={isId || false}
+                onChange={(e) => onIdChange(e.target.checked)}
               />
             </CheckboxRow>
             <Divider />

--- a/packages/editor/src/main/components/style-pane/style-pane.tsx
+++ b/packages/editor/src/main/components/style-pane/style-pane.tsx
@@ -30,6 +30,8 @@ type OwnProps = {
   onDerivedChange?: (checked: boolean) => void;
   isId?: boolean;
   onIdChange?: (checked: boolean) => void;
+  isExternalId?: boolean;
+  onExternalIdChange?: (checked: boolean) => void;
   defaultValue?: any;
   onDefaultValueChange?: (value: string) => void;
   attributeType?: string;
@@ -253,7 +255,7 @@ class StylePaneComponent extends Component<Props, State> {
 
   render() {
     const { fillSelectOpen, strokeSelectOpen, textSelectOpen } = this.state;
-    const { open, element, fillColor, lineColor, textColor, showDescription, showUri, showIcon, isOptional, onOptionalChange, isDerived, onDerivedChange, isId, onIdChange, defaultValue, onDefaultValueChange, enumerationLiterals } = this.props;
+    const { open, element, fillColor, lineColor, textColor, showDescription, showUri, showIcon, isOptional, onOptionalChange, isDerived, onDerivedChange, isId, onIdChange, isExternalId, onExternalIdChange, defaultValue, onDefaultValueChange, enumerationLiterals } = this.props;
     const noneOpen = !fillSelectOpen && !strokeSelectOpen && !textSelectOpen;
 
     if (!open) return null;
@@ -299,6 +301,20 @@ class StylePaneComponent extends Component<Props, State> {
                 type="checkbox"
                 checked={isId || false}
                 onChange={(e) => onIdChange(e.target.checked)}
+              />
+            </CheckboxRow>
+            <Divider />
+          </>
+        )}
+        {onExternalIdChange && (
+          <>
+            <CheckboxRow as="label" htmlFor={`external-id-${element?.id}`}>
+              <span>External ID</span>
+              <input
+                id={`external-id-${element?.id}`}
+                type="checkbox"
+                checked={isExternalId || false}
+                onChange={(e) => onExternalIdChange(e.target.checked)}
               />
             </CheckboxRow>
             <Divider />

--- a/packages/editor/src/main/components/style-pane/style-pane.tsx
+++ b/packages/editor/src/main/components/style-pane/style-pane.tsx
@@ -262,6 +262,13 @@ class StylePaneComponent extends Component<Props, State> {
 
     const isEnumType = enumerationLiterals && enumerationLiterals.length > 0;
 
+    // Metamodel rule: an attribute marked as an identifier (primary or
+    // external) cannot also be optional. Lock the conflicting checkbox
+    // on each side so the user can't save invalid state — on submit it
+    // would fail validation in the backend Property() setter anyway.
+    const optionalLockedByIdFlag = Boolean(isId || isExternalId);
+    const idLockedByOptional = Boolean(isOptional);
+
     return (
       <Container>
         {onOptionalChange && (
@@ -272,6 +279,8 @@ class StylePaneComponent extends Component<Props, State> {
                 id={`optional-${element?.id}`}
                 type="checkbox"
                 checked={isOptional || false}
+                disabled={optionalLockedByIdFlag}
+                title={optionalLockedByIdFlag ? 'Identifier attributes cannot be optional.' : undefined}
                 onChange={(e) => onOptionalChange(e.target.checked)}
               />
             </CheckboxRow>
@@ -300,6 +309,8 @@ class StylePaneComponent extends Component<Props, State> {
                 id={`id-${element?.id}`}
                 type="checkbox"
                 checked={isId || false}
+                disabled={idLockedByOptional}
+                title={idLockedByOptional ? 'Optional attributes cannot be the identifier.' : undefined}
                 onChange={(e) => onIdChange(e.target.checked)}
               />
             </CheckboxRow>
@@ -314,6 +325,8 @@ class StylePaneComponent extends Component<Props, State> {
                 id={`external-id-${element?.id}`}
                 type="checkbox"
                 checked={isExternalId || false}
+                disabled={idLockedByOptional}
+                title={idLockedByOptional ? 'Optional attributes cannot be the external identifier.' : undefined}
                 onChange={(e) => onExternalIdChange(e.target.checked)}
               />
             </CheckboxRow>

--- a/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-attribute-update.tsx
+++ b/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-attribute-update.tsx
@@ -125,6 +125,7 @@ type AttributeValues = {
   attributeType?: string;
   isOptional?: boolean;
   isDerived?: boolean;
+  isId?: boolean;
   defaultValue?: any;
   fillColor?: string;
   textColor?: string;
@@ -139,6 +140,7 @@ type Props = {
   attributeType?: string;
   isOptional?: boolean;
   isDerived?: boolean;
+  isId?: boolean;
   defaultValue?: any;
   onChange: (id: string, values: AttributeValues) => void;
   onSubmitKeyUp: () => void;
@@ -190,6 +192,7 @@ const UmlAttributeUpdate = ({
   attributeType: propAttributeType,
   isOptional: propIsOptional,
   isDerived: propIsDerived,
+  isId: propIsId,
   defaultValue: propDefaultValue,
   onChange,
   onSubmitKeyUp,
@@ -256,6 +259,7 @@ const UmlAttributeUpdate = ({
 
   const isOptional = propIsOptional || false;
   const isDerived = propIsDerived || false;
+  const isId = propIsId || false;
   const defaultValue = propDefaultValue;
 
   // Get available enumerations from the model
@@ -270,6 +274,7 @@ const UmlAttributeUpdate = ({
       attributeType,
       isOptional,
       isDerived,
+      isId,
       defaultValue,
     });
   };
@@ -282,6 +287,7 @@ const UmlAttributeUpdate = ({
       attributeType,
       isOptional,
       isDerived,
+      isId,
       defaultValue,
     });
   };
@@ -294,6 +300,7 @@ const UmlAttributeUpdate = ({
       attributeType: typeStr,
       isOptional,
       isDerived,
+      isId,
       defaultValue,
     });
   };
@@ -305,6 +312,7 @@ const UmlAttributeUpdate = ({
       attributeType,
       isOptional: checked,
       isDerived,
+      isId,
       defaultValue,
     });
   };
@@ -316,6 +324,20 @@ const UmlAttributeUpdate = ({
       attributeType,
       isOptional,
       isDerived: checked,
+      isId,
+      defaultValue,
+    });
+  };
+
+  const handleIdChange = (checked: boolean) => {
+    onChange(id, {
+      name: attrName,
+      visibility,
+      attributeType,
+      // Metamodel constraint: an attribute cannot be both an id and optional.
+      isOptional: checked ? false : isOptional,
+      isDerived,
+      isId: checked,
       defaultValue,
     });
   };
@@ -327,6 +349,7 @@ const UmlAttributeUpdate = ({
       attributeType,
       isOptional,
       isDerived,
+      isId,
       defaultValue: newDefaultValue || undefined,
     });
   };
@@ -392,6 +415,8 @@ const UmlAttributeUpdate = ({
         onOptionalChange={handleOptionalChange}
         isDerived={isDerived}
         onDerivedChange={handleDerivedChange}
+        isId={isId}
+        onIdChange={handleIdChange}
         defaultValue={defaultValue}
         onDefaultValueChange={handleDefaultValueChange}
         attributeType={attributeType}

--- a/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-attribute-update.tsx
+++ b/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-attribute-update.tsx
@@ -126,6 +126,7 @@ type AttributeValues = {
   isOptional?: boolean;
   isDerived?: boolean;
   isId?: boolean;
+  isExternalId?: boolean;
   defaultValue?: any;
   fillColor?: string;
   textColor?: string;
@@ -141,6 +142,7 @@ type Props = {
   isOptional?: boolean;
   isDerived?: boolean;
   isId?: boolean;
+  isExternalId?: boolean;
   defaultValue?: any;
   onChange: (id: string, values: AttributeValues) => void;
   onSubmitKeyUp: () => void;
@@ -193,6 +195,7 @@ const UmlAttributeUpdate = ({
   isOptional: propIsOptional,
   isDerived: propIsDerived,
   isId: propIsId,
+  isExternalId: propIsExternalId,
   defaultValue: propDefaultValue,
   onChange,
   onSubmitKeyUp,
@@ -260,6 +263,7 @@ const UmlAttributeUpdate = ({
   const isOptional = propIsOptional || false;
   const isDerived = propIsDerived || false;
   const isId = propIsId || false;
+  const isExternalId = propIsExternalId || false;
   const defaultValue = propDefaultValue;
 
   // Get available enumerations from the model
@@ -275,6 +279,7 @@ const UmlAttributeUpdate = ({
       isOptional,
       isDerived,
       isId,
+      isExternalId,
       defaultValue,
     });
   };
@@ -288,6 +293,7 @@ const UmlAttributeUpdate = ({
       isOptional,
       isDerived,
       isId,
+      isExternalId,
       defaultValue,
     });
   };
@@ -301,6 +307,7 @@ const UmlAttributeUpdate = ({
       isOptional,
       isDerived,
       isId,
+      isExternalId,
       defaultValue,
     });
   };
@@ -313,6 +320,7 @@ const UmlAttributeUpdate = ({
       isOptional: checked,
       isDerived,
       isId,
+      isExternalId,
       defaultValue,
     });
   };
@@ -325,6 +333,7 @@ const UmlAttributeUpdate = ({
       isOptional,
       isDerived: checked,
       isId,
+      isExternalId,
       defaultValue,
     });
   };
@@ -338,6 +347,21 @@ const UmlAttributeUpdate = ({
       isOptional: checked ? false : isOptional,
       isDerived,
       isId: checked,
+      isExternalId,
+      defaultValue,
+    });
+  };
+
+  const handleExternalIdChange = (checked: boolean) => {
+    onChange(id, {
+      name: attrName,
+      visibility,
+      attributeType,
+      // Metamodel constraint: an attribute cannot be both an external identifier and optional.
+      isOptional: checked ? false : isOptional,
+      isDerived,
+      isId,
+      isExternalId: checked,
       defaultValue,
     });
   };
@@ -350,6 +374,7 @@ const UmlAttributeUpdate = ({
       isOptional,
       isDerived,
       isId,
+      isExternalId,
       defaultValue: newDefaultValue || undefined,
     });
   };
@@ -417,6 +442,8 @@ const UmlAttributeUpdate = ({
         onDerivedChange={handleDerivedChange}
         isId={isId}
         onIdChange={handleIdChange}
+        isExternalId={isExternalId}
+        onExternalIdChange={handleExternalIdChange}
         defaultValue={defaultValue}
         onDefaultValueChange={handleDefaultValueChange}
         attributeType={attributeType}

--- a/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-member.ts
+++ b/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-member.ts
@@ -71,6 +71,7 @@ export interface IUMLClassifierMember extends IUMLElement {
   isOptional?: boolean;
   isDerived?: boolean;
   isId?: boolean;
+  isExternalId?: boolean;
   defaultValue?: any;
 }
 
@@ -96,6 +97,7 @@ export abstract class UMLClassifierMember extends UMLElement implements IUMLClas
   isOptional: boolean = false;
   isDerived: boolean = false;
   isId: boolean = false;
+  isExternalId: boolean = false;
   defaultValue: any = undefined;
 
   constructor(values?: DeepPartial<IUMLClassifierMember>) {
@@ -115,7 +117,11 @@ export abstract class UMLClassifierMember extends UMLElement implements IUMLClas
       }
       const derivedPrefix = this.isDerived ? '/' : '';
       const optionalMarker = this.isOptional ? '?' : '';
-      const idSuffix = this.isId ? ' {id}' : '';
+      const idMarkers = [
+        this.isId ? 'id' : null,
+        this.isExternalId ? 'external id' : null,
+      ].filter(Boolean);
+      const idSuffix = idMarkers.length > 0 ? ` {${idMarkers.join(', ')}}` : '';
       const defaultSuffix = (this.defaultValue !== undefined && this.defaultValue !== null && this.defaultValue !== '')
         ? ` = ${this.defaultValue}`
         : '';
@@ -189,6 +195,7 @@ export abstract class UMLClassifierMember extends UMLElement implements IUMLClas
       isOptional: this.isOptional,
       isDerived: this.isDerived,
       isId: this.isId,
+      isExternalId: this.isExternalId,
       defaultValue: this.defaultValue,
     } as Apollon.UMLModelElement & Apollon.UMLClassifierMember;
   }
@@ -207,6 +214,7 @@ export abstract class UMLClassifierMember extends UMLElement implements IUMLClas
       this.isOptional = memberValues.isOptional || false;
       this.isDerived = memberValues.isDerived || false;
       this.isId = memberValues.isId || false;
+      this.isExternalId = memberValues.isExternalId || false;
     } else {
       // Legacy format - parse from name to extract visibility and type
       const parsed = UMLClassifierMember.parseNameFormat(this.name);
@@ -215,6 +223,7 @@ export abstract class UMLClassifierMember extends UMLElement implements IUMLClas
       this.isOptional = false;
       this.isDerived = false;
       this.isId = false;
+      this.isExternalId = false;
       // Update name to just the attribute name (without visibility symbol and type)
       this.name = parsed.name;
     }

--- a/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-member.ts
+++ b/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-member.ts
@@ -70,6 +70,7 @@ export interface IUMLClassifierMember extends IUMLElement {
   quantumCircuitId?: string;
   isOptional?: boolean;
   isDerived?: boolean;
+  isId?: boolean;
   defaultValue?: any;
 }
 
@@ -94,6 +95,7 @@ export abstract class UMLClassifierMember extends UMLElement implements IUMLClas
   quantumCircuitId: string = '';
   isOptional: boolean = false;
   isDerived: boolean = false;
+  isId: boolean = false;
   defaultValue: any = undefined;
 
   constructor(values?: DeepPartial<IUMLClassifierMember>) {
@@ -113,10 +115,11 @@ export abstract class UMLClassifierMember extends UMLElement implements IUMLClas
       }
       const derivedPrefix = this.isDerived ? '/' : '';
       const optionalMarker = this.isOptional ? '?' : '';
+      const idSuffix = this.isId ? ' {id}' : '';
       const defaultSuffix = (this.defaultValue !== undefined && this.defaultValue !== null && this.defaultValue !== '')
         ? ` = ${this.defaultValue}`
         : '';
-      return `${visSymbol} ${derivedPrefix}${this.name}${optionalMarker}: ${this.attributeType}${defaultSuffix}`;
+      return `${visSymbol} ${derivedPrefix}${this.name}${optionalMarker}: ${this.attributeType}${defaultSuffix}${idSuffix}`;
     }
     // Fallback to name for backward compatibility or simple display
     return this.name;
@@ -185,6 +188,7 @@ export abstract class UMLClassifierMember extends UMLElement implements IUMLClas
       quantumCircuitId: this.quantumCircuitId,
       isOptional: this.isOptional,
       isDerived: this.isDerived,
+      isId: this.isId,
       defaultValue: this.defaultValue,
     } as Apollon.UMLModelElement & Apollon.UMLClassifierMember;
   }
@@ -202,6 +206,7 @@ export abstract class UMLClassifierMember extends UMLElement implements IUMLClas
       this.attributeType = memberValues.attributeType || 'str';
       this.isOptional = memberValues.isOptional || false;
       this.isDerived = memberValues.isDerived || false;
+      this.isId = memberValues.isId || false;
     } else {
       // Legacy format - parse from name to extract visibility and type
       const parsed = UMLClassifierMember.parseNameFormat(this.name);
@@ -209,6 +214,7 @@ export abstract class UMLClassifierMember extends UMLElement implements IUMLClas
       this.attributeType = parsed.attributeType;
       this.isOptional = false;
       this.isDerived = false;
+      this.isId = false;
       // Update name to just the attribute name (without visibility symbol and type)
       this.name = parsed.name;
     }

--- a/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-update.tsx
+++ b/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-update.tsx
@@ -280,6 +280,7 @@ class ClassifierUpdate extends Component<Props, State> {
                     attributeType={attrMember.attributeType}
                     isOptional={attrMember.isOptional}
                     isDerived={attrMember.isDerived}
+                    isId={attrMember.isId}
                     defaultValue={attrMember.defaultValue}
                     onChange={this.props.update}
                     onSubmitKeyUp={() =>

--- a/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-update.tsx
+++ b/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-update.tsx
@@ -281,6 +281,7 @@ class ClassifierUpdate extends Component<Props, State> {
                     isOptional={attrMember.isOptional}
                     isDerived={attrMember.isDerived}
                     isId={attrMember.isId}
+                    isExternalId={attrMember.isExternalId}
                     defaultValue={attrMember.defaultValue}
                     onChange={this.props.update}
                     onSubmitKeyUp={() =>

--- a/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-update.tsx
+++ b/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-update.tsx
@@ -5,6 +5,8 @@ import styled from 'styled-components';
 import { Button } from '../../../components/controls/button/button';
 import { ColorButton } from '../../../components/controls/color-button/color-button';
 import { Divider } from '../../../components/controls/divider/divider';
+import { ArrowDownIcon } from '../../../components/controls/icon/arrow-down';
+import { ArrowUpIcon } from '../../../components/controls/icon/arrow-up';
 import { TrashIcon } from '../../../components/controls/icon/trash';
 import { Switch } from '../../../components/controls/switch/switch';
 import { Textfield } from '../../../components/controls/textfield/textfield';
@@ -57,6 +59,40 @@ const SectionHeader = styled(Header)`
   letter-spacing: 0.5px;
   opacity: 0.6;
   margin-bottom: 4px;
+`;
+
+const ReorderRow = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 2px;
+`;
+
+const ReorderControls = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+  padding-top: 6px;
+`;
+
+const ReorderButton = styled(Button)`
+  padding: 0 2px;
+  line-height: 1;
+  min-height: 12px;
+  font-size: 10px;
+  opacity: 0.55;
+  &:hover:not(:disabled) {
+    opacity: 1;
+  }
+  &:disabled {
+    opacity: 0.15;
+    cursor: default;
+  }
+`;
+
+const ReorderChild = styled.div`
+  flex: 1;
+  min-width: 0;
 `;
 
 interface OwnProps {
@@ -112,6 +148,35 @@ class ClassifierUpdate extends Component<Props, State> {
 
   private onFieldChange = (id: string, values: { description?: string; uri?: string }) => {
     this.props.update(id, values);
+  };
+
+  private moveMember = (memberId: string, direction: -1 | 1) => () => {
+    const { element, elements, update } = this.props;
+    const live = elements[element.id] as UMLClassifier | undefined;
+    const ownedElements = live?.ownedElements ?? element.ownedElements;
+
+    const isAttribute = (id: string) => elements[id]?.type === ClassElementType.ClassAttribute;
+    const isMethod = (id: string) => elements[id]?.type === ClassElementType.ClassMethod;
+    const sameKind = isAttribute(memberId) ? isAttribute : isMethod(memberId) ? isMethod : null;
+    if (!sameKind) return;
+
+    const siblings = ownedElements.filter(sameKind);
+    const index = siblings.indexOf(memberId);
+    const target = index + direction;
+    if (index < 0 || target < 0 || target >= siblings.length) return;
+
+    const reordered = [...siblings];
+    [reordered[index], reordered[target]] = [reordered[target], reordered[index]];
+
+    const attributes = ownedElements.filter(isAttribute);
+    const methods = ownedElements.filter(isMethod);
+    const others = ownedElements.filter((id) => !isAttribute(id) && !isMethod(id));
+    const newAttributes = isAttribute(memberId) ? reordered : attributes;
+    const newMethods = isMethod(memberId) ? reordered : methods;
+
+    update<UMLClassifier>(element.id, {
+      ownedElements: [...newAttributes, ...newMethods, ...others],
+    } as Partial<UMLClassifier>);
   };
 
   componentDidUpdate(prevProps: Readonly<Props>, prevState: Readonly<{}>, snapshot?: any) {
@@ -183,31 +248,56 @@ class ClassifierUpdate extends Component<Props, State> {
           </SectionHeader>
           {attributes.map((attribute, index) => {
             const attrMember = attribute as UMLClassifierMember;
+            const canMoveUp = index > 0;
+            const canMoveDown = index < attributes.length - 1;
             return (
-              <UmlAttributeUpdate
-                id={attribute.id}
-                key={attribute.id}
-                value={attribute.name}
-                visibility={attrMember.visibility}
-                attributeType={attrMember.attributeType}
-                isOptional={attrMember.isOptional}
-                isDerived={attrMember.isDerived}
-                defaultValue={attrMember.defaultValue}
-                onChange={this.props.update}
-                onSubmitKeyUp={() =>
-                  index === attributes.length - 1
-                    ? this.newAttributeField.current?.focus()
-                    : this.setState({
-                        fieldToFocus: attributeRefs[index + 1],
-                      })
-                }
-                onDelete={this.delete}
-                onRefChange={(ref) => (attributeRefs[index] = ref)}
-                element={attribute}
-                isEnumeration={isEnumeration}
-                availableEnumerations={availableEnumerations}
-                elements={elements}
-              />
+              <ReorderRow key={attribute.id}>
+                <ReorderControls>
+                  <ReorderButton
+                    color="link"
+                    tabIndex={-1}
+                    disabled={!canMoveUp}
+                    onClick={canMoveUp ? this.moveMember(attribute.id, -1) : undefined}
+                    title="Move up"
+                  >
+                    <ArrowUpIcon width={10} height={10} />
+                  </ReorderButton>
+                  <ReorderButton
+                    color="link"
+                    tabIndex={-1}
+                    disabled={!canMoveDown}
+                    onClick={canMoveDown ? this.moveMember(attribute.id, 1) : undefined}
+                    title="Move down"
+                  >
+                    <ArrowDownIcon />
+                  </ReorderButton>
+                </ReorderControls>
+                <ReorderChild>
+                  <UmlAttributeUpdate
+                    id={attribute.id}
+                    value={attribute.name}
+                    visibility={attrMember.visibility}
+                    attributeType={attrMember.attributeType}
+                    isOptional={attrMember.isOptional}
+                    isDerived={attrMember.isDerived}
+                    defaultValue={attrMember.defaultValue}
+                    onChange={this.props.update}
+                    onSubmitKeyUp={() =>
+                      index === attributes.length - 1
+                        ? this.newAttributeField.current?.focus()
+                        : this.setState({
+                            fieldToFocus: attributeRefs[index + 1],
+                          })
+                    }
+                    onDelete={this.delete}
+                    onRefChange={(ref) => (attributeRefs[index] = ref)}
+                    element={attribute}
+                    isEnumeration={isEnumeration}
+                    availableEnumerations={availableEnumerations}
+                    elements={elements}
+                  />
+                </ReorderChild>
+              </ReorderRow>
             );
           })}
           <Textfield
@@ -256,29 +346,54 @@ class ClassifierUpdate extends Component<Props, State> {
               <SectionHeader>{this.props.translate('popup.methods')}</SectionHeader>
             {methods.map((method, index) => {
               const methodMember = method as UMLClassifierMember;
+              const canMoveUp = index > 0;
+              const canMoveDown = index < methods.length - 1;
               return (
-                <UmlMethodUpdate
-                  id={method.id}
-                  key={method.id}
-                  value={methodMember.displayName}
-                  code={methodMember.code || ''}
-                  implementationType={methodMember.implementationType || 'none'}
-                  stateMachineId={methodMember.stateMachineId || ''}
-                  quantumCircuitId={methodMember.quantumCircuitId || ''}
-                  availableStateMachines={diagramBridge.getStateMachineDiagrams()}
-                  availableQuantumCircuits={diagramBridge.getQuantumCircuitDiagrams()}
-                  onChange={this.props.update}
-                  onSubmitKeyUp={() =>
-                    index === methods.length - 1
-                      ? this.newMethodField.current?.focus()
-                      : this.setState({
-                          fieldToFocus: methodRefs[index + 1],
-                        })
-                  }
-                  onDelete={this.delete}
-                  onRefChange={(ref) => (methodRefs[index] = ref)}
-                  element={method}
-                />
+                <ReorderRow key={method.id}>
+                  <ReorderControls>
+                    <ReorderButton
+                      color="link"
+                      tabIndex={-1}
+                      disabled={!canMoveUp}
+                      onClick={canMoveUp ? this.moveMember(method.id, -1) : undefined}
+                      title="Move up"
+                    >
+                      <ArrowUpIcon />
+                    </ReorderButton>
+                    <ReorderButton
+                      color="link"
+                      tabIndex={-1}
+                      disabled={!canMoveDown}
+                      onClick={canMoveDown ? this.moveMember(method.id, 1) : undefined}
+                      title="Move down"
+                    >
+                      <ArrowDownIcon />
+                    </ReorderButton>
+                  </ReorderControls>
+                  <ReorderChild>
+                    <UmlMethodUpdate
+                      id={method.id}
+                      value={methodMember.displayName}
+                      code={methodMember.code || ''}
+                      implementationType={methodMember.implementationType || 'none'}
+                      stateMachineId={methodMember.stateMachineId || ''}
+                      quantumCircuitId={methodMember.quantumCircuitId || ''}
+                      availableStateMachines={diagramBridge.getStateMachineDiagrams()}
+                      availableQuantumCircuits={diagramBridge.getQuantumCircuitDiagrams()}
+                      onChange={this.props.update}
+                      onSubmitKeyUp={() =>
+                        index === methods.length - 1
+                          ? this.newMethodField.current?.focus()
+                          : this.setState({
+                              fieldToFocus: methodRefs[index + 1],
+                            })
+                      }
+                      onDelete={this.delete}
+                      onRefChange={(ref) => (methodRefs[index] = ref)}
+                      element={method}
+                    />
+                  </ReorderChild>
+                </ReorderRow>
               );
             })}
             <InputRow>

--- a/packages/editor/src/main/typings.ts
+++ b/packages/editor/src/main/typings.ts
@@ -122,6 +122,7 @@ export type UMLClassifierMember = UMLElement & {
   quantumCircuitId?: string;
   isOptional?: boolean;
   isDerived?: boolean;
+  isId?: boolean;
   defaultValue?: any;
 };
 

--- a/packages/editor/src/main/typings.ts
+++ b/packages/editor/src/main/typings.ts
@@ -123,6 +123,7 @@ export type UMLClassifierMember = UMLElement & {
   isOptional?: boolean;
   isDerived?: boolean;
   isId?: boolean;
+  isExternalId?: boolean;
   defaultValue?: any;
 };
 


### PR DESCRIPTION
Bundles the editor-side work that shipped alongside backend v7.1.6.

## Changes

- **`795311f` — is_id toggle**: new **ID** checkbox in the attribute style pane, trailing `{id}` marker in the attribute display name. Threaded through `typings.ts`, `uml-classifier-member.ts` (serialize/deserialize), `uml-classifier-attribute-update.tsx` and `uml-classifier-update.tsx`. Related to BESSER#478.
- **`b5102c0` — is_external_id toggle**: symmetric **External ID** checkbox, `{external id}` marker (or `{id, external id}` when both). Marks user-facing identifiers distinct from the internal PK. Related to BESSER#230, BESSER#225, BESSER#108.
- **`a1839b8` — UX lock**: Optional is disabled (with tooltip) when ID/External ID is on, and vice versa — the metamodel rejects `is_optional + is_id` / `is_optional + is_external_id`, so the UI now prevents the invalid state from being reachable instead of letting it fail server-side.

## Backend contract

All three checkboxes serialize to `isId` / `isExternalId` / `isOptional` in the diagram JSON, which the backend already round-trips in `class_diagram_processor.py` / `class_diagram_converter.py` (shipped in v7.1.6).

## Test plan

- [ ] Create a class, add an attribute, tick **ID** → display name shows `+ name: str {id}`, Optional is greyed out with tooltip
- [ ] Tick **External ID** → display name shows `+ name: str {external id}` (or `{id, external id}` when both on)
- [ ] Mark an attribute Optional → both ID checkboxes disable with tooltip
- [ ] Save / reload the diagram → flags persist (already verified via backend round-trip tests)