### PR TITLE
release: v7.2.0 — ER notation support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,18 @@ All prefixed with `besser_`:
 - `besser_userThemePreference` - dark/light mode
 - `besser_agentConfigs` / `besser_agentProfileMappings` - agent state
 - `besser_userProfiles` - user profiles
+- `besser-standalone-settings` - application display settings (managed by `settingsService`), including `classNotation: 'UML' | 'ER'` which selects the class-diagram rendering flavor (pure rendering — no metamodel change)
+
+### Global Display Settings (settingsService)
+`packages/editor/src/main/services/settings/settings-service.ts` holds display preferences in localStorage under `besser-standalone-settings`. Rendering components read these **synchronously at render time** (e.g. `settingsService.shouldShowAssociationNames()`), they don't subscribe. For a toggle to actually repaint the canvas live, extend the existing `settingsService.onSettingsChange` listener in `packages/editor/src/main/scenes/application.tsx` and mirror the new field into component state — the `setState` call is what forces the subtree to re-render. Rendering components keep reading from `settingsService` directly (no props drilling needed). Don't bump `editorRevision` for view-only toggles — that clears undo history.
+
+### Custom SVG Rendering
+The editor uses custom SVG elements, **not** React-Flow or Apollon Canvas. Theme-aware wrappers live in `packages/editor/src/main/components/theme/themedComponents` (`ThemedRect`, `ThemedPath`, `ThemedPolyline`) — they pull fill/stroke from styled-components theme. Raw SVG primitives (`<polygon>`, `<rect>`, `<ellipse>`) **bypass the theme**, so always provide a fallback when using them with an optional `element.strokeColor`/`element.fillColor`:
+```tsx
+stroke={element.strokeColor || 'currentColor'}
+fill={element.fillColor || 'white'}
+```
+The `Text` component at `packages/editor/src/main/components/controls/text/text.tsx` forwards unknown props to the underlying `<text>`, so SVG presentation attributes like `textDecoration="underline"` work directly.
 
 ## Adding a New Diagram Element
 
@@ -212,9 +224,15 @@ When you see `M besser/utilities/web_modeling_editor/frontend` in the parent rep
 ## Testing Approach
 
 - **Unit tests**: Vitest with jsdom. Config in `vitest.config.ts`, setup in `src/test/setup.ts`
-- **E2E tests**: Playwright. Run with `npm run test:e2e`
+- **E2E tests**: Playwright. Run from `packages/webapp2` (not the monorepo root) with `npm run test:e2e`
 - **Linting**: ESLint (permissive — `any` and `ts-ignore` are warnings, not errors)
 - **Formatting**: Prettier (check with `npm run prettier:check`)
+
+Known environment quirks (verified April 2026):
+- On Node >= 25, Playwright 1.58 fails every spec with "test.describe() not expected here" — it's a harness-loading regression, not a test bug. Use Node 20/22 LTS locally, or rely on CI. All existing specs fail identically with my env so don't chase green locally if you see it.
+- `src/main/shared/services/storage/__tests__/ProjectStorageRepository.test.ts` currently fails every assertion with `localStorage.clear is not a function` — pre-existing jsdom setup bug in this repo, unrelated to individual changes. Confirm with `git stash` before assuming your edits broke it.
+
+E2E-testing gotcha: only the **GUI** editor exposes itself via `(window as any).editor`. The UML/class diagram editor instance is NOT on `window`, so Playwright can't drive the class diagram model through a JS handle — use UI interactions, or (for setup) write a project JSON directly to `localStorage['besser_project_<uuid>']` and reload. The project shape is `{id, name, diagrams: {ClassDiagram: [{model: {elements, relationships, ...}}], ...}, currentDiagramType, currentDiagramIndices, ...}`. Inside `elements`, ClassAttribute entries need both the legacy `name: "+ foo: str"` AND the new-format fields (`visibility`, `attributeType`, `isId`, `isOptional`, `isDerived`, `isExternalId`, `defaultValue`) — deserialize takes the legacy-parse branch and *resets* these booleans to false when the new-format fields are missing, so pre-injecting `isId: true` alone won't stick unless visibility+attributeType are also present.
 
 ## Important Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,12 +228,6 @@ When you see `M besser/utilities/web_modeling_editor/frontend` in the parent rep
 - **Linting**: ESLint (permissive — `any` and `ts-ignore` are warnings, not errors)
 - **Formatting**: Prettier (check with `npm run prettier:check`)
 
-Known environment quirks (verified April 2026):
-- On Node >= 25, Playwright 1.58 fails every spec with "test.describe() not expected here" — it's a harness-loading regression, not a test bug. Use Node 20/22 LTS locally, or rely on CI. All existing specs fail identically with my env so don't chase green locally if you see it.
-- `src/main/shared/services/storage/__tests__/ProjectStorageRepository.test.ts` currently fails every assertion with `localStorage.clear is not a function` — pre-existing jsdom setup bug in this repo, unrelated to individual changes. Confirm with `git stash` before assuming your edits broke it.
-
-E2E-testing gotcha: only the **GUI** editor exposes itself via `(window as any).editor`. The UML/class diagram editor instance is NOT on `window`, so Playwright can't drive the class diagram model through a JS handle — use UI interactions, or (for setup) write a project JSON directly to `localStorage['besser_project_<uuid>']` and reload. The project shape is `{id, name, diagrams: {ClassDiagram: [{model: {elements, relationships, ...}}], ...}, currentDiagramType, currentDiagramIndices, ...}`. Inside `elements`, ClassAttribute entries need both the legacy `name: "+ foo: str"` AND the new-format fields (`visibility`, `attributeType`, `isId`, `isOptional`, `isDerived`, `isExternalId`, `defaultValue`) — deserialize takes the legacy-parse branch and *resets* these booleans to false when the new-format fields are missing, so pre-injecting `isId: true` alone won't stick unless visibility+attributeType are also present.
-
 ## Important Conventions
 
 ### Code Style

--- a/package-lock.json
+++ b/package-lock.json
@@ -5861,6 +5861,38 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-roving-focus": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
@@ -29342,6 +29374,7 @@
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-label": "^2.1.7",
+        "@radix-ui/react-radio-group": "^1.3.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.4",

--- a/packages/editor/src/main/components/theme/themedComponents.ts
+++ b/packages/editor/src/main/components/theme/themedComponents.ts
@@ -99,6 +99,18 @@ export const ThemedEllipse = styled.ellipse.withConfig({
   stroke: ${(props) => props.strokeColor || props.theme.color.primaryContrast};
 `;
 
+export const ThemedPolygon = styled.polygon.withConfig({
+  shouldForwardProp: shouldForwardThemedProp as any,
+}).attrs(
+  (props: { fillColor: string | undefined; strokeColor: string | undefined }) => ({
+    stroke: props.strokeColor || 'black',
+    fill: props.fillColor || 'white',
+  }),
+)`
+  fill: ${(props) => props.fillColor || props.theme.color.background};
+  stroke: ${(props) => props.strokeColor || props.theme.color.primaryContrast};
+`;
+
 export const ThemedLine = styled.line.withConfig({
   shouldForwardProp: (prop: string) => prop !== 'strokeColor',
 } as any).attrs((props: { strokeColor: string | undefined }) => ({

--- a/packages/editor/src/main/index.ts
+++ b/packages/editor/src/main/index.ts
@@ -31,6 +31,11 @@ export * from './services/diagram-bridge';
 // Provides configuration management for standalone applications
 export * from './services/settings/settings-service';
 
+// Export the multiplicity helpers used by the ER-notation rendering
+// (parseMultiplicity / toERCardinality). Pure functions, safe to import
+// from tests and from consumer webapps.
+export * from './packages/common/uml-association/multiplicity';
+
 // Export only the Patch type (not the implementation) for type safety
 // Used when working with patching operations in TypeScript
 export type { Patch } from './services/patcher';

--- a/packages/editor/src/main/packages/common/uml-association/multiplicity.ts
+++ b/packages/editor/src/main/packages/common/uml-association/multiplicity.ts
@@ -1,0 +1,35 @@
+/**
+ * Parse a UML multiplicity string into an explicit {min, max} pair.
+ * Accepts the range form ("1..1", "0..*", "2..5") and the UML shorthands:
+ * "1" == "1..1", "*" == "0..*". The "*" token is preserved in `max`; the
+ * caller maps it to the target notation (UML `*` or ER `N`). Returns `null`
+ * for unparseable input so the caller can fall back to the original text.
+ */
+export const parseMultiplicity = (value: string): { min: string; max: string } | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.includes('..')) {
+    const parts = trimmed.split('..');
+    if (parts.length !== 2) return null;
+    const min = parts[0].trim();
+    const max = parts[1].trim();
+    if (!min || !max) return null;
+    return { min, max };
+  }
+  if (trimmed === '*') return { min: '0', max: '*' };
+  return { min: trimmed, max: trimmed };
+};
+
+/**
+ * Transform a UML multiplicity into an ER/Chen-style "(min,max)" cardinality.
+ * Both UML range form and shorthands map to the same ER pair, so that "1"
+ * and "1..1" both become "(1,1)", and "*" and "0..*" both become "(0,N)".
+ * Unparseable input is returned unchanged to preserve user intent.
+ */
+export const toERCardinality = (multiplicity: string | undefined): string => {
+  if (!multiplicity) return '';
+  const parsed = parseMultiplicity(multiplicity);
+  if (!parsed) return multiplicity;
+  const max = parsed.max === '*' ? 'N' : parsed.max;
+  return `(${parsed.min},${max})`;
+};

--- a/packages/editor/src/main/packages/common/uml-association/multiplicity.ts
+++ b/packages/editor/src/main/packages/common/uml-association/multiplicity.ts
@@ -33,3 +33,27 @@ export const toERCardinality = (multiplicity: string | undefined): string => {
   const max = parsed.max === '*' ? 'N' : parsed.max;
   return `(${parsed.min},${max})`;
 };
+
+/**
+ * Inverse of toERCardinality: normalize an ER-style "(min,max)" input to
+ * the UML storage form. "(0,N)" -> "0..*", "(1,1)" -> "1..1", "(2,5)" ->
+ * "2..5". "N"/"n" in the max position map to "*". Input that is not wrapped
+ * in parentheses is assumed to already be UML form and returned unchanged —
+ * the function is safe to call on every multiplicity value regardless of
+ * which syntax the user typed.
+ */
+export const erCardinalityToUML = (value: string | undefined): string => {
+  if (!value) return '';
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('(') || !trimmed.endsWith(')')) {
+    return value;
+  }
+  const inner = trimmed.slice(1, -1);
+  const parts = inner.split(',');
+  if (parts.length !== 2) return value;
+  const min = parts[0].trim();
+  const rawMax = parts[1].trim();
+  if (!min || !rawMax) return value;
+  const max = /^n$/i.test(rawMax) ? '*' : rawMax;
+  return `${min}..${max}`;
+};

--- a/packages/editor/src/main/packages/common/uml-association/uml-association-component.tsx
+++ b/packages/editor/src/main/packages/common/uml-association/uml-association-component.tsx
@@ -4,7 +4,7 @@ import { Point } from '../../../utils/geometry/point';
 import { ClassRelationshipType } from '../../uml-class-diagram';
 import { UMLAssociation } from './uml-association';
 import { GeneralRelationshipType, UMLRelationshipType } from '../../uml-relationship-type';
-import { ThemedPath, ThemedPathContrast, ThemedPolyline } from '../../../components/theme/themedComponents';
+import { ThemedPath, ThemedPathContrast, ThemedPolygon, ThemedPolyline } from '../../../components/theme/themedComponents';
 import { settingsService } from '../../../services/settings/settings-service';
 
 const Marker = {
@@ -249,10 +249,10 @@ export const UMLAssociationComponent: FunctionComponent<Props> = ({ element }) =
           pointerEvents="none"
           data-testid="er-relationship-diamond"
         >
-          <polygon
+          <ThemedPolygon
             points="-30,0 0,-15 30,0 0,15"
-            fill={element.fillColor || 'white'}
-            stroke={element.strokeColor || 'currentColor'}
+            fillColor={element.fillColor}
+            strokeColor={element.strokeColor}
             strokeWidth={1}
           />
           {element.name && (

--- a/packages/editor/src/main/packages/common/uml-association/uml-association-component.tsx
+++ b/packages/editor/src/main/packages/common/uml-association/uml-association-component.tsx
@@ -188,18 +188,20 @@ export const UMLAssociationComponent: FunctionComponent<Props> = ({ element }) =
   const isER = notation === 'ER';
 
   // In ER (Chen) mode, replace the UML arrow/rhombus end markers with a named
-  // diamond drawn at the midpoint. Inheritance/realization keep their UML
-  // syntax (explicit requirement of the issue); OCL and link relationships
-  // keep their existing rendering because they have no ER equivalent.
-  const isERClassBinary =
-    isER &&
-    !isInheritance &&
-    !isLinkRel &&
-    element.type !== ClassRelationshipType.ClassRealization &&
-    element.type !== ClassRelationshipType.ClassOCLLink &&
-    element.type !== ClassRelationshipType.ClassDependency;
+  // diamond drawn at the midpoint — but only for the four "plain" binary
+  // associations that have an ER counterpart. Inheritance, realization, OCL,
+  // dependency, and link relationships keep their UML rendering. Using an
+  // explicit allow-list here (instead of excluding types) means new
+  // relationship types won't silently inherit the ER diamond.
+  const ER_DIAMOND_RELATIONSHIP_TYPES: ReadonlyArray<string> = [
+    ClassRelationshipType.ClassBidirectional,
+    ClassRelationshipType.ClassUnidirectional,
+    ClassRelationshipType.ClassAggregation,
+    ClassRelationshipType.ClassComposition,
+  ];
+  const showsERDiamond = isER && ER_DIAMOND_RELATIONSHIP_TYPES.includes(element.type);
 
-  const marker = isERClassBinary ? undefined : getMarkerForTypeForUMLAssociation(element.type);
+  const marker = showsERDiamond ? undefined : getMarkerForTypeForUMLAssociation(element.type);
 
   const stroke = ((type) => {
     switch (type) {
@@ -231,7 +233,7 @@ export const UMLAssociationComponent: FunctionComponent<Props> = ({ element }) =
         markerEnd={`url(#${id})`}
         strokeDasharray={stroke}
       />
-      {showAssociationNames && element.name && !isInheritance && !isLinkRel && !isERClassBinary && (
+      {showAssociationNames && element.name && !isInheritance && !isLinkRel && !showsERDiamond && (
         <text
           x={middle.x || 0}
           y={middle.y || 0}
@@ -243,7 +245,7 @@ export const UMLAssociationComponent: FunctionComponent<Props> = ({ element }) =
           {element.name}
         </text>
       )}
-      {isERClassBinary && (
+      {showsERDiamond && (
         <g
           transform={`translate(${middle.x || 0} ${middle.y || 0})`}
           pointerEvents="none"

--- a/packages/editor/src/main/packages/common/uml-association/uml-association-component.tsx
+++ b/packages/editor/src/main/packages/common/uml-association/uml-association-component.tsx
@@ -107,6 +107,58 @@ export const computeTextPositionForUMLAssociation = (alignmentPath: Point[], has
   return alignmentPath[0].add(vector.normalize().scale(distance));
 };
 
+/**
+ * Normalize a UML multiplicity string into an explicit {min, max} pair,
+ * accepting both the range form ("1..1", "0..*", "2..5") and the UML
+ * shorthands ("1" == "1..1", "*" == "0..*"). `*` is kept as-is in max; the
+ * caller maps it to the target notation (UML `*` or ER `N`). Returns `null`
+ * for unparseable input so the caller can fall back to the original text.
+ */
+const parseMultiplicity = (value: string): { min: string; max: string } | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.includes('..')) {
+    const parts = trimmed.split('..');
+    if (parts.length !== 2) return null;
+    const min = parts[0].trim();
+    const max = parts[1].trim();
+    if (!min || !max) return null;
+    return { min, max };
+  }
+  // Shorthands: "*" means "0..*", a standalone number "n" means "n..n".
+  if (trimmed === '*') return { min: '0', max: '*' };
+  return { min: trimmed, max: trimmed };
+};
+
+/**
+ * Transform a UML multiplicity into an ER/Chen-style "(min,max)" cardinality.
+ * Both UML range form and shorthands map to the same ER pair, so that
+ * "1" and "1..1" both become "(1,1)", and "*" and "0..*" both become "(0,N)".
+ * Unparseable input is returned unchanged to preserve user intent.
+ */
+export const toERCardinality = (multiplicity: string | undefined): string => {
+  if (!multiplicity) return '';
+  const parsed = parseMultiplicity(multiplicity);
+  if (!parsed) return multiplicity;
+  const max = parsed.max === '*' ? 'N' : parsed.max;
+  return `(${parsed.min},${max})`;
+};
+
+/**
+ * Canonicalize a UML multiplicity for display in UML mode. Collapses the
+ * explicit forms to their shorthand equivalents so toggling ER ↔ UML is
+ * symmetric with the ER mapping: "1..1" -> "1", "0..*" -> "*", "5..5" -> "5".
+ * Mixed-bound ranges like "0..1" or "1..*" are left intact.
+ */
+export const toUMLMultiplicity = (multiplicity: string | undefined): string => {
+  if (!multiplicity) return '';
+  const parsed = parseMultiplicity(multiplicity);
+  if (!parsed) return multiplicity;
+  if (parsed.min === '0' && parsed.max === '*') return '*';
+  if (parsed.min === parsed.max) return parsed.min;
+  return `${parsed.min}..${parsed.max}`;
+};
+
 export const computeMiddlePositionForUMLAssociation = (alignmentPath: Point[]): Point => {
   if (alignmentPath.length < 2) return new Point();
   const midIndex = Math.floor(alignmentPath.length / 2);
@@ -138,11 +190,26 @@ export const getMarkerForTypeForUMLAssociation = (relationshipType: UMLRelations
 };
 
 export const UMLAssociationComponent: FunctionComponent<Props> = ({ element }) => {
-  const marker = getMarkerForTypeForUMLAssociation(element.type);
   const isInheritance = element.type === ClassRelationshipType.ClassInheritance;
   // Add special check for OCL Link
   const isLinkRel = element.type === ClassRelationshipType.ClassLinkRel;
   const showAssociationNames = settingsService.shouldShowAssociationNames();
+  const notation = settingsService.getClassNotation();
+  const isER = notation === 'ER';
+
+  // In ER (Chen) mode, replace the UML arrow/rhombus end markers with a named
+  // diamond drawn at the midpoint. Inheritance/realization keep their UML
+  // syntax (explicit requirement of the issue); OCL and link relationships
+  // keep their existing rendering because they have no ER equivalent.
+  const isERClassBinary =
+    isER &&
+    !isInheritance &&
+    !isLinkRel &&
+    element.type !== ClassRelationshipType.ClassRealization &&
+    element.type !== ClassRelationshipType.ClassOCLLink &&
+    element.type !== ClassRelationshipType.ClassDependency;
+
+  const marker = isERClassBinary ? undefined : getMarkerForTypeForUMLAssociation(element.type);
 
   const stroke = ((type) => {
     switch (type) {
@@ -174,7 +241,7 @@ export const UMLAssociationComponent: FunctionComponent<Props> = ({ element }) =
         markerEnd={`url(#${id})`}
         strokeDasharray={stroke}
       />
-      {showAssociationNames && element.name && !isInheritance && !isLinkRel && (
+      {showAssociationNames && element.name && !isInheritance && !isLinkRel && !isERClassBinary && (
         <text
           x={middle.x || 0}
           y={middle.y || 0}
@@ -186,6 +253,31 @@ export const UMLAssociationComponent: FunctionComponent<Props> = ({ element }) =
           {element.name}
         </text>
       )}
+      {isERClassBinary && (
+        <g
+          transform={`translate(${middle.x || 0} ${middle.y || 0})`}
+          pointerEvents="none"
+          data-testid="er-relationship-diamond"
+        >
+          <polygon
+            points="-30,0 0,-15 30,0 0,15"
+            fill={element.fillColor || 'white'}
+            stroke={element.strokeColor || 'currentColor'}
+            strokeWidth={1}
+          />
+          {element.name && (
+            <text
+              x={0}
+              y={0}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              style={{ ...textFill, fontSize: '11px' }}
+            >
+              {element.name}
+            </text>
+          )}
+        </g>
+      )}
       {!isInheritance && !isLinkRel && (
         <>
           <text
@@ -195,7 +287,7 @@ export const UMLAssociationComponent: FunctionComponent<Props> = ({ element }) =
             pointerEvents="none"
             style={{ ...textFill }}
           >
-            {element.source.multiplicity}
+            {isER ? toERCardinality(element.source.multiplicity) : toUMLMultiplicity(element.source.multiplicity)}
           </text>
           <text
             x={target.x || 0}
@@ -204,7 +296,7 @@ export const UMLAssociationComponent: FunctionComponent<Props> = ({ element }) =
             pointerEvents="none"
             style={{ ...textFill }}
           >
-            {element.target.multiplicity}
+            {isER ? toERCardinality(element.target.multiplicity) : toUMLMultiplicity(element.target.multiplicity)}
           </text>
           <text
             x={source.x || 0}

--- a/packages/editor/src/main/packages/common/uml-association/uml-association-component.tsx
+++ b/packages/editor/src/main/packages/common/uml-association/uml-association-component.tsx
@@ -6,6 +6,10 @@ import { UMLAssociation } from './uml-association';
 import { GeneralRelationshipType, UMLRelationshipType } from '../../uml-relationship-type';
 import { ThemedPath, ThemedPathContrast, ThemedPolygon, ThemedPolyline } from '../../../components/theme/themedComponents';
 import { settingsService } from '../../../services/settings/settings-service';
+import { parseMultiplicity, toERCardinality } from './multiplicity';
+// Re-export so downstream consumers can keep importing these from the
+// association component module.
+export { parseMultiplicity, toERCardinality };
 
 const Marker = {
   Arrow: (id: string, color?: string) => (
@@ -106,48 +110,6 @@ export const computeTextPositionForUMLAssociation = (alignmentPath: Point[], has
   const vector = alignmentPath[1].subtract(alignmentPath[0]);
   return alignmentPath[0].add(vector.normalize().scale(distance));
 };
-
-/**
- * Normalize a UML multiplicity string into an explicit {min, max} pair,
- * accepting both the range form ("1..1", "0..*", "2..5") and the UML
- * shorthands ("1" == "1..1", "*" == "0..*"). `*` is kept as-is in max; the
- * caller maps it to the target notation (UML `*` or ER `N`). Returns `null`
- * for unparseable input so the caller can fall back to the original text.
- */
-export const parseMultiplicity = (value: string): { min: string; max: string } | null => {
-  const trimmed = value.trim();
-  if (!trimmed) return null;
-  if (trimmed.includes('..')) {
-    const parts = trimmed.split('..');
-    if (parts.length !== 2) return null;
-    const min = parts[0].trim();
-    const max = parts[1].trim();
-    if (!min || !max) return null;
-    return { min, max };
-  }
-  // Shorthands: "*" means "0..*", a standalone number "n" means "n..n".
-  if (trimmed === '*') return { min: '0', max: '*' };
-  return { min: trimmed, max: trimmed };
-};
-
-/**
- * Transform a UML multiplicity into an ER/Chen-style "(min,max)" cardinality.
- * Both UML range form and shorthands map to the same ER pair, so that
- * "1" and "1..1" both become "(1,1)", and "*" and "0..*" both become "(0,N)".
- * Unparseable input is returned unchanged to preserve user intent.
- */
-export const toERCardinality = (multiplicity: string | undefined): string => {
-  if (!multiplicity) return '';
-  const parsed = parseMultiplicity(multiplicity);
-  if (!parsed) return multiplicity;
-  const max = parsed.max === '*' ? 'N' : parsed.max;
-  return `(${parsed.min},${max})`;
-};
-
-// Note: UML mode deliberately renders the user's typed multiplicity string
-// verbatim. Collapsing "1..1" → "1" at display time would silently rewrite
-// every existing class diagram, so normalization only happens for ER mode
-// via toERCardinality above.
 
 export const computeMiddlePositionForUMLAssociation = (alignmentPath: Point[]): Point => {
   if (alignmentPath.length < 2) return new Point();

--- a/packages/editor/src/main/packages/common/uml-association/uml-association-component.tsx
+++ b/packages/editor/src/main/packages/common/uml-association/uml-association-component.tsx
@@ -114,7 +114,7 @@ export const computeTextPositionForUMLAssociation = (alignmentPath: Point[], has
  * caller maps it to the target notation (UML `*` or ER `N`). Returns `null`
  * for unparseable input so the caller can fall back to the original text.
  */
-const parseMultiplicity = (value: string): { min: string; max: string } | null => {
+export const parseMultiplicity = (value: string): { min: string; max: string } | null => {
   const trimmed = value.trim();
   if (!trimmed) return null;
   if (trimmed.includes('..')) {
@@ -144,20 +144,10 @@ export const toERCardinality = (multiplicity: string | undefined): string => {
   return `(${parsed.min},${max})`;
 };
 
-/**
- * Canonicalize a UML multiplicity for display in UML mode. Collapses the
- * explicit forms to their shorthand equivalents so toggling ER ↔ UML is
- * symmetric with the ER mapping: "1..1" -> "1", "0..*" -> "*", "5..5" -> "5".
- * Mixed-bound ranges like "0..1" or "1..*" are left intact.
- */
-export const toUMLMultiplicity = (multiplicity: string | undefined): string => {
-  if (!multiplicity) return '';
-  const parsed = parseMultiplicity(multiplicity);
-  if (!parsed) return multiplicity;
-  if (parsed.min === '0' && parsed.max === '*') return '*';
-  if (parsed.min === parsed.max) return parsed.min;
-  return `${parsed.min}..${parsed.max}`;
-};
+// Note: UML mode deliberately renders the user's typed multiplicity string
+// verbatim. Collapsing "1..1" → "1" at display time would silently rewrite
+// every existing class diagram, so normalization only happens for ER mode
+// via toERCardinality above.
 
 export const computeMiddlePositionForUMLAssociation = (alignmentPath: Point[]): Point => {
   if (alignmentPath.length < 2) return new Point();
@@ -287,7 +277,7 @@ export const UMLAssociationComponent: FunctionComponent<Props> = ({ element }) =
             pointerEvents="none"
             style={{ ...textFill }}
           >
-            {isER ? toERCardinality(element.source.multiplicity) : toUMLMultiplicity(element.source.multiplicity)}
+            {isER ? toERCardinality(element.source.multiplicity) : element.source.multiplicity}
           </text>
           <text
             x={target.x || 0}
@@ -296,7 +286,7 @@ export const UMLAssociationComponent: FunctionComponent<Props> = ({ element }) =
             pointerEvents="none"
             style={{ ...textFill }}
           >
-            {isER ? toERCardinality(element.target.multiplicity) : toUMLMultiplicity(element.target.multiplicity)}
+            {isER ? toERCardinality(element.target.multiplicity) : element.target.multiplicity}
           </text>
           <text
             x={source.x || 0}

--- a/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-component.tsx
+++ b/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-component.tsx
@@ -5,12 +5,13 @@ import { ThemedPath, ThemedRect } from '../../../components/theme/themedComponen
 import { settingsService } from '../../../services/settings/settings-service';
 import { ClassElementType } from '../../uml-class-diagram';
 
-// Classifier types that represent class-diagram entities and can thus be
-// rendered with ER flavor. Enumerations are excluded — they are not an ER concept.
+// Classifier types that map to ER entities and can thus be rendered with
+// ER flavor (no methods compartment). Enumerations and interfaces have no
+// ER equivalent — interfaces in particular define an operation contract,
+// which is the exact opposite of an entity.
 const ER_CAPABLE_CLASSIFIER_TYPES: ReadonlyArray<string> = [
   ClassElementType.Class,
   ClassElementType.AbstractClass,
-  ClassElementType.Interface,
 ];
 
 export const UMLClassifierComponent: FunctionComponent<Props> = ({ element, children, fillColor }) => {

--- a/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-component.tsx
+++ b/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-component.tsx
@@ -2,9 +2,22 @@ import React, { FunctionComponent } from 'react';
 import { Text } from '../../../components/controls/text/text';
 import { UMLClassifier } from './uml-classifier';
 import { ThemedPath, ThemedRect } from '../../../components/theme/themedComponents';
+import { settingsService } from '../../../services/settings/settings-service';
+import { ClassElementType } from '../../uml-class-diagram';
+
+// Classifier types that represent class-diagram entities and can thus be
+// rendered with ER flavor. Enumerations are excluded — they are not an ER concept.
+const ER_CAPABLE_CLASSIFIER_TYPES: ReadonlyArray<string> = [
+  ClassElementType.Class,
+  ClassElementType.AbstractClass,
+  ClassElementType.Interface,
+];
 
 export const UMLClassifierComponent: FunctionComponent<Props> = ({ element, children, fillColor }) => {
   const clipId = `clip-${element.id}`;
+  const isERClassifier =
+    settingsService.getClassNotation() === 'ER' &&
+    ER_CAPABLE_CLASSIFIER_TYPES.includes(element.type);
   return (
     <g>
       {/* Clip all content to the element's bounding box so text doesn't overflow */}
@@ -61,7 +74,7 @@ export const UMLClassifierComponent: FunctionComponent<Props> = ({ element, chil
       {element.hasAttributes && (
         <ThemedPath d={`M 0 ${element.headerHeight} H ${element.bounds.width}`} strokeColor={element.strokeColor} />
       )}
-      {element.hasMethods && element.stereotype !== 'enumeration' && (
+      {element.hasMethods && element.stereotype !== 'enumeration' && !isERClassifier && (
         <ThemedPath d={`M 0 ${element.deviderPosition} H ${element.bounds.width}`} strokeColor={element.strokeColor} />
       )}
     </g>

--- a/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-member-component.tsx
+++ b/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-member-component.tsx
@@ -7,6 +7,7 @@ import { settingsService } from '../../../services/settings/settings-service';
 import { ModelState } from '../../../components/store/model-state';
 import { ObjectElementType } from '../../uml-object-diagram';
 import { UserModelElementType } from '../../user-modeling';
+import { ClassElementType } from '../../uml-class-diagram';
 
 interface OwnProps {
   element: UMLClassifierMember;
@@ -25,19 +26,47 @@ const UMLClassifierMemberComponentUnconnected: FunctionComponent<Props> = ({ ele
   const isObjectAttribute = element.type === ObjectElementType.ObjectAttribute;
   const isObjectMethod = element.type === ObjectElementType.ObjectMethod;
   const isUserModelAttribute = element.type === UserModelElementType.UserModelAttribute;
+  const isClassAttribute = element.type === ClassElementType.ClassAttribute;
+  const isClassMethod = element.type === ClassElementType.ClassMethod;
   const shouldShowIconView = settingsService.shouldShowIconView();
+  const notation = settingsService.getClassNotation();
+  const isEREnabled = notation === 'ER';
 
   // Hide attributes and methods in icon view for object diagrams
   if ((isObjectAttribute || isObjectMethod || isUserModelAttribute) && shouldShowIconView) {
     return null;
   }
 
+  // Hide methods entirely when rendering class diagrams in ER (Chen) mode:
+  // ER notation has no concept of operations/methods on entities.
+  if (isClassMethod && isEREnabled) {
+    return null;
+  }
+
   // Check if owner is enumeration
   const isEnumeration = owner && 'stereotype' in owner && (owner as any).stereotype === 'enumeration';
 
-  // Use displayName for class attributes/methods, fallback to name for others
-  // For enumerations, only show the name (no visibility or type)
-  const displayText = isEnumeration ? element.name : (element.displayName || element.name);
+  // Build the label. In ER mode, strip UML visibility symbols and the "{id}"
+  // suffix since ER has no visibility semantics and uses underline for PKs.
+  let displayText: string;
+  let underlineText = false;
+  if (isEnumeration) {
+    displayText = element.name;
+  } else if (isEREnabled && isClassAttribute) {
+    const attr = element as UMLClassifierMember;
+    const derivedPrefix = attr.isDerived ? '/' : '';
+    const optionalMarker = attr.isOptional ? '?' : '';
+    const defaultSuffix =
+      attr.defaultValue !== undefined && attr.defaultValue !== null && attr.defaultValue !== ''
+        ? ` = ${attr.defaultValue}`
+        : '';
+    displayText = attr.attributeType
+      ? `${derivedPrefix}${attr.name}${optionalMarker}: ${attr.attributeType}${defaultSuffix}`
+      : `${derivedPrefix}${attr.name}${optionalMarker}${defaultSuffix}`;
+    underlineText = !!attr.isId;
+  } else {
+    displayText = element.displayName || element.name;
+  }
 
   // Check if this is a string-type object attribute to add quotes
   const isStringAttribute = isObjectAttribute &&
@@ -60,7 +89,14 @@ const UMLClassifierMemberComponentUnconnected: FunctionComponent<Props> = ({ ele
   return (
     <g>
       <ThemedRect fillColor={fillColor || element.fillColor} strokeColor="none" width="100%" height="100%" />
-      <Text x={10} fill={element.textColor} fontWeight="normal" textAnchor="start">
+      <Text
+        x={10}
+        fill={element.textColor}
+        fontWeight="normal"
+        textAnchor="start"
+        textDecoration={underlineText ? 'underline' : undefined}
+        data-testid={underlineText ? 'er-id-attribute' : undefined}
+      >
         {finalDisplayText}
       </Text>
     </g>

--- a/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-member-component.tsx
+++ b/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-member-component.tsx
@@ -46,24 +46,18 @@ const UMLClassifierMemberComponentUnconnected: FunctionComponent<Props> = ({ ele
   // Check if owner is enumeration
   const isEnumeration = owner && 'stereotype' in owner && (owner as any).stereotype === 'enumeration';
 
-  // Build the label. In ER mode, strip UML visibility symbols and the "{id}"
-  // suffix since ER has no visibility semantics and uses underline for PKs.
+  // Build the label. ER class attributes get the ER-flavored display
+  // (no visibility symbol, no {id} suffix) plus underline when isId is set;
+  // ER has no visibility semantics and identifies PKs via underline.
+  // The ER formatting itself lives on UMLClassifierMember.displayNameER so
+  // it stays in sync with displayName if the shared fields evolve.
   let displayText: string;
   let underlineText = false;
   if (isEnumeration) {
     displayText = element.name;
   } else if (isEREnabled && isClassAttribute) {
-    const attr = element as UMLClassifierMember;
-    const derivedPrefix = attr.isDerived ? '/' : '';
-    const optionalMarker = attr.isOptional ? '?' : '';
-    const defaultSuffix =
-      attr.defaultValue !== undefined && attr.defaultValue !== null && attr.defaultValue !== ''
-        ? ` = ${attr.defaultValue}`
-        : '';
-    displayText = attr.attributeType
-      ? `${derivedPrefix}${attr.name}${optionalMarker}: ${attr.attributeType}${defaultSuffix}`
-      : `${derivedPrefix}${attr.name}${optionalMarker}${defaultSuffix}`;
-    underlineText = !!attr.isId;
+    displayText = element.displayNameER;
+    underlineText = !!element.isId;
   } else {
     displayText = element.displayName || element.name;
   }

--- a/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-member.ts
+++ b/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-member.ts
@@ -132,6 +132,26 @@ export abstract class UMLClassifierMember extends UMLElement implements IUMLClas
   }
 
   /**
+   * Get the display name for rendering in ER (Chen) mode. Drops the UML
+   * visibility symbol and the `{id, external id}` suffix — ER has no
+   * visibility semantics and marks identifying attributes with an underline
+   * on the attribute name itself (rendered by the classifier-member
+   * component). Keeps `/` for derived, `?` for optional, and ` = default`.
+   */
+  get displayNameER(): string {
+    const derivedPrefix = this.isDerived ? '/' : '';
+    const optionalMarker = this.isOptional ? '?' : '';
+    const defaultSuffix =
+      this.defaultValue !== undefined && this.defaultValue !== null && this.defaultValue !== ''
+        ? ` = ${this.defaultValue}`
+        : '';
+    if (this.name && this.attributeType) {
+      return `${derivedPrefix}${this.name}${optionalMarker}: ${this.attributeType}${defaultSuffix}`;
+    }
+    return `${derivedPrefix}${this.name}${optionalMarker}${defaultSuffix}`;
+  }
+
+  /**
    * Parse legacy name format and extract visibility, name, and attributeType
    * Used for backward compatibility when loading old diagrams
    */

--- a/packages/editor/src/main/packages/common/uml-classifier/uml-classifier.ts
+++ b/packages/editor/src/main/packages/common/uml-classifier/uml-classifier.ts
@@ -4,13 +4,23 @@ import { ILayoutable } from '../../../services/layouter/layoutable';
 import { IUMLContainer, UMLContainer } from '../../../services/uml-container/uml-container';
 import { IUMLElement, UMLElement } from '../../../services/uml-element/uml-element';
 import { UMLElementFeatures } from '../../../services/uml-element/uml-element-features';
+import { settingsService } from '../../../services/settings/settings-service';
 import * as Apollon from '../../../typings';
 import { assign } from '../../../utils/fx/assign';
 import { Text } from '../../../utils/svg/text';
+import { ClassElementType } from '../../uml-class-diagram';
 import { UMLElementType } from '../../uml-element-type';
 import { UMLClassifierAttribute } from './uml-classifier-attribute';
 import { UMLClassifierMethod } from './uml-classifier-method';
 import { UMLClassifierMember } from './uml-classifier-member';
+
+// Classifier types that drop their methods compartment when ER notation is
+// active. Must match ER_CAPABLE_CLASSIFIER_TYPES in uml-classifier-component
+// — kept in sync manually (only two entries, not worth a shared module).
+const ER_HIDES_METHODS_FOR_TYPES: ReadonlyArray<string> = [
+  ClassElementType.Class,
+  ClassElementType.AbstractClass,
+];
 
 export const CLASSIFIER_MIN_WIDTH = 80;
 export const CLASSIFIER_MAX_AUTO_WIDTH = 420;
@@ -68,17 +78,29 @@ export abstract class UMLClassifier extends UMLContainer implements IUMLClassifi
     const attributes = children.filter((x): x is UMLClassifierAttribute => x instanceof UMLClassifierAttribute);
     const methods = children.filter((x): x is UMLClassifierMethod => x instanceof UMLClassifierMethod);
 
+    // In ER (Chen) mode, Class/AbstractClass classifiers drop the methods
+    // compartment entirely — ER entities have no operations. We zero
+    // hasMethods and skip the methods height loop so the box doesn't leave
+    // empty space where the compartment used to be. The method children
+    // are still returned so selection/hit-testing keeps working.
+    const isERHidingMethods =
+      settingsService.getClassNotation() === 'ER' &&
+      ER_HIDES_METHODS_FOR_TYPES.includes(this.type);
+
     this.hasAttributes = attributes.length > 0;
-    this.hasMethods = methods.length > 0;
+    this.hasMethods = !isERHidingMethods && methods.length > 0;
     const radix = 10;
     const userWidth = Math.round(this.bounds.width / radix) * radix;
 
     // Compute the minimum width needed to fit all text without clipping.
     // This is used as a suggestion, but the user can resize smaller — text
-    // will be clipped visually instead of forcing the box wider.
+    // will be clipped visually instead of forcing the box wider. Methods
+    // are excluded from width fitting when ER is hiding them, so a very
+    // long method signature doesn't pad the entity box in ER mode.
+    const widthMembers = isERHidingMethods ? attributes : [...attributes, ...methods];
     let textFitWidth = CLASSIFIER_MIN_WIDTH;
-    for (let i = 0; i < [this, ...attributes, ...methods].length; i++) {
-      const child = [this, ...attributes, ...methods][i];
+    for (let i = 0; i < [this, ...widthMembers].length; i++) {
+      const child = [this, ...widthMembers][i];
       const displayText = child instanceof UMLClassifierMember
         ? (this.stereotype === 'enumeration' ? child.name : child.displayName)
         : child.name;
@@ -111,7 +133,11 @@ export abstract class UMLClassifier extends UMLContainer implements IUMLClassifi
       method.bounds.x = 0.5;
       method.bounds.y = y + 0.5;
       method.bounds.width = this.bounds.width - 1;
-      y += method.bounds.height;
+      // Skip advancing y in ER mode — the method component returns null and
+      // we don't want blank space below the attributes compartment.
+      if (!isERHidingMethods) {
+        y += method.bounds.height;
+      }
     }
     this.bounds.height = y;
     return [this, ...attributes, ...methods];

--- a/packages/editor/src/main/packages/uml-class-diagram/uml-class-association/uml-class-association-update.tsx
+++ b/packages/editor/src/main/packages/uml-class-diagram/uml-class-association/uml-class-association-update.tsx
@@ -20,6 +20,8 @@ import { UMLElementRepository } from '../../../services/uml-element/uml-element-
 import { UMLRelationshipRepository } from '../../../services/uml-relationship/uml-relationship-repository';
 import { AsyncDispatch } from '../../../utils/actions/actions';
 import { UMLAssociation } from '../../common/uml-association/uml-association';
+import { erCardinalityToUML } from '../../common/uml-association/multiplicity';
+import { settingsService } from '../../../services/settings/settings-service';
 
 type OwnProps = {
   element: UMLAssociation;
@@ -71,6 +73,12 @@ class ClassAssociationComponent extends Component<Props, State> {
     if (!source || !target) return null;
 
     const isInheritance = element.type === ClassRelationshipType.ClassInheritance;
+    // Hint both accepted syntaxes when ER display mode is active. The
+    // stored value is still UML, so the textfield itself shows the UML
+    // form — the placeholder is just there so ER-native users know
+    // "(1,N)" is accepted as input.
+    const multiplicityPlaceholder =
+      settingsService.getClassNotation() === 'ER' ? '(1,1) or 1..1' : '1..1';
 
     return (
       <div>
@@ -147,7 +155,7 @@ class ClassAssociationComponent extends Component<Props, State> {
                   value={element.source.multiplicity}
                   onChange={this.onUpdate('multiplicity', 'source')}
                   autoFocus
-                  placeholder={`1..1`}
+                  placeholder={multiplicityPlaceholder}
                 />
               </Flex>
               <Flex>
@@ -165,7 +173,7 @@ class ClassAssociationComponent extends Component<Props, State> {
                   gutter
                   value={element.target.multiplicity}
                   onChange={this.onUpdate('multiplicity', 'target')}
-                  placeholder={`1..1`}
+                  placeholder={multiplicityPlaceholder}
                 />
               </Flex>
               <Flex>
@@ -185,7 +193,13 @@ class ClassAssociationComponent extends Component<Props, State> {
 
   private onUpdate = (type: 'multiplicity' | 'role', end: 'source' | 'target') => (value: string) => {
     const { element, update } = this.props;
-    update<UMLAssociation>(element.id, { [end]: { ...element[end], [type]: value } });
+    // Accept ER-style "(min,max)" input and normalize to UML form before
+    // storing. Storage is always UML — ER is a display-only flavor — so a
+    // user typing "(0,N)" in ER mode has the same effect as typing "0..*".
+    // UML input is returned unchanged by erCardinalityToUML, so this is
+    // safe to apply regardless of the active notation.
+    const storedValue = type === 'multiplicity' ? erCardinalityToUML(value) : value;
+    update<UMLAssociation>(element.id, { [end]: { ...element[end], [type]: storedValue } });
   };
 }
 

--- a/packages/editor/src/main/scenes/application.tsx
+++ b/packages/editor/src/main/scenes/application.tsx
@@ -21,7 +21,7 @@ import { RootContext, RootProvider } from '../components/root/root-context';
 import { UMLModel } from '../typings';
 import { Patcher } from '../services/patcher';
 import { MouseEventListener } from '../components/canvas/mouse-eventlistener';
-import { settingsService } from '../services/settings/settings-service';
+import { settingsService, ClassNotation } from '../services/settings/settings-service';
 
 type Props = {
   patcher: Patcher<UMLModel>;
@@ -34,12 +34,14 @@ type State = {
   canvas: ILayer | null;
   root: HTMLDivElement | null;
   usePropertiesPanel: boolean;
+  classNotation: ClassNotation;
 };
 
 const initialState: State = Object.freeze({
   canvas: null,
   root: null,
   usePropertiesPanel: settingsService.shouldUsePropertiesPanel(),
+  classNotation: settingsService.getClassNotation(),
 });
 
 export class Application extends React.Component<Props, State> {
@@ -55,7 +57,10 @@ export class Application extends React.Component<Props, State> {
 
   componentDidMount() {
     this.unsubscribeSettings = settingsService.onSettingsChange((settings) => {
-      this.setState({ usePropertiesPanel: settings.usePropertiesPanel });
+      this.setState({
+        usePropertiesPanel: settings.usePropertiesPanel,
+        classNotation: settings.classNotation,
+      });
     });
   }
 

--- a/packages/editor/src/main/services/settings/settings-service.ts
+++ b/packages/editor/src/main/services/settings/settings-service.ts
@@ -1,4 +1,11 @@
 /**
+ * Rendering flavor for class diagrams.
+ * - 'UML' (default) — standard UML class notation
+ * - 'ER' — Chen-style entity-relationship flavor (rendering-only; no metamodel change)
+ */
+export type ClassNotation = 'UML' | 'ER';
+
+/**
  * Interface for application settings
  */
 export interface IApplicationSettings {
@@ -10,6 +17,8 @@ export interface IApplicationSettings {
   showAssociationNames: boolean;
   /** Whether to use the right-side properties panel instead of the floating popover */
   usePropertiesPanel: boolean;
+  /** Rendering flavor for class diagrams */
+  classNotation: ClassNotation;
   /** Other settings can be added here */
   // theme: 'light' | 'dark';
   // autoSave: boolean;
@@ -23,6 +32,7 @@ export const DEFAULT_SETTINGS: IApplicationSettings = {
   showIconView: false, // Default to false to hide class icons
   showAssociationNames: false, // Default to false to hide association names
   usePropertiesPanel: true, // Default to true to use the right-side properties panel
+  classNotation: 'UML', // Default to UML notation for class diagrams
 };
 
 /**
@@ -185,6 +195,13 @@ export class SettingsService implements ISettingsService {
    */
   shouldUsePropertiesPanel(): boolean {
     return this.settings.usePropertiesPanel;
+  }
+
+  /**
+   * Get the current class-diagram rendering notation
+   */
+  getClassNotation(): ClassNotation {
+    return this.settings.classNotation;
   }
 }
 

--- a/packages/webapp2/package.json
+++ b/packages/webapp2/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.4",

--- a/packages/webapp2/src/components/ui/radio-group.tsx
+++ b/packages/webapp2/src/components/ui/radio-group.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
+import { cn } from '@/lib/utils';
+
+const RadioGroup = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <RadioGroupPrimitive.Root ref={ref} className={cn('inline-flex overflow-hidden rounded-md border border-border/60', className)} {...props} />
+));
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+
+const RadioGroupItem = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <RadioGroupPrimitive.Item
+    ref={ref}
+    className={cn(
+      'px-3 py-1 text-xs transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+      'bg-background hover:bg-muted/40',
+      'data-[state=checked]:bg-brand data-[state=checked]:text-brand-foreground data-[state=checked]:hover:bg-brand',
+      className,
+    )}
+    {...props}
+  >
+    {children}
+  </RadioGroupPrimitive.Item>
+));
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+
+export { RadioGroup, RadioGroupItem };

--- a/packages/webapp2/src/main/features/editors/uml/__tests__/multiplicity.test.ts
+++ b/packages/webapp2/src/main/features/editors/uml/__tests__/multiplicity.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { parseMultiplicity, toERCardinality } from '@besser/wme';
+
+describe('parseMultiplicity', () => {
+  it('parses range form "1..1"', () => {
+    expect(parseMultiplicity('1..1')).toEqual({ min: '1', max: '1' });
+  });
+
+  it('parses range form "0..*"', () => {
+    expect(parseMultiplicity('0..*')).toEqual({ min: '0', max: '*' });
+  });
+
+  it('parses numeric range form "2..5"', () => {
+    expect(parseMultiplicity('2..5')).toEqual({ min: '2', max: '5' });
+  });
+
+  it('expands bare "*" to "0..*"', () => {
+    expect(parseMultiplicity('*')).toEqual({ min: '0', max: '*' });
+  });
+
+  it('expands bare number "3" to "3..3"', () => {
+    expect(parseMultiplicity('3')).toEqual({ min: '3', max: '3' });
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(parseMultiplicity('  1..*  ')).toEqual({ min: '1', max: '*' });
+    expect(parseMultiplicity(' 1 .. 5 ')).toEqual({ min: '1', max: '5' });
+  });
+
+  it('returns null for empty or whitespace-only input', () => {
+    expect(parseMultiplicity('')).toBeNull();
+    expect(parseMultiplicity('   ')).toBeNull();
+  });
+
+  it('returns null for malformed ranges', () => {
+    expect(parseMultiplicity('1..')).toBeNull();
+    expect(parseMultiplicity('..*')).toBeNull();
+    expect(parseMultiplicity('1..2..3')).toBeNull();
+  });
+});
+
+describe('toERCardinality', () => {
+  it('maps "1..1" to "(1,1)"', () => {
+    expect(toERCardinality('1..1')).toBe('(1,1)');
+  });
+
+  it('maps shorthand "1" to "(1,1)"', () => {
+    expect(toERCardinality('1')).toBe('(1,1)');
+  });
+
+  it('maps "0..*" to "(0,N)"', () => {
+    expect(toERCardinality('0..*')).toBe('(0,N)');
+  });
+
+  it('maps shorthand "*" to "(0,N)"', () => {
+    expect(toERCardinality('*')).toBe('(0,N)');
+  });
+
+  it('maps "1..*" to "(1,N)"', () => {
+    expect(toERCardinality('1..*')).toBe('(1,N)');
+  });
+
+  it('collapses identical numeric bounds "5..5" to "(5,5)"', () => {
+    expect(toERCardinality('5..5')).toBe('(5,5)');
+  });
+
+  it('preserves mixed numeric ranges "2..5" as "(2,5)"', () => {
+    expect(toERCardinality('2..5')).toBe('(2,5)');
+  });
+
+  it('returns empty string for empty/undefined input', () => {
+    expect(toERCardinality('')).toBe('');
+    expect(toERCardinality(undefined)).toBe('');
+  });
+
+  it('returns malformed input verbatim so user intent is preserved', () => {
+    expect(toERCardinality('1..')).toBe('1..');
+    expect(toERCardinality('1..2..3')).toBe('1..2..3');
+  });
+});

--- a/packages/webapp2/src/main/features/editors/uml/__tests__/multiplicity.test.ts
+++ b/packages/webapp2/src/main/features/editors/uml/__tests__/multiplicity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseMultiplicity, toERCardinality } from '@besser/wme';
+import { parseMultiplicity, toERCardinality, erCardinalityToUML } from '@besser/wme';
 
 describe('parseMultiplicity', () => {
   it('parses range form "1..1"', () => {
@@ -76,5 +76,62 @@ describe('toERCardinality', () => {
   it('returns malformed input verbatim so user intent is preserved', () => {
     expect(toERCardinality('1..')).toBe('1..');
     expect(toERCardinality('1..2..3')).toBe('1..2..3');
+  });
+});
+
+describe('erCardinalityToUML', () => {
+  it('maps "(0,N)" to "0..*"', () => {
+    expect(erCardinalityToUML('(0,N)')).toBe('0..*');
+  });
+
+  it('maps "(1,N)" to "1..*"', () => {
+    expect(erCardinalityToUML('(1,N)')).toBe('1..*');
+  });
+
+  it('maps "(1,1)" to "1..1"', () => {
+    expect(erCardinalityToUML('(1,1)')).toBe('1..1');
+  });
+
+  it('maps "(2,5)" to "2..5"', () => {
+    expect(erCardinalityToUML('(2,5)')).toBe('2..5');
+  });
+
+  it('accepts lowercase "n" as max', () => {
+    expect(erCardinalityToUML('(0,n)')).toBe('0..*');
+  });
+
+  it('accepts literal "*" in the max position', () => {
+    expect(erCardinalityToUML('(1,*)')).toBe('1..*');
+  });
+
+  it('tolerates whitespace inside and around parentheses', () => {
+    expect(erCardinalityToUML('  (0, N)  ')).toBe('0..*');
+    expect(erCardinalityToUML('( 2 , 5 )')).toBe('2..5');
+  });
+
+  it('returns UML input unchanged (safe to apply unconditionally)', () => {
+    expect(erCardinalityToUML('1..*')).toBe('1..*');
+    expect(erCardinalityToUML('1..1')).toBe('1..1');
+    expect(erCardinalityToUML('*')).toBe('*');
+    expect(erCardinalityToUML('1')).toBe('1');
+  });
+
+  it('returns empty string for empty/undefined input', () => {
+    expect(erCardinalityToUML('')).toBe('');
+    expect(erCardinalityToUML(undefined)).toBe('');
+  });
+
+  it('returns malformed parenthesized input verbatim', () => {
+    expect(erCardinalityToUML('(1,)')).toBe('(1,)');
+    expect(erCardinalityToUML('(,N)')).toBe('(,N)');
+    expect(erCardinalityToUML('(1,2,3)')).toBe('(1,2,3)');
+    expect(erCardinalityToUML('(1')).toBe('(1');
+  });
+
+  it('is the inverse of toERCardinality for canonical inputs', () => {
+    const canonicalUMLInputs = ['0..*', '1..*', '1..1', '2..5'];
+    for (const uml of canonicalUMLInputs) {
+      expect(erCardinalityToUML(toERCardinality(uml))).toBe(uml);
+    }
   });
 });

--- a/packages/webapp2/src/main/features/import/useImportDiagramPicture.ts
+++ b/packages/webapp2/src/main/features/import/useImportDiagramPicture.ts
@@ -19,6 +19,22 @@ export const useImportDiagramPictureFromImage = () => {
       formData.append('image_file', file);
       formData.append('api_key', apiKey);
 
+      // If the active ClassDiagram already has elements, send it so the backend
+      // merges the image into it instead of replacing.
+      const currentForMerge = ProjectStorageRepository.getCurrentProject();
+      const classDiagramsForMerge = currentForMerge?.diagrams?.['ClassDiagram'] ?? [];
+      const classActiveIndex = currentForMerge?.currentDiagramIndices?.['ClassDiagram'] ?? 0;
+      const activeClassDiagram = classDiagramsForMerge[
+        Math.min(classActiveIndex, Math.max(classDiagramsForMerge.length - 1, 0))
+      ];
+      const activeClassElements = (activeClassDiagram as any)?.model?.elements;
+      if (activeClassElements && Object.keys(activeClassElements).length > 0) {
+        formData.append('existing_model', JSON.stringify({
+          title: activeClassDiagram.title,
+          model: (activeClassDiagram as any).model,
+        }));
+      }
+
       const response = await fetch(`${BACKEND_URL}/get-json-model-from-image`, {
         method: 'POST',
         body: formData,

--- a/packages/webapp2/src/main/features/project/ProjectSettingsPanel.tsx
+++ b/packages/webapp2/src/main/features/project/ProjectSettingsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { settingsService } from '@besser/wme';
+import { settingsService, ClassNotation } from '@besser/wme';
 import { toast } from 'react-toastify';
 import { Download, FolderKanban, Layers3, Monitor, Settings } from 'lucide-react';
 import { useProject } from '../../app/hooks/useProject';
@@ -29,6 +29,7 @@ export const ProjectSettingsPanel: React.FC = () => {
   const [showInstancedObjects, setShowInstancedObjects] = useState(false);
   const [showAssociationNames, setShowAssociationNames] = useState(false);
   const [usePropertiesPanel, setUsePropertiesPanel] = useState(false);
+  const [classNotation, setClassNotation] = useState<ClassNotation>('UML');
 
   const { currentProject, loading, error, updateProject, exportProject } = useProject();
 
@@ -36,6 +37,7 @@ export const ProjectSettingsPanel: React.FC = () => {
     setShowInstancedObjects(settingsService.shouldShowInstancedObjects());
     setShowAssociationNames(settingsService.shouldShowAssociationNames());
     setUsePropertiesPanel(settingsService.shouldUsePropertiesPanel());
+    setClassNotation(settingsService.getClassNotation());
   }, []);
 
   const diagrams = useMemo(() => {
@@ -240,6 +242,41 @@ export const ProjectSettingsPanel: React.FC = () => {
                     }}
                   />
                 </label>
+                <Separator />
+                <div className="flex items-center justify-between gap-4 rounded-lg px-1 py-3">
+                  <div>
+                    <p className="text-sm font-medium">Class Diagram Notation</p>
+                    <p className="text-xs text-muted-foreground">
+                      UML (default) shows standard UML classes; ER shows a Chen-style entity/relationship rendering
+                    </p>
+                  </div>
+                  <div
+                    role="radiogroup"
+                    aria-label="Class diagram notation"
+                    className="inline-flex overflow-hidden rounded-md border border-border/60"
+                  >
+                    {(['UML', 'ER'] as const).map((value) => (
+                      <button
+                        key={value}
+                        role="radio"
+                        type="button"
+                        aria-checked={classNotation === value}
+                        data-testid={`class-notation-${value.toLowerCase()}`}
+                        className={`px-3 py-1 text-xs transition-colors ${
+                          classNotation === value
+                            ? 'bg-brand text-brand-foreground'
+                            : 'bg-background hover:bg-muted/40'
+                        }`}
+                        onClick={() => {
+                          setClassNotation(value);
+                          settingsService.updateSetting('classNotation', value);
+                        }}
+                      >
+                        {value}
+                      </button>
+                    ))}
+                  </div>
+                </div>
               </CardContent>
             </Card>
           </div>

--- a/packages/webapp2/src/main/features/project/ProjectSettingsPanel.tsx
+++ b/packages/webapp2/src/main/features/project/ProjectSettingsPanel.tsx
@@ -10,6 +10,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { FormField } from '@/components/ui/form-field';
 import { validateProjectName } from '../../shared/utils/validation';
 import { useFieldValidation } from '../../shared/hooks/useFieldValidation';
@@ -250,32 +251,25 @@ export const ProjectSettingsPanel: React.FC = () => {
                       UML (default) shows standard UML classes; ER shows a Chen-style entity/relationship rendering
                     </p>
                   </div>
-                  <div
-                    role="radiogroup"
+                  <RadioGroup
                     aria-label="Class diagram notation"
-                    className="inline-flex overflow-hidden rounded-md border border-border/60"
+                    value={classNotation}
+                    onValueChange={(value) => {
+                      const next = value as ClassNotation;
+                      setClassNotation(next);
+                      settingsService.updateSetting('classNotation', next);
+                    }}
                   >
                     {(['UML', 'ER'] as const).map((value) => (
-                      <button
+                      <RadioGroupItem
                         key={value}
-                        role="radio"
-                        type="button"
-                        aria-checked={classNotation === value}
+                        value={value}
                         data-testid={`class-notation-${value.toLowerCase()}`}
-                        className={`px-3 py-1 text-xs transition-colors ${
-                          classNotation === value
-                            ? 'bg-brand text-brand-foreground'
-                            : 'bg-background hover:bg-muted/40'
-                        }`}
-                        onClick={() => {
-                          setClassNotation(value);
-                          settingsService.updateSetting('classNotation', value);
-                        }}
                       >
                         {value}
-                      </button>
+                      </RadioGroupItem>
                     ))}
-                  </div>
+                  </RadioGroup>
                 </div>
               </CardContent>
             </Card>

--- a/packages/webapp2/tests/e2e/er-notation.spec.ts
+++ b/packages/webapp2/tests/e2e/er-notation.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * ER-notation toggle tests — verify the Class Diagram Notation radio group
+ * in Project Settings, persistence to localStorage, and that re-opening
+ * Settings after a reload reflects the saved choice (issue #508).
+ *
+ * Rendering-level assertions (diamond at midpoint, underline on isId, hidden
+ * methods compartment) are covered by manual browser verification — they
+ * require interacting with the Apollon editor's internal model, which is not
+ * exposed on `window` for the UML editor.
+ */
+test.describe('ER Notation setting', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate(() => {
+      localStorage.clear();
+      localStorage.setItem(
+        'besser_analytics_consent',
+        JSON.stringify({ status: 'declined', version: '1.2', timestamp: Date.now() }),
+      );
+    });
+    await page.reload();
+    await createBlankProject(page, 'ER_Notation_E2E');
+  });
+
+  test('Class Diagram Notation row is present in Display card with UML selected by default', async ({ page }) => {
+    await navigateToSettings(page);
+
+    await expect(page.getByText('Class Diagram Notation', { exact: true })).toBeVisible();
+    await expect(
+      page.getByText(/UML \(default\) shows standard UML classes; ER shows a Chen-style/i),
+    ).toBeVisible();
+
+    const umlRadio = page.getByTestId('class-notation-uml');
+    const erRadio = page.getByTestId('class-notation-er');
+    await expect(umlRadio).toBeVisible();
+    await expect(erRadio).toBeVisible();
+    await expect(umlRadio).toHaveAttribute('aria-checked', 'true');
+    await expect(erRadio).toHaveAttribute('aria-checked', 'false');
+  });
+
+  test('clicking ER switches aria-checked and writes ER to localStorage', async ({ page }) => {
+    await navigateToSettings(page);
+
+    const umlRadio = page.getByTestId('class-notation-uml');
+    const erRadio = page.getByTestId('class-notation-er');
+
+    await erRadio.click();
+
+    await expect(erRadio).toHaveAttribute('aria-checked', 'true');
+    await expect(umlRadio).toHaveAttribute('aria-checked', 'false');
+
+    const stored = await page.evaluate(() => localStorage.getItem('besser-standalone-settings'));
+    expect(stored).toBeTruthy();
+    expect(JSON.parse(stored as string)).toMatchObject({ classNotation: 'ER' });
+  });
+
+  test('clicking UML after ER flips the selection back and persists', async ({ page }) => {
+    await navigateToSettings(page);
+
+    await page.getByTestId('class-notation-er').click();
+    await expect(page.getByTestId('class-notation-er')).toHaveAttribute('aria-checked', 'true');
+
+    await page.getByTestId('class-notation-uml').click();
+    await expect(page.getByTestId('class-notation-uml')).toHaveAttribute('aria-checked', 'true');
+    await expect(page.getByTestId('class-notation-er')).toHaveAttribute('aria-checked', 'false');
+
+    const stored = await page.evaluate(() => localStorage.getItem('besser-standalone-settings'));
+    expect(JSON.parse(stored as string)).toMatchObject({ classNotation: 'UML' });
+  });
+
+  test('ER selection survives a page reload', async ({ page }) => {
+    await navigateToSettings(page);
+    await page.getByTestId('class-notation-er').click();
+    await expect(page.getByTestId('class-notation-er')).toHaveAttribute('aria-checked', 'true');
+
+    await page.reload();
+
+    // Re-enter settings and confirm ER is still the selected radio.
+    await navigateToSettings(page);
+    await expect(page.getByTestId('class-notation-er')).toHaveAttribute('aria-checked', 'true');
+    await expect(page.getByTestId('class-notation-uml')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  test('editor renders without errors in ER mode', async ({ page }) => {
+    await navigateToSettings(page);
+    await page.getByTestId('class-notation-er').click();
+
+    const sidebar = page.getByRole('complementary');
+    await sidebar.getByRole('button', { name: /class/i }).click();
+
+    // The Class editor returns; confirm no crash loader visible and main canvas is live.
+    await expect(page.getByText('Switching diagram...')).toBeHidden({ timeout: 5_000 });
+    await expect(page.locator('main')).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers (duplicated from settings.spec.ts — kept local to avoid cross-file imports)
+// ---------------------------------------------------------------------------
+
+async function createBlankProject(page: import('@playwright/test').Page, name: string) {
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible({ timeout: 15_000 });
+
+  await dialog.getByText('Create Blank').click();
+  await expect(dialog.getByText('Create A Project')).toBeVisible();
+
+  const nameInput = dialog.getByLabel(/name/i);
+  await nameInput.clear();
+  await nameInput.fill(name);
+
+  await dialog.getByRole('button', { name: /create project/i }).click();
+  await expect(dialog).toBeHidden({ timeout: 10_000 });
+}
+
+async function navigateToSettings(page: import('@playwright/test').Page) {
+  const sidebar = page.getByRole('complementary');
+  await expect(sidebar).toBeVisible({ timeout: 10_000 });
+  await sidebar.getByRole('button', { name: /settings/i }).click();
+  await expect(page.getByRole('heading', { name: /project settings/i })).toBeVisible({ timeout: 10_000 });
+}


### PR DESCRIPTION
Sync \`develop\` → \`main\` for BESSER v7.2.0.

## Summary

- **ER (Chen) notation for class diagrams** (#108, closes #508) — display-only rendering flavor selectable from Project Settings → Display. ER diamonds on plain binary associations, \`(min,max)\` cardinality display, underlined \`is_id\` attributes, hidden methods compartment on entity classes. Storage stays in UML; the toggle is lossless. Shipped with 15 unit tests in \`multiplicity.test.ts\` (including round-trip invariant) and a Playwright suite in \`tests/e2e/er-notation.spec.ts\` covering the toggle, localStorage persistence, and reload survival.
- **Backend-side companion**: one-to-many REST endpoint emission landed in \`BESSER\` PR #509 / release v7.2.0.

## Test plan

- [ ] Unit tests pass: \`multiplicity.test.ts\`
- [ ] E2E smoke: \`er-notation.spec.ts\`
- [ ] Visual: toggle ER in Project Settings, confirm diamonds render on associations, methods compartment disappears on entity classes, cardinalities render as \`(min,max)\`, switching back to UML restores original rendering