### PR TITLE
fix(class-diagram): clear stereotype/italic when toggling Abstract or Enumeration off

### DIFF
--- a/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-update.tsx
+++ b/packages/editor/src/main/packages/common/uml-classifier/uml-classifier-update.tsx
@@ -482,13 +482,21 @@ class ClassifierUpdate extends Component<Props, State> {
     const instance = new UMLElements[newType]({
       id: element.id,
       name: element.name,
-      type: element.type,
       owner: element.owner,
       bounds: element.bounds,
       ownedElements: element.ownedElements,
-    });
+    }) as UMLClassifier;
     const { id: _ignoredId, ...values } = instance.serialize();
-    update(element.id, values as Partial<UMLElement>);
+    // serialize() omits stereotype/italic/underline, but those are exactly the
+    // fields that distinguish the classifier kinds — without explicitly
+    // forwarding them the reducer's partial merge keeps the old values, so
+    // toggling Abstract/Enumeration off would leave the stereotype banner.
+    update<UMLClassifier>(element.id, {
+      ...values,
+      stereotype: instance.stereotype,
+      italic: instance.italic,
+      underline: instance.underline,
+    } as Partial<UMLClassifier>);
   };
 
   private delete = (id: string) => () => {


### PR DESCRIPTION
## Summary

Toggling the Abstract / Enumeration switch off in the class-diagram property panel left the `<<abstract>>` / `<<enumeration>>` stereotype banner visible until the page was refreshed.

Fixes BESSER-PEARL/BESSER#517.

## Root cause

Two interacting bugs in `ClassifierUpdate.toggle` (`packages/editor/src/main/packages/common/uml-classifier/uml-classifier-update.tsx`):

1. The new instance was constructed with `type: element.type` (the **old** type). `assign()` then overwrote the new class's `type` field initializer, so a freshly-built `UMLClass` ended up with `type === AbstractClass`.
2. `UMLClassifier.serialize()` does not include `stereotype`, `italic`, or `underline`. The toggle dispatched `update(id, instance.serialize())`, so those distinguishing fields were never sent — the reducer's partial merge kept the previous `'abstract'` / `'enumeration'` stereotype and `italic: true` on the existing element.

## Fix

- Drop the stale `type: element.type` argument so the new class's field initializer wins.
- Explicitly forward `stereotype` / `italic` / `underline` from the new instance in the dispatched values, so the partial update fully overwrites the classifier kind.

## Test plan

- [x] Drop a class, enable Abstract → `<<abstract>>` appears.
- [x] Disable Abstract → stereotype is removed immediately, no refresh required.
- [x] Same for Enumeration toggle.
- [x] Toggling between Abstract ↔ Enumeration swaps stereotypes correctly.
- [x] `tsc --noEmit` clean for the touched file.