### PR TITLE
fix(topbar): allow application bar to collapse on agent diagram

### DIFF
--- a/packages/webapp2/src/main/app/shell/WorkspaceTopBar.tsx
+++ b/packages/webapp2/src/main/app/shell/WorkspaceTopBar.tsx
@@ -93,7 +93,7 @@ const WorkspaceTopBarInner: React.FC<WorkspaceTopBarProps> = ({
           </div>
         </div>
 
-        <div className="flex items-center gap-1 xl:gap-2">
+        <div className="flex min-w-0 items-center gap-1 xl:gap-2">
           <FileMenu
             outlineButtonClass={outlineButtonClass}
             hasProject={hasProject}

--- a/packages/webapp2/src/main/app/shell/menus/TopBarUtilities.tsx
+++ b/packages/webapp2/src/main/app/shell/menus/TopBarUtilities.tsx
@@ -76,13 +76,14 @@ export const TopBarUtilities: React.FC<TopBarUtilitiesProps> = ({
   return (
     <>
       {showAgentVariantSelector && (
-        <div className="hidden items-center gap-2 xl:flex">
-          <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Variant</span>
+        <div className="hidden min-w-0 shrink items-center gap-1.5 xl:flex 2xl:gap-2">
+          <span className="hidden text-[11px] font-medium uppercase tracking-wide text-muted-foreground 2xl:inline">Variant</span>
           <select
-            className="h-9 min-w-[210px] rounded-md border border-input bg-background px-3 py-1 text-sm transition-colors hover:border-brand/30 focus:border-brand/40 focus:outline-none focus:ring-2 focus:ring-brand/20"
+            className="h-9 w-[140px] min-w-0 shrink rounded-md border border-input bg-background px-2 py-1 text-sm transition-colors hover:border-brand/30 focus:border-brand/40 focus:outline-none focus:ring-2 focus:ring-brand/20 2xl:w-[210px] 2xl:px-3"
             value={activeAgentVariantId ?? ''}
             onChange={(event) => onAgentVariantChange?.(event.target.value)}
             aria-label="Select agent model variant"
+            title="Select agent model variant"
           >
             <option value="">Base agent model</option>
             {(agentVariantOptions ?? []).map((option) => (


### PR DESCRIPTION
## Summary
- The agent variant `<select>` had a hard `min-w-[210px]` and an always-visible "Variant" prefix label, both appearing at `xl` (≥1280px) — the same breakpoint where button labels un-collapse. Combined, this added ~270px of unshrinkable width and pushed the topbar past the viewport between 1280–1400px on agent diagrams only.
- Made the dropdown shrinkable (`min-w-0 shrink`, `w-[140px]` at xl) and deferred the "Variant" prefix label + full `w-[210px]` width to `2xl` (≥1400px) where the bar has room.
- Added `min-w-0` to the menu row in `WorkspaceTopBar` so flex children can actually shrink past their min-content width.

Net effect: the existing collapse behavior now works on agent diagrams. Below xl the dropdown is hidden (unchanged); at xl–2xl it's a compact 140px dropdown without the prefix label; at 2xl+ it's the original full-width version.

## Test plan
- [ ] Open an agent diagram and resize the window across the 1024 / 1280 / 1400px breakpoints — bar fits at every width without horizontal overflow.
- [ ] Confirm the variant dropdown is functional at xl (compact form) and 2xl (full form with "Variant" label).
- [ ] Confirm non-agent diagrams (class, state machine, etc.) are visually unchanged.
- [ ] Confirm `<xl` widths still hide the dropdown as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)