### PR TITLE
feat(perspectives): toggle modeling perspectives from settings

### DIFF
--- a/packages/editor/src/main/services/settings/settings-service.ts
+++ b/packages/editor/src/main/services/settings/settings-service.ts
@@ -6,6 +6,34 @@
 export type ClassNotation = 'UML' | 'ER';
 
 /**
+ * Use-case modeling perspectives that can be toggled on/off in settings.
+ * Each perspective bundles a set of diagram types and generators; a diagram
+ * or generator is visible whenever at least one enabled perspective lists
+ * it (perspectives may share diagrams — e.g. ClassDiagram appears in data
+ * modeling, database, web applications, and state machines).
+ */
+export type ModelingPerspective =
+  | 'dataModeling'
+  | 'database'
+  | 'webApplication'
+  | 'agent'
+  | 'stateMachine'
+  | 'userModeling'
+  | 'quantum';
+
+export const MODELING_PERSPECTIVES: ModelingPerspective[] = [
+  'dataModeling',
+  'database',
+  'webApplication',
+  'agent',
+  'stateMachine',
+  'userModeling',
+  'quantum',
+];
+
+export type EnabledPerspectives = Record<ModelingPerspective, boolean>;
+
+/**
  * Interface for application settings
  */
 export interface IApplicationSettings {
@@ -19,10 +47,22 @@ export interface IApplicationSettings {
   usePropertiesPanel: boolean;
   /** Rendering flavor for class diagrams */
   classNotation: ClassNotation;
+  /** Which modeling perspectives are enabled (visible in the workspace) */
+  enabledPerspectives: EnabledPerspectives;
   /** Other settings can be added here */
   // theme: 'light' | 'dark';
   // autoSave: boolean;
 }
+
+const DEFAULT_ENABLED_PERSPECTIVES: EnabledPerspectives = {
+  dataModeling: true,
+  database: true,
+  webApplication: true,
+  agent: true,
+  stateMachine: true,
+  userModeling: true,
+  quantum: true,
+};
 
 /**
  * Default settings configuration
@@ -33,6 +73,7 @@ export const DEFAULT_SETTINGS: IApplicationSettings = {
   showAssociationNames: false, // Default to false to hide association names
   usePropertiesPanel: true, // Default to true to use the right-side properties panel
   classNotation: 'UML', // Default to UML notation for class diagrams
+  enabledPerspectives: { ...DEFAULT_ENABLED_PERSPECTIVES },
 };
 
 /**
@@ -83,8 +124,20 @@ export class SettingsService implements ISettingsService {
       const stored = localStorage.getItem(this.STORAGE_KEY);
       if (stored) {
         const parsedSettings = JSON.parse(stored);
-        // Merge with defaults to ensure all properties exist
-        return { ...DEFAULT_SETTINGS, ...parsedSettings };
+        // Only carry through known perspective keys — drops any legacy keys
+        // from previous shapes of this setting.
+        const storedPerspectives = parsedSettings?.enabledPerspectives ?? {};
+        const enabledPerspectives = { ...DEFAULT_ENABLED_PERSPECTIVES };
+        for (const key of MODELING_PERSPECTIVES) {
+          if (typeof storedPerspectives[key] === 'boolean') {
+            enabledPerspectives[key] = storedPerspectives[key];
+          }
+        }
+        return {
+          ...DEFAULT_SETTINGS,
+          ...parsedSettings,
+          enabledPerspectives,
+        };
       }
     } catch (error) {
       console.warn('Failed to load settings from localStorage:', error);
@@ -202,6 +255,31 @@ export class SettingsService implements ISettingsService {
    */
   getClassNotation(): ClassNotation {
     return this.settings.classNotation;
+  }
+
+  /**
+   * Get the map of enabled modeling perspectives.
+   * ClassDiagram is always implicitly enabled and is not part of this map.
+   */
+  getEnabledPerspectives(): EnabledPerspectives {
+    return { ...this.settings.enabledPerspectives };
+  }
+
+  /**
+   * Whether a given modeling perspective is enabled.
+   * The data-modeling perspective is always considered enabled and is not
+   * tracked here.
+   */
+  isPerspectiveEnabled(perspective: ModelingPerspective): boolean {
+    return this.settings.enabledPerspectives[perspective] !== false;
+  }
+
+  /**
+   * Toggle a single modeling perspective. Persists and notifies listeners.
+   */
+  setPerspectiveEnabled(perspective: ModelingPerspective, enabled: boolean): void {
+    const next = { ...this.settings.enabledPerspectives, [perspective]: enabled };
+    this.updateSetting('enabledPerspectives', next);
   }
 }
 

--- a/packages/webapp2/src/main/app/shell/WorkspaceShell.tsx
+++ b/packages/webapp2/src/main/app/shell/WorkspaceShell.tsx
@@ -58,6 +58,8 @@ const HelpGuideDialog = React.lazy(() =>
 // mixed static/dynamic import warning (the module is already in this chunk).
 import { KeyboardShortcutsDialog, useKeyboardShortcutsToggle } from '../../shared/dialogs/KeyboardShortcutsDialog';
 import { CommandPalette, useCommandPaletteShortcut, buildDefaultActions } from '../../shared/components/command-palette/CommandPalette';
+import { useEnabledPerspectives } from '../../shared/hooks/useEnabledPerspectives';
+import { isDiagramVisible } from '../../shared/perspectives';
 
 export type { GeneratorType, GeneratorMenuMode } from './workspace-types';
 
@@ -705,7 +707,8 @@ export const WorkspaceShell: React.FC<WorkspaceShellProps> = ({
     }
   };
 
-  // Command palette actions
+  // Command palette actions (filter by enabled modeling perspectives)
+  const enabledPerspectives = useEnabledPerspectives();
   const commandPaletteActions = useMemo(
     () =>
       buildDefaultActions({
@@ -723,8 +726,9 @@ export const WorkspaceShell: React.FC<WorkspaceShellProps> = ({
         onQualityCheck: () => {
           void handleTrackedQualityCheck();
         },
+        isDiagramVisible: (type) => isDiagramVisible(type, enabledPerspectives),
       }),
-    [handleSwitchUml, handleSwitchDiagramType, handleSafeNavigate, onExportProject, handleTrackedQualityCheck],
+    [handleSwitchUml, handleSwitchDiagramType, handleSafeNavigate, onExportProject, handleTrackedQualityCheck, enabledPerspectives],
   );
 
   return (

--- a/packages/webapp2/src/main/app/shell/WorkspaceSidebar.tsx
+++ b/packages/webapp2/src/main/app/shell/WorkspaceSidebar.tsx
@@ -4,6 +4,8 @@ import { Separator } from '@/components/ui/separator';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import type { BesserProject, SupportedDiagramType } from '../../shared/types/project';
 import { toSupportedDiagramType } from '../../shared/types/project';
+import { useEnabledPerspectives } from '../../shared/hooks/useEnabledPerspectives';
+import { isDiagramVisible } from '../../shared/perspectives';
 import {
   AGENT_ROUTE_ITEMS,
   NON_UML_EDITOR_ITEMS,
@@ -89,13 +91,23 @@ const WorkspaceSidebarInner: React.FC<WorkspaceSidebarProps> = ({
     return map;
   }, [project]);
 
+  const enabledPerspectives = useEnabledPerspectives();
+  const visibleUmlItems = useMemo(
+    () => UML_ITEMS.filter((item) => isDiagramVisible(toSupportedDiagramType(item.type), enabledPerspectives)),
+    [enabledPerspectives],
+  );
+  const visibleNonUmlItems = useMemo(
+    () => NON_UML_EDITOR_ITEMS.filter((item) => isDiagramVisible(item.type, enabledPerspectives)),
+    [enabledPerspectives],
+  );
+
   const isCollapsed = !isSidebarExpanded;
 
   return (
     <TooltipProvider delayDuration={300}>
       <aside className={`${sidebarBaseClass} animate-slide-in-left ${isSidebarExpanded ? 'w-48' : 'w-[72px]'}`}>
         {isSidebarExpanded && <p className={sidebarTitleClass}>Editors</p>}
-        {UML_ITEMS.map((item) => {
+        {visibleUmlItems.map((item) => {
           const active = locationPath === '/' && !isNonUmlActive && activeUmlType === item.type;
           const isAgentItem = item.type === UMLDiagramType.AgentDiagram;
           const count = countMap[item.type] ?? 0;
@@ -161,7 +173,7 @@ const WorkspaceSidebarInner: React.FC<WorkspaceSidebarProps> = ({
           );
         })}
 
-        {NON_UML_EDITOR_ITEMS.map((item) => {
+        {visibleNonUmlItems.map((item) => {
           const active = locationPath === '/' && activeDiagramType === item.type;
           const count = countMap[item.type] ?? 0;
           const displayLabel = labelWithCount(item.label, count);

--- a/packages/webapp2/src/main/app/shell/menus/MobileNavigation.tsx
+++ b/packages/webapp2/src/main/app/shell/menus/MobileNavigation.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { UMLDiagramType } from '@besser/wme';
 import type { SupportedDiagramType } from '../../../shared/types/project';
+import { toSupportedDiagramType } from '../../../shared/types/project';
+import { useEnabledPerspectives } from '../../../shared/hooks/useEnabledPerspectives';
+import { isDiagramVisible } from '../../../shared/perspectives';
 import { NON_UML_EDITOR_ITEMS, ROUTE_ITEMS, UML_ITEMS, navButtonClass } from '../workspace-navigation';
 
 interface MobileNavigationProps {
@@ -22,9 +25,19 @@ export const MobileNavigation: React.FC<MobileNavigationProps> = ({
   onSwitchDiagramType,
   onNavigate,
 }) => {
+  const enabledPerspectives = useEnabledPerspectives();
+  const visibleUmlItems = useMemo(
+    () => UML_ITEMS.filter((item) => isDiagramVisible(toSupportedDiagramType(item.type), enabledPerspectives)),
+    [enabledPerspectives],
+  );
+  const visibleNonUmlItems = useMemo(
+    () => NON_UML_EDITOR_ITEMS.filter((item) => isDiagramVisible(item.type, enabledPerspectives)),
+    [enabledPerspectives],
+  );
+
   return (
     <div className="mt-3 flex items-center gap-2 overflow-x-auto pb-1 md:hidden">
-      {UML_ITEMS.map((item) => {
+      {visibleUmlItems.map((item) => {
         const active = locationPath === '/' && activeUmlType === item.type;
         return (
           <button
@@ -38,7 +51,7 @@ export const MobileNavigation: React.FC<MobileNavigationProps> = ({
           </button>
         );
       })}
-      {NON_UML_EDITOR_ITEMS.map((item) => {
+      {visibleNonUmlItems.map((item) => {
         const active = locationPath === '/' && activeDiagramType === item.type;
         return (
           <button

--- a/packages/webapp2/src/main/features/project/ProjectHubDialog.tsx
+++ b/packages/webapp2/src/main/features/project/ProjectHubDialog.tsx
@@ -5,6 +5,7 @@ import {
   CalendarDays,
   FileSpreadsheet,
   FolderOpen,
+  Layers3,
   Plus,
   Sparkles,
   Trash2,
@@ -611,6 +612,11 @@ export const ProjectHubDialog: React.FC<ProjectHubDialogProps> = ({ open, onOpen
                   </CardContent>
                 </Card>
               </div>
+
+              <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <Layers3 className="size-3" />
+                Tip: tailor your workspace via modeling perspectives in Settings.
+              </p>
             </div>
           )}
 

--- a/packages/webapp2/src/main/features/project/ProjectSettingsPanel.tsx
+++ b/packages/webapp2/src/main/features/project/ProjectSettingsPanel.tsx
@@ -1,8 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { settingsService, ClassNotation } from '@besser/wme';
+import {
+  settingsService,
+  ClassNotation,
+  ModelingPerspective,
+  EnabledPerspectives,
+} from '@besser/wme';
 import { toast } from 'react-toastify';
-import { Download, FolderKanban, Layers3, Monitor, Settings } from 'lucide-react';
+import { Atom, Bot, Database, Download, FolderKanban, Globe, Layers3, Monitor, Network, Repeat2, Settings, User as UserIcon } from 'lucide-react';
 import { useProject } from '../../app/hooks/useProject';
+import { PERSPECTIVES } from '../../shared/perspectives';
 import { SupportedDiagramType, ProjectDiagram } from '../../shared/types/project';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -26,12 +32,26 @@ const colorByType: Record<SupportedDiagramType, string> = {
   QuantumCircuitDiagram: 'bg-violet-100 text-violet-900 dark:bg-violet-900/30 dark:text-violet-300',
 };
 
+/** Icon shown next to each perspective toggle. */
+const PERSPECTIVE_ICONS: Record<ModelingPerspective, React.ReactNode> = {
+  dataModeling: <Network className="size-4" />,
+  database: <Database className="size-4" />,
+  webApplication: <Globe className="size-4" />,
+  agent: <Bot className="size-4" />,
+  stateMachine: <Repeat2 className="size-4" />,
+  userModeling: <UserIcon className="size-4" />,
+  quantum: <Atom className="size-4" />,
+};
+
 export const ProjectSettingsPanel: React.FC = () => {
   const [isExporting, setIsExporting] = useState(false);
   const [showInstancedObjects, setShowInstancedObjects] = useState(false);
   const [showAssociationNames, setShowAssociationNames] = useState(false);
   const [usePropertiesPanel, setUsePropertiesPanel] = useState(false);
   const [classNotation, setClassNotation] = useState<ClassNotation>('UML');
+  const [enabledPerspectives, setEnabledPerspectives] = useState<EnabledPerspectives>(
+    () => settingsService.getEnabledPerspectives(),
+  );
 
   const { currentProject, loading, error, updateProject, exportProject } = useProject();
 
@@ -40,6 +60,12 @@ export const ProjectSettingsPanel: React.FC = () => {
     setShowAssociationNames(settingsService.shouldShowAssociationNames());
     setUsePropertiesPanel(settingsService.shouldUsePropertiesPanel());
     setClassNotation(settingsService.getClassNotation());
+    setEnabledPerspectives(settingsService.getEnabledPerspectives());
+  }, []);
+
+  const handleTogglePerspective = useCallback((perspective: ModelingPerspective, enabled: boolean) => {
+    settingsService.setPerspectiveEnabled(perspective, enabled);
+    setEnabledPerspectives(settingsService.getEnabledPerspectives());
   }, []);
 
   const diagrams = useMemo(() => {
@@ -276,36 +302,83 @@ export const ProjectSettingsPanel: React.FC = () => {
             </Card>
           </div>
 
-          {/* Right column — Diagrams */}
-          <Card className="h-fit">
-            <CardHeader className="pb-4">
-              <div className="flex items-center gap-2">
-                <Layers3 className="size-4 text-brand" />
-                <CardTitle className="text-base">Diagrams</CardTitle>
-              </div>
-              <CardDescription>
-                {diagrams.length > 0
-                  ? `${diagrams.length} diagram${diagrams.length !== 1 ? 's' : ''} with content`
-                  : 'No diagrams with content yet'}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="flex flex-col gap-2">
-                {diagrams.map(({ type, diagram, index }) => (
-                  <div key={`${type}-${index}`} className="flex items-center justify-between gap-3 rounded-lg border border-border/50 px-4 py-3 transition-colors hover:bg-muted/30">
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-medium">{diagram.title}</p>
-                      <p className="text-xs text-muted-foreground">Updated {new Date(diagram.lastUpdate).toLocaleString()}</p>
+          {/* Right column — Diagrams + Modeling Perspectives */}
+          <div className="flex flex-col gap-6">
+            <Card className="h-fit">
+              <CardHeader className="pb-4">
+                <div className="flex items-center gap-2">
+                  <Layers3 className="size-4 text-brand" />
+                  <CardTitle className="text-base">Diagrams</CardTitle>
+                </div>
+                <CardDescription>
+                  {diagrams.length > 0
+                    ? `${diagrams.length} diagram${diagrams.length !== 1 ? 's' : ''} with content`
+                    : 'No diagrams with content yet'}
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex flex-col gap-2">
+                  {diagrams.map(({ type, diagram, index }) => (
+                    <div key={`${type}-${index}`} className="flex items-center justify-between gap-3 rounded-lg border border-border/50 px-4 py-3 transition-colors hover:bg-muted/30">
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-medium">{diagram.title}</p>
+                        <p className="text-xs text-muted-foreground">Updated {new Date(diagram.lastUpdate).toLocaleString()}</p>
+                      </div>
+                      <Badge className={colorByType[type]}>{type.replace('Diagram', '')}</Badge>
                     </div>
-                    <Badge className={colorByType[type]}>{type.replace('Diagram', '')}</Badge>
-                  </div>
-                ))}
-                {diagrams.length === 0 && (
-                  <p className="py-6 text-center text-sm text-muted-foreground">Start editing a diagram to see it here</p>
-                )}
-              </div>
-            </CardContent>
-          </Card>
+                  ))}
+                  {diagrams.length === 0 && (
+                    <p className="py-6 text-center text-sm text-muted-foreground">Start editing a diagram to see it here</p>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Modeling Perspectives */}
+            <Card>
+              <CardHeader className="pb-4">
+                <div className="flex items-center gap-2">
+                  <Layers3 className="size-4 text-brand" />
+                  <CardTitle className="text-base">Modeling Perspectives</CardTitle>
+                </div>
+                <CardDescription>
+                  Pick the kinds of modeling you care about. Each perspective declares the diagrams relevant to that
+                  use case; disabling a perspective hides those diagrams from the sidebar and command palette.
+                  Diagrams shared by several perspectives stay visible as long as at least one of those perspectives is
+                  enabled. Code generators remain unfiltered — every generator that fits your active diagram is always
+                  reachable from the Generate menu.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex flex-col gap-1">
+                {PERSPECTIVES.map((perspective, idx) => {
+                  const isEnabled = enabledPerspectives[perspective.key] !== false;
+                  return (
+                    <React.Fragment key={perspective.key}>
+                      {idx > 0 && <Separator />}
+                      <label className="flex cursor-pointer items-center justify-between gap-4 rounded-lg px-1 py-3 transition-colors hover:bg-muted/30">
+                        <div className="flex items-center gap-3">
+                          <span className="flex size-7 items-center justify-center rounded-md bg-muted text-muted-foreground">
+                            {PERSPECTIVE_ICONS[perspective.key]}
+                          </span>
+                          <div>
+                            <p className="text-sm font-medium">{perspective.label}</p>
+                            <p className="text-xs text-muted-foreground">{perspective.description}</p>
+                          </div>
+                        </div>
+                        <input
+                          type="checkbox"
+                          className="size-4 accent-brand"
+                          checked={isEnabled}
+                          onChange={(event) => handleTogglePerspective(perspective.key, event.target.checked)}
+                          aria-label={`${perspective.label} perspective`}
+                        />
+                      </label>
+                    </React.Fragment>
+                  );
+                })}
+              </CardContent>
+            </Card>
+          </div>
 
         </div>
       </div>

--- a/packages/webapp2/src/main/features/project/__tests__/ProjectSettingsPanel.test.tsx
+++ b/packages/webapp2/src/main/features/project/__tests__/ProjectSettingsPanel.test.tsx
@@ -24,6 +24,17 @@ vi.mock('@besser/wme', async (importOriginal) => {
       shouldShowInstancedObjects: vi.fn(() => false),
       shouldShowAssociationNames: vi.fn(() => false),
       shouldUsePropertiesPanel: vi.fn(() => false),
+      getClassNotation: vi.fn(() => 'UML'),
+      getEnabledPerspectives: vi.fn(() => ({
+        dataModeling: true,
+        database: true,
+        webApplication: true,
+        agent: true,
+        stateMachine: true,
+        userModeling: true,
+        quantum: true,
+      })),
+      setPerspectiveEnabled: vi.fn(),
       updateSetting: vi.fn(),
     },
   };
@@ -156,12 +167,27 @@ describe('ProjectSettingsPanel', () => {
     expect(screen.getByText('Show Association Names')).toBeInTheDocument();
     expect(screen.getByText('Properties Panel')).toBeInTheDocument();
 
-    // All three checkboxes should be present and unchecked by default
+    // 3 display toggles (off by default in this mock) + 7 perspective toggles (on by default)
     const checkboxes = screen.getAllByRole('checkbox');
-    expect(checkboxes).toHaveLength(3);
+    expect(checkboxes).toHaveLength(10);
     expect(checkboxes[0]).not.toBeChecked();
     expect(checkboxes[1]).not.toBeChecked();
     expect(checkboxes[2]).not.toBeChecked();
+  });
+
+  it('renders the Modeling Perspectives card with one toggle per use-case perspective', () => {
+    const project = createDefaultProject('Test', '', 'owner');
+    setupUseProject({ currentProject: project });
+    render(<ProjectSettingsPanel />);
+
+    expect(screen.getByText('Modeling Perspectives')).toBeInTheDocument();
+    expect(screen.getByText('Data Modeling')).toBeInTheDocument();
+    expect(screen.getByText('Database Modeling')).toBeInTheDocument();
+    expect(screen.getByText('Web Applications')).toBeInTheDocument();
+    expect(screen.getByText('Agent Modeling')).toBeInTheDocument();
+    expect(screen.getByText('State Machines')).toBeInTheDocument();
+    expect(screen.getByText('User Modeling')).toBeInTheDocument();
+    expect(screen.getByText('Quantum Computing')).toBeInTheDocument();
   });
 
   it('renders project name in the input field', () => {

--- a/packages/webapp2/src/main/shared/components/command-palette/CommandPalette.tsx
+++ b/packages/webapp2/src/main/shared/components/command-palette/CommandPalette.tsx
@@ -299,6 +299,19 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onOpenChan
 
 const ICON_SIZE = 'size-4';
 
+/**
+ * Diagram-type tokens used to gate the "Switch to …" entries. The strings
+ * intentionally mirror `SupportedDiagramType` from the webapp project so
+ * callers can pass a single predicate driven by the perspective settings.
+ */
+type SwitchableDiagramType =
+  | 'ClassDiagram'
+  | 'ObjectDiagram'
+  | 'StateMachineDiagram'
+  | 'AgentDiagram'
+  | 'GUINoCodeDiagram'
+  | 'QuantumCircuitDiagram';
+
 interface BuildActionsOptions {
   onSwitchToClassDiagram: () => void;
   onSwitchToStateMachine: () => void;
@@ -310,6 +323,12 @@ interface BuildActionsOptions {
   onExportJSON: () => void;
   onExportBUML: () => void;
   onQualityCheck: () => void;
+  /**
+   * Predicate driven by the modeling-perspective settings. When omitted, all
+   * editor switch actions are shown. When provided, an action is included
+   * only if the predicate returns `true` for its diagram type.
+   */
+  isDiagramVisible?: (type: SwitchableDiagramType) => boolean;
 }
 
 /**
@@ -317,50 +336,77 @@ interface BuildActionsOptions {
  * Kept as a factory so the host component can supply its own callbacks.
  */
 export function buildDefaultActions(opts: BuildActionsOptions): CommandAction[] {
+  const allowDiagram = opts.isDiagramVisible ?? (() => true);
+
+  const candidateEditorActions: Array<{ type: SwitchableDiagramType; action: CommandAction }> = [
+    {
+      type: 'ClassDiagram',
+      action: {
+        id: 'switch-class',
+        label: 'Switch to Class Diagram',
+        icon: <Network className={ICON_SIZE} />,
+        category: 'Editors',
+        onSelect: opts.onSwitchToClassDiagram,
+      },
+    },
+    {
+      type: 'StateMachineDiagram',
+      action: {
+        id: 'switch-state',
+        label: 'Switch to State Machine',
+        icon: <Repeat2 className={ICON_SIZE} />,
+        category: 'Editors',
+        onSelect: opts.onSwitchToStateMachine,
+      },
+    },
+    {
+      type: 'ObjectDiagram',
+      action: {
+        id: 'switch-object',
+        label: 'Switch to Object Diagram',
+        icon: <Layers3 className={ICON_SIZE} />,
+        category: 'Editors',
+        onSelect: opts.onSwitchToObjectDiagram,
+      },
+    },
+    {
+      type: 'GUINoCodeDiagram',
+      action: {
+        id: 'switch-gui',
+        label: 'Switch to GUI Editor',
+        icon: <PackageOpen className={ICON_SIZE} />,
+        category: 'Editors',
+        onSelect: opts.onSwitchToGUIEditor,
+      },
+    },
+    {
+      type: 'AgentDiagram',
+      action: {
+        id: 'switch-agent',
+        label: 'Switch to Agent Diagram',
+        icon: <Bot className={ICON_SIZE} />,
+        category: 'Editors',
+        onSelect: opts.onSwitchToAgentDiagram,
+      },
+    },
+    {
+      type: 'QuantumCircuitDiagram',
+      action: {
+        id: 'switch-quantum',
+        label: 'Switch to Quantum Circuit',
+        icon: <Atom className={ICON_SIZE} />,
+        category: 'Editors',
+        onSelect: opts.onSwitchToQuantumCircuit,
+      },
+    },
+  ];
+
+  const editorActions = candidateEditorActions
+    .filter(({ type }) => allowDiagram(type))
+    .map(({ action }) => action);
+
   return [
-    // ── Editors ─────────────────────────────────────────────────────
-    {
-      id: 'switch-class',
-      label: 'Switch to Class Diagram',
-      icon: <Network className={ICON_SIZE} />,
-      category: 'Editors',
-      onSelect: opts.onSwitchToClassDiagram,
-    },
-    {
-      id: 'switch-state',
-      label: 'Switch to State Machine',
-      icon: <Repeat2 className={ICON_SIZE} />,
-      category: 'Editors',
-      onSelect: opts.onSwitchToStateMachine,
-    },
-    {
-      id: 'switch-object',
-      label: 'Switch to Object Diagram',
-      icon: <Layers3 className={ICON_SIZE} />,
-      category: 'Editors',
-      onSelect: opts.onSwitchToObjectDiagram,
-    },
-    {
-      id: 'switch-gui',
-      label: 'Switch to GUI Editor',
-      icon: <PackageOpen className={ICON_SIZE} />,
-      category: 'Editors',
-      onSelect: opts.onSwitchToGUIEditor,
-    },
-    {
-      id: 'switch-agent',
-      label: 'Switch to Agent Diagram',
-      icon: <Bot className={ICON_SIZE} />,
-      category: 'Editors',
-      onSelect: opts.onSwitchToAgentDiagram,
-    },
-    {
-      id: 'switch-quantum',
-      label: 'Switch to Quantum Circuit',
-      icon: <Atom className={ICON_SIZE} />,
-      category: 'Editors',
-      onSelect: opts.onSwitchToQuantumCircuit,
-    },
+    ...editorActions,
     // ── Navigation ──────────────────────────────────────────────────
     {
       id: 'go-settings',

--- a/packages/webapp2/src/main/shared/hooks/useEnabledPerspectives.ts
+++ b/packages/webapp2/src/main/shared/hooks/useEnabledPerspectives.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { settingsService, EnabledPerspectives } from '@besser/wme';
+
+/**
+ * Subscribe to the global modeling-perspective toggles. The returned map
+ * lists which use-case perspectives are enabled (web application, agent,
+ * state machine, user modeling, quantum). The data-modeling perspective
+ * (Class + Object diagrams plus database, OOP, and schema generators) is
+ * always enabled and is not part of this map.
+ *
+ * Use the helpers in `shared/perspectives.ts` (`isDiagramVisible`,
+ * `isGeneratorVisible`) to translate this map into actual UI visibility.
+ */
+export function useEnabledPerspectives(): EnabledPerspectives {
+  const [perspectives, setPerspectives] = useState<EnabledPerspectives>(() => settingsService.getEnabledPerspectives());
+
+  useEffect(() => {
+    const unsubscribe = settingsService.onSettingsChange((settings) => {
+      setPerspectives({ ...settings.enabledPerspectives });
+    });
+    return unsubscribe;
+  }, []);
+
+  return perspectives;
+}

--- a/packages/webapp2/src/main/shared/perspectives.ts
+++ b/packages/webapp2/src/main/shared/perspectives.ts
@@ -1,0 +1,85 @@
+import { ModelingPerspective } from '@besser/wme';
+import type { SupportedDiagramType } from './types/project';
+
+/**
+ * Frontend-side definition of a modeling perspective.
+ *
+ * Each perspective declares the diagram types relevant to that kind of
+ * project. A diagram is visible in the sidebar / mobile nav / command
+ * palette whenever at least one **enabled** perspective lists it — so
+ * perspectives may freely share entries (e.g. ClassDiagram appears in
+ * `dataModeling`, `database`, `webApplication`, and `stateMachine`;
+ * AgentDiagram appears in `agent`, `webApplication`, and `userModeling`).
+ *
+ * Generators are intentionally **not** filtered by perspective. The
+ * Generate menu only narrows entries by the currently active diagram
+ * type — once a user is on a given diagram, all of its supported
+ * generators stay reachable regardless of perspective settings.
+ */
+export interface PerspectiveDefinition {
+  key: ModelingPerspective;
+  label: string;
+  description: string;
+  diagrams: SupportedDiagramType[];
+}
+
+/**
+ * The perspectives users can toggle. Order is the order shown in settings.
+ */
+export const PERSPECTIVES: PerspectiveDefinition[] = [
+  {
+    key: 'dataModeling',
+    label: 'Data Modeling',
+    description: 'Model your domain with class and object diagrams (Python, Java, Pydantic, JSON Schema, Smart Data Models)',
+    diagrams: ['ClassDiagram', 'ObjectDiagram'],
+  },
+  {
+    key: 'database',
+    label: 'Database Modeling',
+    description: 'Class diagrams for SQL DDL and SQLAlchemy schema generation',
+    diagrams: ['ClassDiagram'],
+  },
+  {
+    key: 'webApplication',
+    label: 'Web Applications',
+    description: 'Class diagrams plus a no-code GUI and an optional agent for full-stack web apps (Django, FastAPI, React)',
+    diagrams: ['ClassDiagram', 'GUINoCodeDiagram', 'AgentDiagram'],
+  },
+  {
+    key: 'agent',
+    label: 'Agent Modeling',
+    description: 'Design conversational agents (BESSER Agent Framework)',
+    diagrams: ['AgentDiagram'],
+  },
+  {
+    key: 'stateMachine',
+    label: 'State Machines',
+    description: 'Model behaviour as state machines used inside class methods',
+    diagrams: ['ClassDiagram', 'StateMachineDiagram'],
+  },
+  {
+    key: 'userModeling',
+    label: 'User Modeling',
+    description: 'User diagrams plus agents for educational/learner scenarios',
+    diagrams: ['UserDiagram', 'AgentDiagram'],
+  },
+  {
+    key: 'quantum',
+    label: 'Quantum Computing',
+    description: 'Quantum circuits for Qiskit code generation',
+    diagrams: ['QuantumCircuitDiagram'],
+  },
+];
+
+/**
+ * Whether a diagram type is currently visible: any **enabled** perspective
+ * lists it.
+ */
+export function isDiagramVisible(
+  type: SupportedDiagramType,
+  enabled: Partial<Record<ModelingPerspective, boolean>>,
+): boolean {
+  return PERSPECTIVES.some(
+    (p) => enabled[p.key] !== false && p.diagrams.includes(type),
+  );
+}


### PR DESCRIPTION
## Summary

Implements [BESSER-PEARL/BESSER#519](https://github.com/BESSER-PEARL/BESSER/issues/519) — let users hide modeling perspectives they don't care about so the workspace stays focused on what they're modeling.

A new **Modeling Perspectives** card in *Project Settings* exposes seven use-case toggles. Each perspective declares the diagrams that matter for that kind of project; a diagram is visible whenever at least one **enabled** perspective lists it. Generators are intentionally **not** filtered — every generator that fits the active diagram remains reachable in the Generate menu.

| Perspective         | Diagrams visible when enabled |
|---------------------|-------------------------------|
| Data Modeling       | Class, Object                 |
| Database Modeling   | Class                         |
| Web Applications    | Class, GUI, Agent             |
| Agent Modeling      | Agent                         |
| State Machines      | Class, StateMachine           |
| User Modeling       | User, Agent                   |
| Quantum Computing   | Quantum                       |

All toggles are on by default, persisted globally via `settingsService` (`besser-standalone-settings` localStorage key), and are reflected live in the sidebar, mobile nav, and command palette.

## Architecture

- `packages/editor/.../settings-service.ts` — `ModelingPerspective` + `EnabledPerspectives` types, default-on map, `getEnabledPerspectives` / `isPerspectiveEnabled` / `setPerspectiveEnabled` helpers; `loadSettings` drops legacy perspective keys defensively.
- `webapp2/src/main/shared/perspectives.ts` — single source of truth (`PERSPECTIVES`, `PerspectiveDefinition`, `isDiagramVisible`). The visibility helper iterates over enabled perspectives and OR-merges their diagrams.
- `webapp2/src/main/shared/hooks/useEnabledPerspectives.ts` — subscribes to `settingsService.onSettingsChange` so consumers re-render live.
- `WorkspaceSidebar` + `MobileNavigation` — UML and non-UML editor entries pass through `isDiagramVisible`.
- `CommandPalette` — `buildDefaultActions` takes an `isDiagramVisible` predicate; switch actions are filtered by it.
- `ProjectSettingsPanel` — new card on the right column, under Diagrams.
- `ProjectHubDialog` — subtle one-liner under the Create form pointing users to Settings.

## Test plan

- [x] `npm test -- --run ProjectSettingsPanel` — 15/15 pass (mocks updated for the new settings methods, new assertion that all seven toggles render)
- [x] `npm test -- --run WorkspaceSidebar` — 16/16 pass
- [x] `npx tsc --noEmit` — clean for every touched file
- [ ] Manual smoke: open Project Settings, toggle off Quantum + State Machines + User → those entries disappear from the sidebar and command palette, Generate menu unchanged
- [ ] Manual smoke: re-enable from Settings → entries reappear without page reload