### PR TITLE
fix(agent-config): warn before replacing existing profile mapping on Save and Apply

### DIFF
--- a/packages/webapp2/src/main/features/agent-config/AgentConfigurationPanel.tsx
+++ b/packages/webapp2/src/main/features/agent-config/AgentConfigurationPanel.tsx
@@ -873,6 +873,34 @@ export const AgentConfigurationPanel: React.FC = () => {
     });
   }, [activeConfigId]);
 
+  // Warn before silently replacing an existing user-profile -> agent-config
+  // mapping. A user profile may only be mapped to a single agent configuration
+  // at a time, so saving a *different*-named config against an already-mapped
+  // profile will discard the prior mapping. Returns false when the user
+  // cancels — callers must abort the save in that case.
+  const confirmOverwriteIfProfileCollides = useCallback(async (
+    profile: { id: string; name: string },
+    newConfigName: string,
+  ): Promise<boolean> => {
+    const trimmed = newConfigName.trim();
+    if (!profile.id || !trimmed) return true;
+    const existingMapping = LocalStorageRepository.getAgentProfileConfigurationMappings()
+      .find((entry) => entry.userProfileId === profile.id);
+    if (!existingMapping) {
+      return true;
+    }
+    if (existingMapping.agentConfigurationName.toLowerCase() === trimmed.toLowerCase()) {
+      return true;
+    }
+    return globalConfirm({
+      title: 'Replace existing user profile mapping?',
+      description: `User profile "${profile.name}" is already mapped to configuration "${existingMapping.agentConfigurationName}". Saving will replace that mapping with "${trimmed}".`,
+      confirmLabel: 'Replace',
+      cancelLabel: 'Cancel',
+      variant: 'danger',
+    });
+  }, []);
+
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     const proceed = await confirmOverwriteIfNameCollides(configurationName);
@@ -1193,6 +1221,12 @@ export const AgentConfigurationPanel: React.FC = () => {
       toast.error('The selected user profile is not available. Please select a valid saved user profile.');
       return;
     }
+
+    const proceedProfileMapping = await confirmOverwriteIfProfileCollides(
+      { id: selectedProfile.id, name: selectedProfile.name },
+      trimmedName,
+    );
+    if (!proceedProfileMapping) return;
 
     const config = getConfigObject();
     const requestConfig: AgentTransformationConfig = buildSparseGenerationConfig(config);


### PR DESCRIPTION
## Summary
- A user profile may only be mapped to a single agent configuration at a time, but `LocalStorageRepository.saveAgentProfileConfigurationMapping` silently overwrote any prior mapping for the same `userProfileId`. Running Save and Apply with the same user profile but a different config name discarded the old mapping with no warning.
- Added `confirmOverwriteIfProfileCollides`, mirroring the existing `confirmOverwriteIfNameCollides`. It looks up the existing mapping for the selected profile and, if it points at a *different*-named configuration, prompts with "User profile X is already mapped to A. Saving will replace that mapping with B." (Replace / Cancel). When the new save targets the same config name as the existing mapping (i.e., user is just updating their own record) no prompt fires.
- Wired into `handleSaveAndApply` immediately after `selectedProfile` is validated and **before** the 10-min transform request, so users can abort early without burning a backend call.

The pre-existing name-collision prompt (`confirmOverwriteIfNameCollides`) already covers point 2 of the request — saving with an existing config name still prompts "A configuration named X already exists. Saving will replace it." — no change needed there.

## Test plan
- [ ] Save and Apply a configuration A mapped to user profile P → no prompt (first mapping).
- [ ] Save and Apply configuration B (different name) with the same user profile P → "Replace existing user profile mapping?" prompt with both names. Cancel aborts; Replace proceeds and the old mapping is replaced.
- [ ] Save and Apply with the same name as the existing mapping for the same profile → no profile-mapping prompt (still triggers name-collision prompt if the active config differs, as before).
- [ ] Save and Apply with a brand-new profile and an existing config name → name-collision prompt fires (unchanged behavior).
- [ ] Cancelling either prompt does not fire the backend transform request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)