### PR TITLE
Toggle modeling perspectives

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2252,7 +2252,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2269,7 +2268,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2286,7 +2284,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2303,7 +2300,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2320,7 +2316,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2337,7 +2332,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2354,7 +2348,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2371,7 +2364,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2388,7 +2380,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2405,7 +2396,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2422,7 +2412,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2439,7 +2428,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2456,7 +2444,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2473,7 +2460,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2490,7 +2476,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2507,7 +2492,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2524,7 +2508,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2541,7 +2524,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2558,7 +2540,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2575,7 +2556,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2592,7 +2572,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2609,7 +2588,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2626,7 +2604,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2643,7 +2620,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2660,7 +2636,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2677,7 +2652,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/packages/webapp2/src/main/app/shell/WorkspaceShell.tsx
+++ b/packages/webapp2/src/main/app/shell/WorkspaceShell.tsx
@@ -25,6 +25,7 @@ import type { GenerationResult } from '../../features/generation/types';
 import { JsonViewerModal } from '../../shared/components/json-viewer-modal/json-viewer-modal';
 import { WorkspaceTopBar } from './WorkspaceTopBar';
 import { DiagramTabs } from '../../features/editors/diagram-tabs/DiagramTabs';
+import { HiddenPerspectivesBanner } from '../../features/editors/HiddenPerspectivesBanner';
 import { WorkspaceSidebar } from './WorkspaceSidebar';
 import { AboutDialog } from '../../shared/dialogs/AboutDialog';
 import { AssistantImportDialog } from '../../features/assistant/components/AssistantImportDialog';
@@ -873,6 +874,7 @@ export const WorkspaceShell: React.FC<WorkspaceShellProps> = ({
         />
 
         <main className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+          {location.pathname === '/' && <HiddenPerspectivesBanner />}
           {location.pathname === '/' && (
             <DiagramTabs
               onRequestTabSwitch={handleRequestTabSwitch}

--- a/packages/webapp2/src/main/app/shell/WorkspaceSidebar.tsx
+++ b/packages/webapp2/src/main/app/shell/WorkspaceSidebar.tsx
@@ -3,7 +3,7 @@ import { UMLDiagramType } from '@besser/wme';
 import { Separator } from '@/components/ui/separator';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import type { BesserProject, SupportedDiagramType } from '../../shared/types/project';
-import { toSupportedDiagramType } from '../../shared/types/project';
+import { isPerspectiveVisible, toSupportedDiagramType } from '../../shared/types/project';
 import {
   AGENT_ROUTE_ITEMS,
   NON_UML_EDITOR_ITEMS,
@@ -89,13 +89,25 @@ const WorkspaceSidebarInner: React.FC<WorkspaceSidebarProps> = ({
     return map;
   }, [project]);
 
+  // Filter the static perspective lists by the per-project `perspectives` setting.
+  // Hidden perspectives are removed from the sidebar entirely; their data is preserved.
+  const perspectives = project?.settings?.perspectives;
+  const visibleUmlItems = useMemo(
+    () => UML_ITEMS.filter((it) => isPerspectiveVisible(perspectives, toSupportedDiagramType(it.type))),
+    [perspectives],
+  );
+  const visibleNonUmlItems = useMemo(
+    () => NON_UML_EDITOR_ITEMS.filter((it) => isPerspectiveVisible(perspectives, it.type)),
+    [perspectives],
+  );
+
   const isCollapsed = !isSidebarExpanded;
 
   return (
     <TooltipProvider delayDuration={300}>
       <aside className={`${sidebarBaseClass} animate-slide-in-left ${isSidebarExpanded ? 'w-48' : 'w-[72px]'}`}>
         {isSidebarExpanded && <p className={sidebarTitleClass}>Editors</p>}
-        {UML_ITEMS.map((item) => {
+        {visibleUmlItems.map((item) => {
           const active = locationPath === '/' && !isNonUmlActive && activeUmlType === item.type;
           const isAgentItem = item.type === UMLDiagramType.AgentDiagram;
           const count = countMap[item.type] ?? 0;
@@ -161,7 +173,7 @@ const WorkspaceSidebarInner: React.FC<WorkspaceSidebarProps> = ({
           );
         })}
 
-        {NON_UML_EDITOR_ITEMS.map((item) => {
+        {visibleNonUmlItems.map((item) => {
           const active = locationPath === '/' && activeDiagramType === item.type;
           const count = countMap[item.type] ?? 0;
           const displayLabel = labelWithCount(item.label, count);

--- a/packages/webapp2/src/main/app/shell/__tests__/WorkspaceSidebar.test.tsx
+++ b/packages/webapp2/src/main/app/shell/__tests__/WorkspaceSidebar.test.tsx
@@ -200,4 +200,35 @@ describe('WorkspaceSidebar', () => {
     expect(screen.getByText('Class')).toBeInTheDocument();
     expect(screen.getByText('Settings')).toBeInTheDocument();
   });
+
+  it('hides UML perspectives that are disabled in project settings', () => {
+    const project = createDefaultProject('Test', '', 'owner');
+    project.settings.perspectives.ClassDiagram = false;
+    project.settings.perspectives.AgentDiagram = false;
+
+    render(<WorkspaceSidebar {...defaultProps({ project })} />);
+
+    expect(screen.queryByText('Class')).not.toBeInTheDocument();
+    expect(screen.queryByText('Agent')).not.toBeInTheDocument();
+    // Other perspectives still render
+    expect(screen.getByText('Object')).toBeInTheDocument();
+    expect(screen.getByText('State')).toBeInTheDocument();
+    expect(screen.getByText('User')).toBeInTheDocument();
+    expect(screen.getByText('GUI')).toBeInTheDocument();
+    expect(screen.getByText('Quantum')).toBeInTheDocument();
+    // Settings route always visible
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+  });
+
+  it('hides non-UML perspectives that are disabled in project settings', () => {
+    const project = createDefaultProject('Test', '', 'owner');
+    project.settings.perspectives.GUINoCodeDiagram = false;
+    project.settings.perspectives.QuantumCircuitDiagram = false;
+
+    render(<WorkspaceSidebar {...defaultProps({ project })} />);
+
+    expect(screen.queryByText('GUI')).not.toBeInTheDocument();
+    expect(screen.queryByText('Quantum')).not.toBeInTheDocument();
+    expect(screen.getByText('Class')).toBeInTheDocument();
+  });
 });

--- a/packages/webapp2/src/main/app/shell/menus/MobileNavigation.tsx
+++ b/packages/webapp2/src/main/app/shell/menus/MobileNavigation.tsx
@@ -1,7 +1,10 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { UMLDiagramType } from '@besser/wme';
 import type { SupportedDiagramType } from '../../../shared/types/project';
+import { isPerspectiveVisible, toSupportedDiagramType } from '../../../shared/types/project';
 import { NON_UML_EDITOR_ITEMS, ROUTE_ITEMS, UML_ITEMS, navButtonClass } from '../workspace-navigation';
+import { useAppSelector } from '../../store/hooks';
+import { selectPerspectives } from '../../store/workspaceSlice';
 
 interface MobileNavigationProps {
   locationPath: string;
@@ -22,9 +25,19 @@ export const MobileNavigation: React.FC<MobileNavigationProps> = ({
   onSwitchDiagramType,
   onNavigate,
 }) => {
+  const perspectives = useAppSelector(selectPerspectives);
+  const visibleUmlItems = useMemo(
+    () => UML_ITEMS.filter((it) => isPerspectiveVisible(perspectives, toSupportedDiagramType(it.type))),
+    [perspectives],
+  );
+  const visibleNonUmlItems = useMemo(
+    () => NON_UML_EDITOR_ITEMS.filter((it) => isPerspectiveVisible(perspectives, it.type)),
+    [perspectives],
+  );
+
   return (
     <div className="mt-3 flex items-center gap-2 overflow-x-auto pb-1 md:hidden">
-      {UML_ITEMS.map((item) => {
+      {visibleUmlItems.map((item) => {
         const active = locationPath === '/' && activeUmlType === item.type;
         return (
           <button
@@ -38,7 +51,7 @@ export const MobileNavigation: React.FC<MobileNavigationProps> = ({
           </button>
         );
       })}
-      {NON_UML_EDITOR_ITEMS.map((item) => {
+      {visibleNonUmlItems.map((item) => {
         const active = locationPath === '/' && activeDiagramType === item.type;
         return (
           <button

--- a/packages/webapp2/src/main/app/store/workspaceSlice.ts
+++ b/packages/webapp2/src/main/app/store/workspaceSlice.ts
@@ -1,11 +1,15 @@
 import { createSlice, PayloadAction, createAsyncThunk, createSelector } from '@reduxjs/toolkit';
 import { ApollonMode, Locale, Styles, UMLDiagramType, UMLModel } from '@besser/wme';
 import {
+  ALL_DIAGRAM_TYPES,
   BesserProject,
   MAX_DIAGRAMS_PER_TYPE,
+  PerspectiveSettings,
   ProjectDiagram,
   SupportedDiagramType,
   QuantumCircuitData,
+  defaultPerspectivesAllEnabled,
+  isPerspectiveVisible,
   isUMLModel,
   toSupportedDiagramType,
   toUMLDiagramType,
@@ -302,6 +306,71 @@ export const updateDiagramReferencesThunk = createAsyncThunk(
     if (!success) throw new Error('Failed to update diagram references');
 
     return { diagramType, diagramIndex, references };
+  },
+);
+
+/**
+ * Toggle a single modeling perspective (e.g. ClassDiagram, GUINoCodeDiagram)
+ * on or off for the active project.
+ *
+ * Behavior:
+ *  - Last-enabled guard: refuses to disable the only remaining enabled
+ *    perspective (the workspace would have nothing to show).
+ *  - Active-hidden auto-switch: if the toggled-off perspective is the
+ *    `currentDiagramType`, dispatches `switchDiagramTypeThunk` to the first
+ *    perspective still enabled (in `ALL_DIAGRAM_TYPES` order) so the editor
+ *    lands on a working canvas.
+ *  - Persists the updated project via `ProjectStorageRepository` inside
+ *    `withoutNotify` to avoid the storage-listener loop.
+ */
+export const setPerspectiveEnabledThunk = createAsyncThunk(
+  'workspace/setPerspectiveEnabled',
+  async (
+    { type, enabled }: { type: SupportedDiagramType; enabled: boolean },
+    { getState, dispatch },
+  ) => {
+    const state = getState() as { workspace: WorkspaceState };
+    const { project } = state.workspace;
+    if (!project) throw new Error('No active project');
+
+    const current = defaultPerspectivesAllEnabled(project.settings?.perspectives);
+    if (current[type] === enabled) {
+      // No-op: already in the desired state.
+      return { type, enabled, perspectives: current, autoSwitchTo: null as SupportedDiagramType | null };
+    }
+
+    if (!enabled) {
+      const enabledCount = ALL_DIAGRAM_TYPES.filter((t) => current[t] !== false).length;
+      if (enabledCount <= 1) {
+        throw new Error('At least one perspective must be enabled');
+      }
+    }
+
+    const next: PerspectiveSettings = { ...current, [type]: enabled };
+
+    const updatedProject: BesserProject = {
+      ...project,
+      settings: {
+        ...project.settings,
+        perspectives: next,
+      },
+    };
+
+    ProjectStorageRepository.withoutNotify(() => {
+      ProjectStorageRepository.saveProject(updatedProject);
+    });
+
+    let autoSwitchTo: SupportedDiagramType | null = null;
+    if (!enabled && project.currentDiagramType === type) {
+      autoSwitchTo = ALL_DIAGRAM_TYPES.find((t) => next[t] !== false) ?? null;
+    }
+
+    if (autoSwitchTo) {
+      // Fire-and-forget: the switch thunk handles its own state updates.
+      void dispatch(switchDiagramTypeThunk({ diagramType: autoSwitchTo }));
+    }
+
+    return { type, enabled, perspectives: next, autoSwitchTo };
   },
 );
 
@@ -628,6 +697,20 @@ const workspaceSlice = createSlice({
         state.error = action.error.message || 'Failed to update diagram references';
       })
 
+      // ── Toggle perspective visibility (view-only, no revision bump) ──
+      .addCase(setPerspectiveEnabledThunk.fulfilled, (state, action) => {
+        const { perspectives } = action.payload;
+        if (state.project) {
+          state.project.settings = {
+            ...state.project.settings,
+            perspectives,
+          };
+        }
+      })
+      .addCase(setPerspectiveEnabledThunk.rejected, (state, action) => {
+        state.error = action.error.message || 'Failed to update perspective';
+      })
+
       // ── Refresh project from storage (no revision bump) ─────
       .addCase(refreshProjectStateThunk.fulfilled, (state, action) => {
         if (!action.payload) return;
@@ -744,4 +827,14 @@ export const selectIsGUIEditor = createSelector(
 export const selectIsQuantumEditor = createSelector(
   selectActiveDiagramType,
   (activeDiagramType) => activeDiagramType === 'QuantumCircuitDiagram',
+);
+
+export const selectPerspectives = createSelector(
+  selectProject,
+  (project) => project?.settings?.perspectives,
+);
+
+export const selectVisiblePerspectives = createSelector(
+  selectPerspectives,
+  (perspectives) => ALL_DIAGRAM_TYPES.filter((t) => isPerspectiveVisible(perspectives, t)),
 );

--- a/packages/webapp2/src/main/features/editors/HiddenPerspectivesBanner.tsx
+++ b/packages/webapp2/src/main/features/editors/HiddenPerspectivesBanner.tsx
@@ -1,0 +1,61 @@
+import React, { useMemo } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { findHiddenReferencedPerspectives, SupportedDiagramType } from '../../shared/types/project';
+import { PERSPECTIVE_LABELS } from '../../shared/constants/diagramTypeStyles';
+import { useAppDispatch, useAppSelector } from '../../app/store/hooks';
+import { selectProject, setPerspectiveEnabledThunk } from '../../app/store/workspaceSlice';
+
+/**
+ * Non-blocking banner that surfaces when the active project contains content
+ * (or cross-diagram references) that points at a perspective the user has hidden
+ * in Project Settings. Each affected perspective gets an inline "Enable" button.
+ *
+ * Renders nothing when no hidden-but-referenced perspective is detected.
+ */
+export const HiddenPerspectivesBanner: React.FC = () => {
+  const project = useAppSelector(selectProject);
+  const dispatch = useAppDispatch();
+
+  const hidden = useMemo(
+    () => (project ? findHiddenReferencedPerspectives(project) : []),
+    [project],
+  );
+
+  if (hidden.length === 0) return null;
+
+  const handleEnable = (type: SupportedDiagramType) => {
+    void dispatch(setPerspectiveEnabledThunk({ type, enabled: true }));
+  };
+
+  const labelList = hidden.map((t) => PERSPECTIVE_LABELS[t]).join(', ');
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="hidden-perspectives-banner"
+      className="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-amber-300 bg-amber-50 px-4 py-2 text-xs text-amber-900 dark:border-amber-800/60 dark:bg-amber-900/20 dark:text-amber-200"
+    >
+      <span className="flex items-center gap-2">
+        <AlertTriangle className="size-4 shrink-0" />
+        <span>
+          This project uses <span className="font-medium">{labelList}</span> but{' '}
+          {hidden.length === 1 ? 'that perspective is' : 'those perspectives are'} hidden.
+        </span>
+      </span>
+      <span className="flex flex-wrap items-center gap-2">
+        {hidden.map((type) => (
+          <button
+            key={type}
+            type="button"
+            onClick={() => handleEnable(type)}
+            data-testid={`enable-perspective-${type}`}
+            className="inline-flex items-center rounded-md border border-amber-400 bg-white px-2 py-1 text-xs font-medium text-amber-900 transition-colors hover:bg-amber-100 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-100 dark:hover:bg-amber-900/40"
+          >
+            Enable {PERSPECTIVE_LABELS[type]}
+          </button>
+        ))}
+      </span>
+    </div>
+  );
+};

--- a/packages/webapp2/src/main/features/editors/__tests__/HiddenPerspectivesBanner.test.tsx
+++ b/packages/webapp2/src/main/features/editors/__tests__/HiddenPerspectivesBanner.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { UMLDiagramType, type UMLModel } from '@besser/wme';
+import { HiddenPerspectivesBanner } from '../HiddenPerspectivesBanner';
+import { createDefaultProject } from '../../../shared/types/project';
+import type { BesserProject } from '../../../shared/types/project';
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+
+const mockDispatch = vi.fn(() => Promise.resolve());
+
+let mockState: { workspace: { project: BesserProject | null } };
+
+vi.mock('../../../app/store/hooks', () => ({
+  useAppDispatch: () => mockDispatch,
+  useAppSelector: (selector: any) => selector(mockState),
+}));
+
+const setPerspectiveEnabledThunkSpy = vi.fn((payload: any) => ({
+  type: 'setPerspectiveEnabled',
+  payload,
+}));
+
+vi.mock('../../../app/store/workspaceSlice', () => ({
+  selectProject: (state: any) => state.workspace.project,
+  setPerspectiveEnabledThunk: (payload: any) => setPerspectiveEnabledThunkSpy(payload),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function populatedClassModel(): UMLModel {
+  return {
+    version: '3.0.0',
+    type: UMLDiagramType.ClassDiagram,
+    size: { width: 1400, height: 740 },
+    elements: { 'c-1': { id: 'c-1' } as any },
+    relationships: {},
+    interactive: { elements: {}, relationships: {} },
+    assessments: {},
+  };
+}
+
+beforeEach(() => {
+  mockDispatch.mockClear();
+  setPerspectiveEnabledThunkSpy.mockClear();
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('HiddenPerspectivesBanner', () => {
+  it('renders nothing when no project is loaded', () => {
+    mockState = { workspace: { project: null } };
+    const { container } = render(<HiddenPerspectivesBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when no perspective is hidden', () => {
+    mockState = { workspace: { project: createDefaultProject('Clean', '', 'me') } };
+    const { container } = render(<HiddenPerspectivesBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when a perspective is hidden but its diagrams are empty', () => {
+    const project = createDefaultProject('Empty', '', 'me');
+    project.settings.perspectives.AgentDiagram = false;
+    mockState = { workspace: { project } };
+
+    const { container } = render(<HiddenPerspectivesBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders an Enable button per hidden referenced perspective', () => {
+    const project = createDefaultProject('Refs', '', 'me');
+    project.settings.perspectives.ClassDiagram = false;
+    project.diagrams.ClassDiagram[0].model = populatedClassModel();
+    project.diagrams.GUINoCodeDiagram[0].references = {
+      ClassDiagram: project.diagrams.ClassDiagram[0].id,
+    };
+    mockState = { workspace: { project } };
+
+    render(<HiddenPerspectivesBanner />);
+    expect(screen.getByTestId('hidden-perspectives-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('enable-perspective-ClassDiagram')).toBeInTheDocument();
+  });
+
+  it('dispatches setPerspectiveEnabledThunk with enabled:true when Enable is clicked', () => {
+    const project = createDefaultProject('Refs', '', 'me');
+    project.settings.perspectives.ClassDiagram = false;
+    project.diagrams.ClassDiagram[0].model = populatedClassModel();
+    project.diagrams.GUINoCodeDiagram[0].references = {
+      ClassDiagram: project.diagrams.ClassDiagram[0].id,
+    };
+    mockState = { workspace: { project } };
+
+    render(<HiddenPerspectivesBanner />);
+    fireEvent.click(screen.getByTestId('enable-perspective-ClassDiagram'));
+
+    expect(setPerspectiveEnabledThunkSpy).toHaveBeenCalledWith({
+      type: 'ClassDiagram',
+      enabled: true,
+    });
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/webapp2/src/main/features/import/useImportProject.ts
+++ b/packages/webapp2/src/main/features/import/useImportProject.ts
@@ -1,4 +1,12 @@
-import { BesserProject, ProjectDiagram, createEmptyDiagram, SupportedDiagramType, getActiveDiagram } from '../../shared/types/project';
+import {
+  BesserProject,
+  ProjectDiagram,
+  PROJECT_SCHEMA_VERSION,
+  SupportedDiagramType,
+  createDefaultPerspectives,
+  createEmptyDiagram,
+  getActiveDiagram,
+} from '../../shared/types/project';
 import { ProjectStorageRepository } from '../../shared/services/storage/ProjectStorageRepository';
 import { BACKEND_URL } from '../../shared/constants/constant';
 import { UMLDiagramType } from '@besser/wme';
@@ -379,7 +387,7 @@ export async function importProjectFromJson(file: File): Promise<BesserProject> 
           const importedProject: BesserProject = {
             id: newProjectId,
             type: 'Project',
-            schemaVersion: 3,
+            schemaVersion: PROJECT_SCHEMA_VERSION,
             name: jsonData.title || 'Imported Diagram',
             description: '',
             owner: '',
@@ -394,6 +402,7 @@ export async function importProjectFromJson(file: File): Promise<BesserProject> 
               defaultDiagramType: 'ClassDiagram',
               autoSave: true,
               collaborationEnabled: false,
+              perspectives: createDefaultPerspectives(),
             },
           };
 

--- a/packages/webapp2/src/main/features/project/ProjectSettingsPanel.tsx
+++ b/packages/webapp2/src/main/features/project/ProjectSettingsPanel.tsx
@@ -295,6 +295,40 @@ export const ProjectSettingsPanel: React.FC = () => {
               </CardContent>
             </Card>
 
+          </div>
+
+          {/* Right column — Diagrams + Modeling Perspectives */}
+          <div className="flex flex-col gap-6">
+            <Card>
+              <CardHeader className="pb-4">
+                <div className="flex items-center gap-2">
+                  <Layers3 className="size-4 text-brand" />
+                  <CardTitle className="text-base">Diagrams</CardTitle>
+                </div>
+                <CardDescription>
+                  {diagrams.length > 0
+                    ? `${diagrams.length} diagram${diagrams.length !== 1 ? 's' : ''} with content`
+                    : 'No diagrams with content yet'}
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex flex-col gap-2">
+                  {diagrams.map(({ type, diagram, index }) => (
+                    <div key={`${type}-${index}`} className="flex items-center justify-between gap-3 rounded-lg border border-border/50 px-4 py-3 transition-colors hover:bg-muted/30">
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-medium">{diagram.title}</p>
+                        <p className="text-xs text-muted-foreground">Updated {new Date(diagram.lastUpdate).toLocaleString()}</p>
+                      </div>
+                      <Badge className={DIAGRAM_TYPE_BADGE[type]}>{type.replace('Diagram', '')}</Badge>
+                    </div>
+                  ))}
+                  {diagrams.length === 0 && (
+                    <p className="py-6 text-center text-sm text-muted-foreground">Start editing a diagram to see it here</p>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+
             {/* Modeling Perspectives */}
             <Card>
               <CardHeader className="pb-4">
@@ -357,37 +391,6 @@ export const ProjectSettingsPanel: React.FC = () => {
               </CardContent>
             </Card>
           </div>
-
-          {/* Right column — Diagrams */}
-          <Card className="h-fit">
-            <CardHeader className="pb-4">
-              <div className="flex items-center gap-2">
-                <Layers3 className="size-4 text-brand" />
-                <CardTitle className="text-base">Diagrams</CardTitle>
-              </div>
-              <CardDescription>
-                {diagrams.length > 0
-                  ? `${diagrams.length} diagram${diagrams.length !== 1 ? 's' : ''} with content`
-                  : 'No diagrams with content yet'}
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="flex flex-col gap-2">
-                {diagrams.map(({ type, diagram, index }) => (
-                  <div key={`${type}-${index}`} className="flex items-center justify-between gap-3 rounded-lg border border-border/50 px-4 py-3 transition-colors hover:bg-muted/30">
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-medium">{diagram.title}</p>
-                      <p className="text-xs text-muted-foreground">Updated {new Date(diagram.lastUpdate).toLocaleString()}</p>
-                    </div>
-                    <Badge className={DIAGRAM_TYPE_BADGE[type]}>{type.replace('Diagram', '')}</Badge>
-                  </div>
-                ))}
-                {diagrams.length === 0 && (
-                  <p className="py-6 text-center text-sm text-muted-foreground">Start editing a diagram to see it here</p>
-                )}
-              </div>
-            </CardContent>
-          </Card>
 
         </div>
       </div>

--- a/packages/webapp2/src/main/features/project/ProjectSettingsPanel.tsx
+++ b/packages/webapp2/src/main/features/project/ProjectSettingsPanel.tsx
@@ -1,9 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { settingsService, ClassNotation } from '@besser/wme';
 import { toast } from 'react-toastify';
-import { Download, FolderKanban, Layers3, Monitor, Settings } from 'lucide-react';
+import { Download, FolderKanban, Layers3, Monitor, Settings, SlidersHorizontal } from 'lucide-react';
 import { useProject } from '../../app/hooks/useProject';
-import { SupportedDiagramType, ProjectDiagram } from '../../shared/types/project';
+import {
+  ALL_DIAGRAM_TYPES,
+  SupportedDiagramType,
+  ProjectDiagram,
+  isPerspectiveVisible,
+} from '../../shared/types/project';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -15,16 +20,13 @@ import { FormField } from '@/components/ui/form-field';
 import { validateProjectName } from '../../shared/utils/validation';
 import { useFieldValidation } from '../../shared/hooks/useFieldValidation';
 import { diagramHasContent } from '../../shared/types/project';
-
-const colorByType: Record<SupportedDiagramType, string> = {
-  ClassDiagram: 'bg-sky-100 text-sky-900 dark:bg-sky-900/30 dark:text-sky-300',
-  ObjectDiagram: 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-300',
-  StateMachineDiagram: 'bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-300',
-  AgentDiagram: 'bg-fuchsia-100 text-fuchsia-900 dark:bg-fuchsia-900/30 dark:text-fuchsia-300',
-  UserDiagram: 'bg-rose-100 text-rose-900 dark:bg-rose-900/30 dark:text-rose-300',
-  GUINoCodeDiagram: 'bg-indigo-100 text-indigo-900 dark:bg-indigo-900/30 dark:text-indigo-300',
-  QuantumCircuitDiagram: 'bg-violet-100 text-violet-900 dark:bg-violet-900/30 dark:text-violet-300',
-};
+import {
+  DIAGRAM_TYPE_BADGE,
+  PERSPECTIVE_DESCRIPTIONS,
+  PERSPECTIVE_LABELS,
+} from '../../shared/constants/diagramTypeStyles';
+import { useAppDispatch } from '../../app/store/hooks';
+import { setPerspectiveEnabledThunk } from '../../app/store/workspaceSlice';
 
 export const ProjectSettingsPanel: React.FC = () => {
   const [isExporting, setIsExporting] = useState(false);
@@ -34,6 +36,24 @@ export const ProjectSettingsPanel: React.FC = () => {
   const [classNotation, setClassNotation] = useState<ClassNotation>('UML');
 
   const { currentProject, loading, error, updateProject, exportProject } = useProject();
+  const dispatch = useAppDispatch();
+
+  const perspectives = currentProject?.settings?.perspectives;
+  const enabledPerspectiveCount = useMemo(
+    () => ALL_DIAGRAM_TYPES.filter((t) => isPerspectiveVisible(perspectives, t)).length,
+    [perspectives],
+  );
+
+  const handlePerspectiveToggle = useCallback(
+    (type: SupportedDiagramType, enabled: boolean) => {
+      dispatch(setPerspectiveEnabledThunk({ type, enabled }))
+        .unwrap()
+        .catch((err: unknown) => {
+          toast.error(err instanceof Error ? err.message : 'Failed to update perspective');
+        });
+    },
+    [dispatch],
+  );
 
   useEffect(() => {
     setShowInstancedObjects(settingsService.shouldShowInstancedObjects());
@@ -274,6 +294,68 @@ export const ProjectSettingsPanel: React.FC = () => {
                 </div>
               </CardContent>
             </Card>
+
+            {/* Modeling Perspectives */}
+            <Card>
+              <CardHeader className="pb-4">
+                <div className="flex items-center gap-2">
+                  <SlidersHorizontal className="size-4 text-brand" />
+                  <CardTitle className="text-base">Modeling Perspectives</CardTitle>
+                </div>
+                <CardDescription>
+                  Hide perspectives you don't need. Disabled perspectives are removed from the
+                  sidebar; existing models are preserved and restored on re-enable. Generators
+                  remain available regardless.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex flex-col gap-1">
+                {ALL_DIAGRAM_TYPES.map((type, index) => {
+                  const checked = isPerspectiveVisible(perspectives, type);
+                  const isLastEnabled = checked && enabledPerspectiveCount === 1;
+                  const labelId = `perspective-toggle-${type}`;
+                  return (
+                    <React.Fragment key={type}>
+                      {index > 0 && <Separator />}
+                      <label
+                        htmlFor={labelId}
+                        className={`flex items-center justify-between gap-4 rounded-lg px-1 py-3 transition-colors ${
+                          isLastEnabled ? 'cursor-not-allowed opacity-70' : 'cursor-pointer hover:bg-muted/30'
+                        }`}
+                        title={
+                          isLastEnabled
+                            ? 'At least one perspective must be enabled.'
+                            : undefined
+                        }
+                      >
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-2">
+                            <p className="text-sm font-medium">{PERSPECTIVE_LABELS[type]}</p>
+                            <Badge className={DIAGRAM_TYPE_BADGE[type]}>
+                              {type.replace('Diagram', '')}
+                            </Badge>
+                          </div>
+                          <p className="text-xs text-muted-foreground">
+                            {PERSPECTIVE_DESCRIPTIONS[type]}
+                          </p>
+                        </div>
+                        <input
+                          id={labelId}
+                          type="checkbox"
+                          className="size-4 accent-brand"
+                          checked={checked}
+                          disabled={isLastEnabled}
+                          aria-label={`Toggle ${PERSPECTIVE_LABELS[type]} visibility`}
+                          data-testid={`perspective-toggle-${type}`}
+                          onChange={(event) =>
+                            handlePerspectiveToggle(type, event.target.checked)
+                          }
+                        />
+                      </label>
+                    </React.Fragment>
+                  );
+                })}
+              </CardContent>
+            </Card>
           </div>
 
           {/* Right column — Diagrams */}
@@ -297,7 +379,7 @@ export const ProjectSettingsPanel: React.FC = () => {
                       <p className="truncate text-sm font-medium">{diagram.title}</p>
                       <p className="text-xs text-muted-foreground">Updated {new Date(diagram.lastUpdate).toLocaleString()}</p>
                     </div>
-                    <Badge className={colorByType[type]}>{type.replace('Diagram', '')}</Badge>
+                    <Badge className={DIAGRAM_TYPE_BADGE[type]}>{type.replace('Diagram', '')}</Badge>
                   </div>
                 ))}
                 {diagrams.length === 0 && (

--- a/packages/webapp2/src/main/features/project/__tests__/ProjectSettingsPanel.test.tsx
+++ b/packages/webapp2/src/main/features/project/__tests__/ProjectSettingsPanel.test.tsx
@@ -38,6 +38,25 @@ vi.mock('react-toastify', () => ({
   },
 }));
 
+// Mock the Redux dispatch + the perspective thunk so we can assert on dispatch.
+const mockDispatch = vi.fn(() => ({
+  unwrap: () => Promise.resolve(),
+}));
+
+vi.mock('../../../app/store/hooks', () => ({
+  useAppDispatch: () => mockDispatch,
+  useAppSelector: vi.fn(),
+}));
+
+const setPerspectiveEnabledThunkSpy = vi.fn((payload: any) => ({
+  type: 'setPerspectiveEnabled',
+  payload,
+}));
+
+vi.mock('../../../app/store/workspaceSlice', () => ({
+  setPerspectiveEnabledThunk: (payload: any) => setPerspectiveEnabledThunkSpy(payload),
+}));
+
 import { useProject } from '../../../app/hooks/useProject';
 
 const mockUseProject = vi.mocked(useProject);
@@ -156,12 +175,9 @@ describe('ProjectSettingsPanel', () => {
     expect(screen.getByText('Show Association Names')).toBeInTheDocument();
     expect(screen.getByText('Properties Panel')).toBeInTheDocument();
 
-    // All three checkboxes should be present and unchecked by default
+    // Display section has 3 checkboxes; the new Modeling Perspectives section adds 7 more.
     const checkboxes = screen.getAllByRole('checkbox');
-    expect(checkboxes).toHaveLength(3);
-    expect(checkboxes[0]).not.toBeChecked();
-    expect(checkboxes[1]).not.toBeChecked();
-    expect(checkboxes[2]).not.toBeChecked();
+    expect(checkboxes).toHaveLength(10);
   });
 
   it('renders project name in the input field', () => {
@@ -209,6 +225,67 @@ describe('ProjectSettingsPanel', () => {
     expect(screen.getByText('Active Editor')).toBeInTheDocument();
     // currentDiagramType is 'ClassDiagram', which gets 'Diagram' stripped -> 'Class'
     expect(screen.getByText('Class')).toBeInTheDocument();
+  });
+
+  it('renders the Modeling Perspectives card with a checkbox per supported diagram type', () => {
+    const project = createDefaultProject('Test', '', 'owner');
+    setupUseProject({ currentProject: project });
+    render(<ProjectSettingsPanel />);
+
+    expect(screen.getByText('Modeling Perspectives')).toBeInTheDocument();
+    // 7 perspective toggles, all checked by default on a fresh project.
+    expect(screen.getByTestId('perspective-toggle-ClassDiagram')).toBeChecked();
+    expect(screen.getByTestId('perspective-toggle-ObjectDiagram')).toBeChecked();
+    expect(screen.getByTestId('perspective-toggle-StateMachineDiagram')).toBeChecked();
+    expect(screen.getByTestId('perspective-toggle-AgentDiagram')).toBeChecked();
+    expect(screen.getByTestId('perspective-toggle-UserDiagram')).toBeChecked();
+    expect(screen.getByTestId('perspective-toggle-GUINoCodeDiagram')).toBeChecked();
+    expect(screen.getByTestId('perspective-toggle-QuantumCircuitDiagram')).toBeChecked();
+  });
+
+  it('reflects already-disabled perspectives as unchecked', () => {
+    const project = createDefaultProject('Test', '', 'owner');
+    project.settings.perspectives.ObjectDiagram = false;
+    setupUseProject({ currentProject: project });
+    render(<ProjectSettingsPanel />);
+
+    expect(screen.getByTestId('perspective-toggle-ObjectDiagram')).not.toBeChecked();
+    expect(screen.getByTestId('perspective-toggle-ClassDiagram')).toBeChecked();
+  });
+
+  it('dispatches setPerspectiveEnabledThunk when a perspective is toggled', () => {
+    setPerspectiveEnabledThunkSpy.mockClear();
+    mockDispatch.mockClear();
+    const project = createDefaultProject('Test', '', 'owner');
+    setupUseProject({ currentProject: project });
+    render(<ProjectSettingsPanel />);
+
+    fireEvent.click(screen.getByTestId('perspective-toggle-AgentDiagram'));
+
+    expect(setPerspectiveEnabledThunkSpy).toHaveBeenCalledWith({
+      type: 'AgentDiagram',
+      enabled: false,
+    });
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the last-enabled perspective checkbox to prevent disabling all', () => {
+    const project = createDefaultProject('Test', '', 'owner');
+    // Disable everything except ClassDiagram
+    for (const type of [
+      'ObjectDiagram',
+      'StateMachineDiagram',
+      'AgentDiagram',
+      'UserDiagram',
+      'GUINoCodeDiagram',
+      'QuantumCircuitDiagram',
+    ] as const) {
+      project.settings.perspectives[type] = false;
+    }
+    setupUseProject({ currentProject: project });
+    render(<ProjectSettingsPanel />);
+
+    expect(screen.getByTestId('perspective-toggle-ClassDiagram')).toBeDisabled();
   });
 
   it('renders correct diagram count when multiple diagrams have content', () => {

--- a/packages/webapp2/src/main/shared/constants/diagramTypeStyles.ts
+++ b/packages/webapp2/src/main/shared/constants/diagramTypeStyles.ts
@@ -1,0 +1,31 @@
+import { SupportedDiagramType } from '../types/project';
+
+export const PERSPECTIVE_LABELS: Record<SupportedDiagramType, string> = {
+  ClassDiagram: 'Class Diagram',
+  ObjectDiagram: 'Object Diagram',
+  StateMachineDiagram: 'State Machine Diagram',
+  AgentDiagram: 'Agent Diagram',
+  UserDiagram: 'User Diagram',
+  GUINoCodeDiagram: 'GUI Diagram',
+  QuantumCircuitDiagram: 'Quantum Circuit Diagram',
+};
+
+export const PERSPECTIVE_DESCRIPTIONS: Record<SupportedDiagramType, string> = {
+  ClassDiagram: 'Structural / data modeling, including OCL constraints attached to classes.',
+  ObjectDiagram: 'Instances of a class diagram, used for tests and OCL validation.',
+  StateMachineDiagram: 'State-based behavior modeling.',
+  AgentDiagram: 'Conversational / AI agent specification.',
+  UserDiagram: 'Actors and their interactions.',
+  GUINoCodeDiagram: 'Graphical user interface design (IFML-inspired).',
+  QuantumCircuitDiagram: 'Quantum program specification.',
+};
+
+export const DIAGRAM_TYPE_BADGE: Record<SupportedDiagramType, string> = {
+  ClassDiagram: 'bg-sky-100 text-sky-900 dark:bg-sky-900/30 dark:text-sky-300',
+  ObjectDiagram: 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-300',
+  StateMachineDiagram: 'bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-300',
+  AgentDiagram: 'bg-fuchsia-100 text-fuchsia-900 dark:bg-fuchsia-900/30 dark:text-fuchsia-300',
+  UserDiagram: 'bg-rose-100 text-rose-900 dark:bg-rose-900/30 dark:text-rose-300',
+  GUINoCodeDiagram: 'bg-indigo-100 text-indigo-900 dark:bg-indigo-900/30 dark:text-indigo-300',
+  QuantumCircuitDiagram: 'bg-violet-100 text-violet-900 dark:bg-violet-900/30 dark:text-violet-300',
+};

--- a/packages/webapp2/src/main/shared/types/__tests__/project.test.ts
+++ b/packages/webapp2/src/main/shared/types/__tests__/project.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vitest';
+import { UMLDiagramType, type UMLModel } from '@besser/wme';
+import {
+  ALL_DIAGRAM_TYPES,
+  PROJECT_SCHEMA_VERSION,
+  type BesserProject,
+  type ProjectDiagram,
+  type SupportedDiagramType,
+  createDefaultPerspectives,
+  createDefaultProject,
+  createEmptyDiagram,
+  defaultPerspectivesAllEnabled,
+  ensureProjectMigrated,
+  findHiddenReferencedPerspectives,
+  isPerspectiveVisible,
+  isProject,
+} from '../project';
+
+const populatedClassModel = (): UMLModel => ({
+  version: '3.0.0',
+  type: UMLDiagramType.ClassDiagram,
+  size: { width: 1400, height: 740 },
+  elements: {
+    'class-1': { id: 'class-1', name: 'Foo', type: 'Class', owner: null, bounds: { x: 0, y: 0, width: 0, height: 0 } } as any,
+  },
+  relationships: {},
+  interactive: { elements: {}, relationships: {} },
+  assessments: {},
+});
+
+describe('createDefaultPerspectives', () => {
+  it('returns true for every supported diagram type', () => {
+    const map = createDefaultPerspectives();
+    for (const type of ALL_DIAGRAM_TYPES) {
+      expect(map[type]).toBe(true);
+    }
+  });
+});
+
+describe('defaultPerspectivesAllEnabled', () => {
+  it('returns all-true when given undefined', () => {
+    const map = defaultPerspectivesAllEnabled(undefined);
+    for (const type of ALL_DIAGRAM_TYPES) {
+      expect(map[type]).toBe(true);
+    }
+  });
+
+  it('preserves explicit user choices and fills missing keys with true', () => {
+    const partial: Partial<Record<SupportedDiagramType, boolean>> = {
+      ClassDiagram: false,
+      GUINoCodeDiagram: false,
+    };
+    const map = defaultPerspectivesAllEnabled(partial);
+    expect(map.ClassDiagram).toBe(false);
+    expect(map.GUINoCodeDiagram).toBe(false);
+    expect(map.ObjectDiagram).toBe(true);
+    expect(map.AgentDiagram).toBe(true);
+    expect(map.UserDiagram).toBe(true);
+    expect(map.StateMachineDiagram).toBe(true);
+    expect(map.QuantumCircuitDiagram).toBe(true);
+  });
+});
+
+describe('isPerspectiveVisible', () => {
+  it('treats undefined map as fully visible', () => {
+    expect(isPerspectiveVisible(undefined, 'ClassDiagram')).toBe(true);
+  });
+
+  it('treats missing key as visible (default-on safety net)', () => {
+    expect(isPerspectiveVisible({} as any, 'ObjectDiagram')).toBe(true);
+  });
+
+  it('returns false only when explicitly false', () => {
+    expect(isPerspectiveVisible({ ClassDiagram: false } as any, 'ClassDiagram')).toBe(false);
+    expect(isPerspectiveVisible({ ClassDiagram: true } as any, 'ClassDiagram')).toBe(true);
+  });
+});
+
+describe('createDefaultProject', () => {
+  it('initializes settings.perspectives with all types enabled', () => {
+    const project = createDefaultProject('Demo', 'desc', 'me');
+    expect(project.schemaVersion).toBe(PROJECT_SCHEMA_VERSION);
+    for (const type of ALL_DIAGRAM_TYPES) {
+      expect(project.settings.perspectives[type]).toBe(true);
+    }
+  });
+});
+
+describe('ensureProjectMigrated v3 → v4', () => {
+  it('adds perspectives with all-true defaults to a v3 project that lacks them', () => {
+    const v3Project = {
+      ...createDefaultProject('Legacy', 'desc', 'me'),
+      schemaVersion: 3,
+      settings: {
+        defaultDiagramType: 'ClassDiagram',
+        autoSave: true,
+        collaborationEnabled: false,
+        // intentionally no `perspectives` field
+      } as any,
+    } as BesserProject;
+
+    expect(isProject(v3Project)).toBe(true);
+
+    const migrated = ensureProjectMigrated(v3Project);
+    expect(migrated.schemaVersion).toBe(4);
+    for (const type of ALL_DIAGRAM_TYPES) {
+      expect(migrated.settings.perspectives[type]).toBe(true);
+    }
+  });
+
+  it('preserves existing user-set perspectives on a v3 project that already has some', () => {
+    const v3Project = {
+      ...createDefaultProject('Legacy', 'desc', 'me'),
+      schemaVersion: 3,
+      settings: {
+        defaultDiagramType: 'ClassDiagram',
+        autoSave: true,
+        collaborationEnabled: false,
+        perspectives: { ClassDiagram: false, ObjectDiagram: true } as any,
+      } as any,
+    } as BesserProject;
+
+    const migrated = ensureProjectMigrated(v3Project);
+    expect(migrated.schemaVersion).toBe(4);
+    expect(migrated.settings.perspectives.ClassDiagram).toBe(false);
+    expect(migrated.settings.perspectives.ObjectDiagram).toBe(true);
+    // Missing keys filled with true
+    expect(migrated.settings.perspectives.AgentDiagram).toBe(true);
+    expect(migrated.settings.perspectives.QuantumCircuitDiagram).toBe(true);
+  });
+
+  it('is idempotent on an already-migrated v4 project', () => {
+    const project = createDefaultProject('Fresh', '', 'me');
+    project.settings.perspectives.AgentDiagram = false;
+    const migrated = ensureProjectMigrated(project);
+    expect(migrated.schemaVersion).toBe(4);
+    expect(migrated.settings.perspectives.AgentDiagram).toBe(false);
+    expect(migrated.settings.perspectives.ClassDiagram).toBe(true);
+  });
+});
+
+describe('findHiddenReferencedPerspectives', () => {
+  function withDiagrams(
+    project: BesserProject,
+    type: SupportedDiagramType,
+    diagrams: ProjectDiagram[],
+  ): BesserProject {
+    return { ...project, diagrams: { ...project.diagrams, [type]: diagrams } };
+  }
+
+  it('returns [] when all perspectives visible', () => {
+    const project = createDefaultProject('Clean', '', 'me');
+    expect(findHiddenReferencedPerspectives(project)).toEqual([]);
+  });
+
+  it('returns hidden type when it has its own non-empty content', () => {
+    let project = createDefaultProject('HasContent', '', 'me');
+    project.settings.perspectives.ObjectDiagram = false;
+    const objectDiagram = createEmptyDiagram('Obj', UMLDiagramType.ObjectDiagram);
+    objectDiagram.model = {
+      ...(objectDiagram.model as UMLModel),
+      elements: { 'obj-1': { id: 'obj-1' } as any },
+    } as any;
+    project = withDiagrams(project, 'ObjectDiagram', [objectDiagram]);
+
+    expect(findHiddenReferencedPerspectives(project)).toEqual(['ObjectDiagram']);
+  });
+
+  it('returns hidden type referenced by another diagram with content', () => {
+    let project = createDefaultProject('Refs', '', 'me');
+    project.settings.perspectives.ClassDiagram = false;
+
+    // Populate a class diagram with content
+    const classDiag = project.diagrams.ClassDiagram[0];
+    classDiag.model = populatedClassModel();
+    project = withDiagrams(project, 'ClassDiagram', [classDiag]);
+
+    // Make the GUI diagram explicitly reference this class diagram by ID
+    const guiDiag = project.diagrams.GUINoCodeDiagram[0];
+    guiDiag.references = { ClassDiagram: classDiag.id };
+    project = withDiagrams(project, 'GUINoCodeDiagram', [guiDiag]);
+
+    expect(findHiddenReferencedPerspectives(project)).toEqual(['ClassDiagram']);
+  });
+
+  it('does not flag a hidden type whose diagrams are all empty and unreferenced', () => {
+    const project = createDefaultProject('Empty', '', 'me');
+    project.settings.perspectives.AgentDiagram = false;
+    expect(findHiddenReferencedPerspectives(project)).toEqual([]);
+  });
+
+  it('does not flag a hidden type when the reference points at a missing target', () => {
+    const project = createDefaultProject('BrokenRef', '', 'me');
+    project.settings.perspectives.ClassDiagram = false;
+    const guiDiag = project.diagrams.GUINoCodeDiagram[0];
+    guiDiag.references = { ClassDiagram: 'nonexistent-id' };
+    expect(findHiddenReferencedPerspectives(project)).toEqual([]);
+  });
+
+  it('returns multiple hidden types in canonical order', () => {
+    let project = createDefaultProject('Multi', '', 'me');
+    project.settings.perspectives.ObjectDiagram = false;
+    project.settings.perspectives.AgentDiagram = false;
+
+    const obj = createEmptyDiagram('Obj', UMLDiagramType.ObjectDiagram);
+    obj.model = {
+      ...(obj.model as UMLModel),
+      elements: { 'obj-1': { id: 'obj-1' } as any },
+    } as any;
+    project = withDiagrams(project, 'ObjectDiagram', [obj]);
+
+    const agent = createEmptyDiagram('Agent', UMLDiagramType.AgentDiagram);
+    agent.model = {
+      ...(agent.model as UMLModel),
+      elements: { 'a-1': { id: 'a-1' } as any },
+    } as any;
+    project = withDiagrams(project, 'AgentDiagram', [agent]);
+
+    expect(findHiddenReferencedPerspectives(project)).toEqual(['ObjectDiagram', 'AgentDiagram']);
+  });
+});

--- a/packages/webapp2/src/main/shared/types/project.ts
+++ b/packages/webapp2/src/main/shared/types/project.ts
@@ -10,11 +10,40 @@ export type SupportedDiagramType =
   | 'QuantumCircuitDiagram';
 
 export const MAX_DIAGRAMS_PER_TYPE = 5;
-export const PROJECT_SCHEMA_VERSION = 3;
+export const PROJECT_SCHEMA_VERSION = 4;
 
 export const ALL_DIAGRAM_TYPES: SupportedDiagramType[] = [
   'ClassDiagram', 'ObjectDiagram', 'StateMachineDiagram', 'AgentDiagram', 'UserDiagram', 'GUINoCodeDiagram', 'QuantumCircuitDiagram',
 ];
+
+export type PerspectiveSettings = Record<SupportedDiagramType, boolean>;
+
+export const createDefaultPerspectives = (): PerspectiveSettings => {
+  const map = {} as PerspectiveSettings;
+  for (const type of ALL_DIAGRAM_TYPES) {
+    map[type] = true;
+  }
+  return map;
+};
+
+export const defaultPerspectivesAllEnabled = (
+  partial?: Partial<PerspectiveSettings>,
+): PerspectiveSettings => {
+  const map = createDefaultPerspectives();
+  if (partial) {
+    for (const type of ALL_DIAGRAM_TYPES) {
+      if (typeof partial[type] === 'boolean') {
+        map[type] = partial[type] as boolean;
+      }
+    }
+  }
+  return map;
+};
+
+export const isPerspectiveVisible = (
+  perspectives: PerspectiveSettings | undefined,
+  type: SupportedDiagramType,
+): boolean => perspectives?.[type] !== false;
 
 // GrapesJS project data structure
 export interface GrapesJSProjectData {
@@ -73,6 +102,7 @@ export interface BesserProject {
     defaultDiagramType: SupportedDiagramType;
     autoSave: boolean;
     collaborationEnabled: boolean;
+    perspectives: PerspectiveSettings;
   };
 }
 
@@ -348,6 +378,7 @@ export const createDefaultProject = (
       defaultDiagramType: 'ClassDiagram',
       autoSave: true,
       collaborationEnabled: false,
+      perspectives: createDefaultPerspectives(),
     },
   };
 };
@@ -400,7 +431,29 @@ export const ensureProjectMigrated = (obj: BesserProject): BesserProject => {
     obj = migrateReferencesToIds(obj);
   }
 
+  // Migrate v3 → v4: ensure settings.perspectives exists (all enabled by default)
+  if (!obj.schemaVersion || obj.schemaVersion < 4) {
+    obj = migratePerspectiveSettings(obj);
+  }
+
   return obj;
+};
+
+/**
+ * Migrate v3 → v4: ensure `settings.perspectives` is populated with a boolean
+ * for every supported diagram type. Existing user choices are preserved; missing
+ * keys default to `true` (perspective visible).
+ */
+const migratePerspectiveSettings = (project: BesserProject): BesserProject => {
+  const existingSettings = (project.settings ?? {}) as Partial<BesserProject['settings']>;
+  project.settings = {
+    defaultDiagramType: existingSettings.defaultDiagramType ?? 'ClassDiagram',
+    autoSave: existingSettings.autoSave ?? true,
+    collaborationEnabled: existingSettings.collaborationEnabled ?? false,
+    perspectives: defaultPerspectivesAllEnabled(existingSettings.perspectives),
+  };
+  project.schemaVersion = 4;
+  return project;
 };
 
 /**
@@ -501,6 +554,45 @@ export const isQuantumCircuitData = (model: unknown): model is QuantumCircuitDat
   return Array.isArray(candidate.cols);
 };
 
+
+/**
+ * Find perspectives that are hidden but the project still references them
+ * (either by holding non-empty diagrams of that type, or via cross-diagram
+ * `references` pointing at a non-empty target). Used to surface a re-enable
+ * banner so users don't lose visibility on data they have.
+ */
+export function findHiddenReferencedPerspectives(project: BesserProject): SupportedDiagramType[] {
+  const perspectives = project.settings?.perspectives;
+  const hidden = new Set<SupportedDiagramType>();
+
+  for (const type of ALL_DIAGRAM_TYPES) {
+    if (isPerspectiveVisible(perspectives, type)) continue;
+    const diagrams = project.diagrams[type] ?? [];
+    if (diagrams.some(diagramHasContent)) {
+      hidden.add(type);
+    }
+  }
+
+  for (const type of ALL_DIAGRAM_TYPES) {
+    const diagrams = project.diagrams[type] ?? [];
+    for (const diagram of diagrams) {
+      const refs = diagram.references;
+      if (!refs) continue;
+      for (const refType of Object.keys(refs) as SupportedDiagramType[]) {
+        if (isPerspectiveVisible(perspectives, refType)) continue;
+        const refId = refs[refType];
+        if (!refId) continue;
+        const targetDiagrams = project.diagrams[refType] ?? [];
+        const target = targetDiagrams.find((d) => d.id === refId);
+        if (target && diagramHasContent(target)) {
+          hidden.add(refType);
+        }
+      }
+    }
+  }
+
+  return ALL_DIAGRAM_TYPES.filter((type) => hidden.has(type));
+}
 
 /** Check whether a single diagram has meaningful content (non-empty model). */
 export function diagramHasContent(diagram: ProjectDiagram): boolean {


### PR DESCRIPTION
Added a new set of settings in the project settings panel to enable/disable different modeling perspectives. This helps users simplify the interface of the editor when they just want to use a specific perspective.

Disabling the perspective doesn't eliminate the models done under that perspective, it just hides them. 

Minimum one perspective is always kept