### PR TITLE
feat(templates): add Full Project tab with multi-diagram bundles

### DIFF
--- a/packages/webapp/src/main/app/store/workspaceSlice.ts
+++ b/packages/webapp/src/main/app/store/workspaceSlice.ts
@@ -108,6 +108,45 @@ function buildInitialState(): WorkspaceState {
 
 // ── Thunks ─────────────────────────────────────────────────────────────
 
+/**
+ * Push the model that some diagram editors expect to find in the shared
+ * `diagramBridge` before they render. Without this:
+ *   - ObjectDiagram → its palette can't resolve the typed objects against
+ *     the referenced ClassDiagram, so the canvas can't be edited correctly.
+ *   - UserDiagram   → its palette is empty (it's an Object Diagram under
+ *     the hood, but it needs the dedicated user metamodel loaded).
+ *
+ * This used to live inline inside `switchDiagramTypeThunk`, which meant
+ * loading a project (via `loadProjectThunk`) whose active diagram was a
+ * UserDiagram or ObjectDiagram would skip the setup entirely. Extracted
+ * so both code paths share it.
+ */
+async function setupBridgeForActiveDiagram(
+  project: BesserProject,
+  activeDiagram: ProjectDiagram | null,
+  diagramType: SupportedDiagramType,
+): Promise<void> {
+  if (diagramType === 'ObjectDiagram') {
+    if (!activeDiagram) return;
+    const classDiagram = getReferencedDiagram(project, activeDiagram, 'ClassDiagram');
+    if (isUMLModel(classDiagram?.model)) {
+      try {
+        const { diagramBridge } = await import('@besser/wme');
+        diagramBridge.setClassDiagramData(classDiagram.model);
+      } catch {
+        /* bridge not available */
+      }
+    }
+  } else if (diagramType === 'UserDiagram') {
+    try {
+      const { diagramBridge } = await import('@besser/wme');
+      diagramBridge.setClassDiagramData(userMetaModel as unknown as UMLModel);
+    } catch {
+      /* bridge not available */
+    }
+  }
+}
+
 export const loadProjectThunk = createAsyncThunk(
   'workspace/loadProject',
   async (projectId: string | undefined) => {
@@ -118,6 +157,13 @@ export const loadProjectThunk = createAsyncThunk(
     if (!project) throw new Error('Project not found');
 
     localStorage.setItem(localStorageLatestProject, project.id);
+
+    // Mirror the bridge setup that `switchDiagramTypeThunk` would do, so
+    // imported / template-loaded projects whose active diagram is a User
+    // or Object diagram show the correct palette on first render.
+    const activeDiagram = getActiveDiagram(project, project.currentDiagramType);
+    await setupBridgeForActiveDiagram(project, activeDiagram, project.currentDiagramType);
+
     return project;
   },
 );
@@ -154,27 +200,7 @@ export const switchDiagramTypeThunk = createAsyncThunk(
     });
     if (!diagram) throw new Error('Failed to switch diagram type');
 
-    // Set class diagram reference in bridge for Object Diagrams
-    // Uses the ObjectDiagram's per-diagram references to find the correct ClassDiagram
-    if (diagramType === UMLDiagramType.ObjectDiagram) {
-      const classDiagram = getReferencedDiagram(project, diagram, 'ClassDiagram');
-      if (isUMLModel(classDiagram?.model)) {
-        try {
-          const { diagramBridge } = await import('@besser/wme');
-          diagramBridge.setClassDiagramData(classDiagram.model);
-        } catch {
-          /* bridge not available */
-        }
-      }
-    } else if (diagramType === UMLDiagramType.UserDiagram) {
-      try {
-        const { diagramBridge } = await import('@besser/wme');
-        // User modeling depends on this metamodel being present in the bridge.
-        diagramBridge.setClassDiagramData(userMetaModel as unknown as UMLModel);
-      } catch {
-        /* bridge not available */
-      }
-    }
+    await setupBridgeForActiveDiagram(project, diagram, supportedType);
 
     return { diagram, diagramType: supportedType };
   },

--- a/packages/webapp/src/main/features/import/useGitHubBumlImport.ts
+++ b/packages/webapp/src/main/features/import/useGitHubBumlImport.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import { toast } from 'react-toastify';
 import { convertToRawUrl, extractFileName, validateGitHubUrl } from '../../shared/utils/githubUrlUtils';
-import { importProjectFromBUML } from './useImportProject';
+import { importProjectFromBUML } from '../../shared/services/project-import/projectImport';
 import { useProject } from '../../app/hooks/useProject';
 
 export const useGitHubBumlImport = () => {

--- a/packages/webapp/src/main/features/project/ADDING_NEW_DIAGRAM_TYPE.md
+++ b/packages/webapp/src/main/features/project/ADDING_NEW_DIAGRAM_TYPE.md
@@ -25,7 +25,7 @@ Adding a new diagram type requires modifications to **5 files** in the frontend,
 | `WorkspaceSidebar.tsx` | Sidebar button and click handling |
 | `export-project-modal.tsx` | Export modal labels |
 | `ProjectSettingsPanel.tsx` | Settings page color badges |
-| `useImportProject.ts` | Import handling for projects |
+| `projectImport.ts` | Import handling for projects |
 | **Backend** | **Parser integration (Required)** |
 
 ---
@@ -191,9 +191,9 @@ const getDiagramTypeColor = (type: SupportedDiagramType): string => {
 
 ---
 
-### Step 5: Add Import Support in `useImportProject.ts`
+### Step 5: Add Import Support in `projectImport.ts`
 
-**File:** `src/main/services/import/useImportProject.ts`
+**File:** `src/main/shared/services/project-import/projectImport.ts`
 
 #### 5.1 Add to `allDiagramTypes` array (line ~43)
 
@@ -309,7 +309,7 @@ The following `UMLDiagramType` values are available in `@besser/wme` (see
 - [ ] `WorkspaceSidebar.tsx` - Add to `sidebarItems`
 - [ ] `export-project-modal.tsx` - Add to `diagramLabels`
 - [ ] `ProjectSettingsPanel.tsx` - Add to `colors` Record
-- [ ] `useImportProject.ts` - Add to `allDiagramTypes`
-- [ ] `useImportProject.ts` - Add to `diagramTypeToUMLType`
-- [ ] `useImportProject.ts` - Add to `diagramTitles`
+- [ ] `projectImport.ts` - Add to `allDiagramTypes`
+- [ ] `projectImport.ts` - Add to `diagramTypeToUMLType`
+- [ ] `projectImport.ts` - Add to `diagramTitles`
 - [ ] **Backend** - Implement parser for the new diagram type

--- a/packages/webapp/src/main/features/project/ProjectHubDialog.tsx
+++ b/packages/webapp/src/main/features/project/ProjectHubDialog.tsx
@@ -25,7 +25,7 @@ import { useProject } from '../../app/hooks/useProject';
 import { useConfirmDialog } from '../../shared/hooks/useConfirmDialog';
 import { useFieldValidation } from '../../shared/hooks/useFieldValidation';
 import { ProjectStorageRepository } from '../../shared/services/storage/ProjectStorageRepository';
-import { importProject } from '../import/useImportProject';
+import { importProject } from '../../shared/services/project-import/projectImport';
 import { normalizeProjectName } from '../../shared/utils/projectName';
 import { validateProjectName } from '../../shared/utils/validation';
 import { BACKEND_URL } from '../../shared/constants/constant';

--- a/packages/webapp/src/main/features/project/TemplateLibraryDialog.tsx
+++ b/packages/webapp/src/main/features/project/TemplateLibraryDialog.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { UMLDiagramType } from '@besser/wme';
 import { toast } from 'react-toastify';
 import { useNavigate } from 'react-router-dom';
-import { Check, Layers, Sparkles, AlertTriangle } from 'lucide-react';
+import { Check, Layers, Sparkles, AlertTriangle, FolderTree } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -19,14 +19,17 @@ import {
   updateQuantumDiagramThunk,
   addDiagramThunk,
   switchDiagramIndexThunk,
+  loadProjectThunk,
   selectProject,
   selectActiveDiagramType,
 } from '../../app/store/workspaceSlice';
 import { ProjectStorageRepository } from '../../shared/services/storage/ProjectStorageRepository';
 import { toSupportedDiagramType, getActiveDiagram, diagramHasContent, SupportedDiagramType } from '../../shared/types/project';
 import { QuantumCircuitData } from '../../shared/types/project';
+import { importProjectFromJson } from '../import/useImportProject';
 import { TemplateFactory } from './create-diagram-from-template-modal/template-factory';
 import {
+  FULL_PROJECT_DIAGRAM_TYPE,
   SoftwarePatternCategory,
   SoftwarePatternTemplate,
   SoftwarePatternType,
@@ -38,6 +41,7 @@ interface TemplateLibraryDialogProps {
 }
 
 const categoryOrder: SoftwarePatternCategory[] = [
+  SoftwarePatternCategory.FULL_PROJECT,
   SoftwarePatternCategory.STRUCTURAL,
   SoftwarePatternCategory.BEHAVIORAL,
   SoftwarePatternCategory.CREATIONAL,
@@ -63,6 +67,33 @@ const categoryColor: Record<SoftwarePatternCategory, string> = {
   [SoftwarePatternCategory.AGENT]: 'bg-fuchsia-100 text-fuchsia-900 dark:bg-fuchsia-900/30 dark:text-fuchsia-300',
   [SoftwarePatternCategory.QUANTUM_CIRCUIT]: 'bg-violet-100 text-violet-900 dark:bg-violet-900/30 dark:text-violet-300',
   [SoftwarePatternCategory.NN]: 'bg-orange-100 text-orange-900 dark:bg-orange-900/30 dark:text-orange-300',
+  [SoftwarePatternCategory.FULL_PROJECT]: 'bg-rose-100 text-rose-900 dark:bg-rose-900/30 dark:text-rose-300',
+};
+
+/**
+ * For full-project templates, summarize which diagrams are populated so users
+ * can tell apart e.g. "class only" from "class + agent + GUI" at a glance.
+ */
+const summarizeFullProjectDiagrams = (template: SoftwarePatternTemplate): string => {
+  const project = (template.diagram as { project?: { diagrams?: Record<string, unknown[]> } })?.project;
+  const diagrams = project?.diagrams;
+  if (!diagrams) return 'Multi-diagram project';
+  const labels: string[] = [];
+  const order: Array<[string, string]> = [
+    ['ClassDiagram', 'Class'],
+    ['ObjectDiagram', 'Object'],
+    ['StateMachineDiagram', 'State'],
+    ['AgentDiagram', 'Agent'],
+    ['UserDiagram', 'User'],
+    ['GUINoCodeDiagram', 'GUI'],
+    ['QuantumCircuitDiagram', 'Quantum'],
+    ['NNDiagram', 'NN'],
+  ];
+  for (const [key, label] of order) {
+    const arr = diagrams[key];
+    if (Array.isArray(arr) && arr.length > 0) labels.push(label);
+  }
+  return labels.length ? labels.join(' · ') : 'Multi-diagram project';
 };
 
 export const TemplateLibraryDialog: React.FC<TemplateLibraryDialogProps> = ({ open, onOpenChange }) => {
@@ -113,8 +144,14 @@ export const TemplateLibraryDialog: React.FC<TemplateLibraryDialogProps> = ({ op
 
   const currentProject = useAppSelector(selectProject);
 
+  const isFullProjectTemplate = selectedTemplate?.diagramType === FULL_PROJECT_DIAGRAM_TYPE;
+
   const hasExistingModel = useMemo(() => {
     if (!currentProject || !selectedTemplate) return false;
+    // Full-project templates always materialize a brand-new project alongside
+    // existing ones, so the per-diagram "replace vs new tab" prompt doesn't
+    // apply — never trigger it for them.
+    if (selectedTemplate.diagramType === FULL_PROJECT_DIAGRAM_TYPE) return false;
     const supportedType = selectedTemplate.diagramType as SupportedDiagramType;
     const existing = getActiveDiagram(currentProject, supportedType);
     return existing ? diagramHasContent(existing) : false;
@@ -135,6 +172,21 @@ export const TemplateLibraryDialog: React.FC<TemplateLibraryDialogProps> = ({ op
 
     try {
       setIsLoading(true);
+
+      // Full-project templates: materialize a brand-new project from the
+      // bundled V2 export envelope, then switch to it. Reuses the same JSON
+      // import path the user-facing ``Import Project`` flow uses, so any
+      // future schema migrations carry over for free.
+      if (selectedTemplate.diagramType === FULL_PROJECT_DIAGRAM_TYPE) {
+        const jsonStr = JSON.stringify(selectedTemplate.diagram);
+        const file = new File([jsonStr], `${selectedTemplate.type}.json`, { type: 'application/json' });
+        const importedProject = await importProjectFromJson(file);
+        await dispatch(loadProjectThunk(importedProject.id)).unwrap();
+        navigate('/');
+        toast.success(`Loaded project template "${selectedTemplate.type}"`);
+        onOpenChange(false);
+        return;
+      }
 
       if (!selectedTemplate.isUMLDiagram && selectedTemplate.diagramType === 'QuantumCircuitDiagram') {
         const qType = 'QuantumCircuitDiagram' as const;
@@ -217,7 +269,7 @@ export const TemplateLibraryDialog: React.FC<TemplateLibraryDialogProps> = ({ op
             Load Template
           </DialogTitle>
           <DialogDescription>
-            Start from ready-made UML, agent, state machine, and quantum templates.
+            Start from ready-made UML, agent, state machine, quantum templates, or full-project bundles.
           </DialogDescription>
         </DialogHeader>
 
@@ -266,8 +318,17 @@ export const TemplateLibraryDialog: React.FC<TemplateLibraryDialogProps> = ({ op
                       </CardHeader>
                       <CardContent className="pt-0">
                         <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                          <Layers className="size-3.5" />
-                          <span>{String(template.diagramType).replace('Diagram', ' Diagram')}</span>
+                          {template.diagramType === FULL_PROJECT_DIAGRAM_TYPE ? (
+                            <>
+                              <FolderTree className="size-3.5" />
+                              <span>{summarizeFullProjectDiagrams(template)}</span>
+                            </>
+                          ) : (
+                            <>
+                              <Layers className="size-3.5" />
+                              <span>{String(template.diagramType).replace('Diagram', ' Diagram')}</span>
+                            </>
+                          )}
                         </div>
                       </CardContent>
                     </Card>

--- a/packages/webapp/src/main/features/project/TemplateLibraryDialog.tsx
+++ b/packages/webapp/src/main/features/project/TemplateLibraryDialog.tsx
@@ -26,7 +26,7 @@ import {
 import { ProjectStorageRepository } from '../../shared/services/storage/ProjectStorageRepository';
 import { toSupportedDiagramType, getActiveDiagram, diagramHasContent, SupportedDiagramType } from '../../shared/types/project';
 import { QuantumCircuitData } from '../../shared/types/project';
-import { importProjectFromJson } from '../import/useImportProject';
+import { importProjectFromJson } from '../../shared/services/project-import/projectImport';
 import { TemplateFactory } from './create-diagram-from-template-modal/template-factory';
 import {
   FULL_PROJECT_DIAGRAM_TYPE,

--- a/packages/webapp/src/main/features/project/create-diagram-from-template-modal/software-pattern/software-pattern-types.ts
+++ b/packages/webapp/src/main/features/project/create-diagram-from-template-modal/software-pattern/software-pattern-types.ts
@@ -42,6 +42,7 @@ export enum SoftwarePatternType {
   QUANTUM_QFT = 'Quantum Fourier Transform',
   // Full Project patterns (multi-diagram bundles imported as new projects)
   LIBRARY_FULL_STACK = 'Library (Full Stack)',
+  PERSONALIZED_GYM_AGENT = 'Personalized Gym Agent',
 }
 
 /**

--- a/packages/webapp/src/main/features/project/create-diagram-from-template-modal/software-pattern/software-pattern-types.ts
+++ b/packages/webapp/src/main/features/project/create-diagram-from-template-modal/software-pattern/software-pattern-types.ts
@@ -9,6 +9,7 @@ export enum SoftwarePatternCategory {
   STATE_MACHINE = 'State Machine Diagram',
   QUANTUM_CIRCUIT = 'Quantum Circuit',
   NN = 'Neural Network',
+  FULL_PROJECT = 'Full Project',
 }
 
 export enum SoftwarePatternType {
@@ -39,7 +40,17 @@ export enum SoftwarePatternType {
   QUANTUM_TELEPORTATION = 'Quantum Teleportation',
   QUANTUM_GROVER = 'Grover Search',
   QUANTUM_QFT = 'Quantum Fourier Transform',
+  // Full Project patterns (multi-diagram bundles imported as new projects)
+  LIBRARY_FULL_STACK = 'Library (Full Stack)',
 }
+
+/**
+ * Sentinel ``TemplateDiagramType`` used for multi-diagram project templates.
+ * The dialog branches on this to load the bundle as a brand-new project
+ * (via the existing JSON import flow) instead of swapping out a single
+ * diagram inside the active project.
+ */
+export const FULL_PROJECT_DIAGRAM_TYPE = 'FullProject' as const;
 
 export class SoftwarePatternTemplate extends Template {
   softwarePatternCategory: SoftwarePatternCategory;

--- a/packages/webapp/src/main/features/project/create-diagram-from-template-modal/template-factory.ts
+++ b/packages/webapp/src/main/features/project/create-diagram-from-template-modal/template-factory.ts
@@ -20,6 +20,7 @@ import nnTutorialExample from '../../../templates/pattern/nn/tutorial_example.js
 import nnAlexnet from '../../../templates/pattern/nn/alexnet_nn.json';
 import nnLstm from '../../../templates/pattern/nn/lstm_nn.json';
 import libraryFullStackProject from '../../../templates/pattern/project/library_full_stack.json';
+import personalizedGymAgentProject from '../../../templates/pattern/project/personalized_gym_agent.json';
 import { EXAMPLE_CIRCUITS } from '../../editors/quantum/exampleCircuits';
 import { serializeCircuit } from '../../editors/quantum/utils';
 
@@ -209,6 +210,14 @@ export class TemplateFactory {
           softwarePatternType,
           FULL_PROJECT_DIAGRAM_TYPE,
           libraryFullStackProject as object,
+          SoftwarePatternCategory.FULL_PROJECT,
+          false,
+        );
+      case SoftwarePatternType.PERSONALIZED_GYM_AGENT:
+        return new SoftwarePatternTemplate(
+          softwarePatternType,
+          FULL_PROJECT_DIAGRAM_TYPE,
+          personalizedGymAgentProject as object,
           SoftwarePatternCategory.FULL_PROJECT,
           false,
         );

--- a/packages/webapp/src/main/features/project/create-diagram-from-template-modal/template-factory.ts
+++ b/packages/webapp/src/main/features/project/create-diagram-from-template-modal/template-factory.ts
@@ -1,4 +1,5 @@
 import {
+  FULL_PROJECT_DIAGRAM_TYPE,
   SoftwarePatternCategory,
   SoftwarePatternTemplate,
   SoftwarePatternType,
@@ -18,6 +19,7 @@ import traficlightModel from '../../../templates/pattern/statemachine/traficligh
 import nnTutorialExample from '../../../templates/pattern/nn/tutorial_example.json';
 import nnAlexnet from '../../../templates/pattern/nn/alexnet_nn.json';
 import nnLstm from '../../../templates/pattern/nn/lstm_nn.json';
+import libraryFullStackProject from '../../../templates/pattern/project/library_full_stack.json';
 import { EXAMPLE_CIRCUITS } from '../../editors/quantum/exampleCircuits';
 import { serializeCircuit } from '../../editors/quantum/utils';
 
@@ -197,6 +199,17 @@ export class TemplateFactory {
           'QuantumCircuitDiagram',
           getQuantumCircuitData('Quantum Fourier Transform (3 qubit)'),
           SoftwarePatternCategory.QUANTUM_CIRCUIT,
+          false,
+        );
+      // Full-project templates: ``diagram`` carries the entire V2 export envelope
+      // (``{ project, exportedAt, version }``); the dialog routes these through
+      // the JSON import flow to materialize a brand-new project.
+      case SoftwarePatternType.LIBRARY_FULL_STACK:
+        return new SoftwarePatternTemplate(
+          softwarePatternType,
+          FULL_PROJECT_DIAGRAM_TYPE,
+          libraryFullStackProject as object,
+          SoftwarePatternCategory.FULL_PROJECT,
           false,
         );
       default:

--- a/packages/webapp/src/main/features/project/create-diagram-from-template-modal/template-types.ts
+++ b/packages/webapp/src/main/features/project/create-diagram-from-template-modal/template-types.ts
@@ -8,8 +8,10 @@ export enum TemplateCategory {
 
 export type TemplateType = SoftwarePatternType;
 
-// DiagramType can be either a UML diagram type or a non-UML type like QuantumCircuitDiagram
-export type TemplateDiagramType = UMLDiagramType | SupportedDiagramType;
+// DiagramType can be either a UML diagram type, a non-UML type like
+// QuantumCircuitDiagram, or the ``'FullProject'`` sentinel used for
+// multi-diagram project templates.
+export type TemplateDiagramType = UMLDiagramType | SupportedDiagramType | 'FullProject';
 
 export class Template {
   type: TemplateType;

--- a/packages/webapp/src/main/shared/services/project-import/projectImport.ts
+++ b/packages/webapp/src/main/shared/services/project-import/projectImport.ts
@@ -6,9 +6,9 @@ import {
   createDefaultPerspectives,
   createEmptyDiagram,
   getActiveDiagram,
-} from '../../shared/types/project';
-import { ProjectStorageRepository } from '../../shared/services/storage/ProjectStorageRepository';
-import { BACKEND_URL } from '../../shared/constants/constant';
+} from '../../types/project';
+import { ProjectStorageRepository } from '../storage/ProjectStorageRepository';
+import { BACKEND_URL } from '../../constants/constant';
 import { UMLDiagramType } from '@besser/wme';
 
 // Interface for V2 JSON export format
@@ -24,12 +24,6 @@ interface LegacyImportData {
   diagrams: ProjectDiagram[];
   exportedAt?: string;
   version?: string;
-}
-
-// Dynamic import for JSZip
-async function loadJSZip() {
-  const JSZip = (await import('jszip')).default;
-  return JSZip;
 }
 
 // Validate V2 export format (now allows partial diagrams)

--- a/packages/webapp/src/main/templates/pattern/project/library_full_stack.json
+++ b/packages/webapp/src/main/templates/pattern/project/library_full_stack.json
@@ -1,0 +1,3053 @@
+{
+  "project": {
+    "id": "project_1778067071085_63id4cn1x",
+    "type": "Project",
+    "schemaVersion": 4,
+    "name": "Library (Full Stack)",
+    "description": "A library management system: class diagram, agent and GUI no-code page (with the agent component) wired together.",
+    "owner": "BESSER User",
+    "createdAt": "2026-05-06T11:31:11.085Z",
+    "currentDiagramType": "GUINoCodeDiagram",
+    "currentDiagramIndices": {
+      "ClassDiagram": 0,
+      "ObjectDiagram": 0,
+      "StateMachineDiagram": 0,
+      "AgentDiagram": 0,
+      "NNDiagram": 0,
+      "UserDiagram": 0,
+      "GUINoCodeDiagram": 0,
+      "QuantumCircuitDiagram": 0
+    },
+    "diagrams": {
+      "ClassDiagram": [
+        {
+          "id": "f913a44b-5a6c-4eb9-9fc9-ed23fca5d051",
+          "title": "Library",
+          "model": {
+            "version": "3.0.0",
+            "type": "ClassDiagram",
+            "size": {
+              "width": 1460,
+              "height": 800
+            },
+            "interactive": {
+              "elements": {},
+              "relationships": {}
+            },
+            "elements": {
+              "class_oho5ergc3_mjikkmod": {
+                "id": "class_oho5ergc3_mjikkmod",
+                "name": "Book",
+                "type": "Class",
+                "owner": null,
+                "bounds": {
+                  "x": -434,
+                  "y": -345,
+                  "width": 240,
+                  "height": 215
+                },
+                "attributes": [
+                  "attr_a87fqdtdi_mjikkmod",
+                  "attr_v6ve12d44_mjikkmod",
+                  "attr_edi3c3l8k_mjikkmod",
+                  "attr_mczftcqfb_mjikkmod",
+                  "attr_785suq5yn_mjikkmod",
+                  "attr_urp7jb0c0_mjikkmod"
+                ],
+                "methods": [
+                  "method_rb01uirsh_mjikkmod"
+                ]
+              },
+              "attr_a87fqdtdi_mjikkmod": {
+                "id": "attr_a87fqdtdi_mjikkmod",
+                "name": "title",
+                "type": "ClassAttribute",
+                "owner": "class_oho5ergc3_mjikkmod",
+                "bounds": {
+                  "x": -433.5,
+                  "y": -304.5,
+                  "width": 239,
+                  "height": 25
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "attr_v6ve12d44_mjikkmod": {
+                "id": "attr_v6ve12d44_mjikkmod",
+                "name": "pages",
+                "type": "ClassAttribute",
+                "owner": "class_oho5ergc3_mjikkmod",
+                "bounds": {
+                  "x": -433.5,
+                  "y": -279.5,
+                  "width": 239,
+                  "height": 25
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "int",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "attr_edi3c3l8k_mjikkmod": {
+                "id": "attr_edi3c3l8k_mjikkmod",
+                "name": "stock",
+                "type": "ClassAttribute",
+                "owner": "class_oho5ergc3_mjikkmod",
+                "bounds": {
+                  "x": -433.5,
+                  "y": -254.5,
+                  "width": 239,
+                  "height": 25
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "int",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "attr_mczftcqfb_mjikkmod": {
+                "id": "attr_mczftcqfb_mjikkmod",
+                "name": "price",
+                "type": "ClassAttribute",
+                "owner": "class_oho5ergc3_mjikkmod",
+                "bounds": {
+                  "x": -433.5,
+                  "y": -229.5,
+                  "width": 239,
+                  "height": 25
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "float",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "attr_785suq5yn_mjikkmod": {
+                "id": "attr_785suq5yn_mjikkmod",
+                "name": "release",
+                "type": "ClassAttribute",
+                "owner": "class_oho5ergc3_mjikkmod",
+                "bounds": {
+                  "x": -433.5,
+                  "y": -204.5,
+                  "width": 239,
+                  "height": 25
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "date",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "attr_urp7jb0c0_mjikkmod": {
+                "id": "attr_urp7jb0c0_mjikkmod",
+                "name": "genre",
+                "type": "ClassAttribute",
+                "owner": "class_oho5ergc3_mjikkmod",
+                "bounds": {
+                  "x": -433.5,
+                  "y": -179.5,
+                  "width": 239,
+                  "height": 25
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "Genre",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "method_rb01uirsh_mjikkmod": {
+                "id": "method_rb01uirsh_mjikkmod",
+                "name": "+ decrease_stock(qty: int)",
+                "type": "ClassMethod",
+                "owner": "class_oho5ergc3_mjikkmod",
+                "bounds": {
+                  "x": -433.5,
+                  "y": -154.5,
+                  "width": 239,
+                  "height": 25
+                },
+                "code": "def decrease_stock(self, qty: int):\n    \"\"\"\n    Decrease the available stock by the given quantity.\n\n    :param qty: Number of items to remove from stock\n    :raises ValueError: If qty is negative or exceeds available stock\n    \"\"\"\n    if qty <= 0:\n        raise ValueError(\"Quantity must be a positive integer\")\n\n    if qty > self.stock:\n        raise ValueError(\n            f\"Cannot decrease stock by {qty}. Only {self.stock} items available.\"\n        )\n\n    self.stock -= qty\n\n",
+                "visibility": "public",
+                "attributeType": "int): any",
+                "implementationType": "code",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "class_06blhjj3h_mjikkmod": {
+                "id": "class_06blhjj3h_mjikkmod",
+                "name": "Library",
+                "type": "Class",
+                "owner": null,
+                "bounds": {
+                  "x": -60,
+                  "y": -150,
+                  "width": 350,
+                  "height": 185
+                },
+                "attributes": [
+                  "attr_eryfh37kl_mjikkmod",
+                  "f9608e0e-745d-4113-85ad-cd06b1900c09",
+                  "4391886d-13b5-4fa0-9894-09f1894af27f",
+                  "a487fd85-dec0-47b9-bd37-71ff92026963"
+                ],
+                "methods": [
+                  "35ef5329-889b-40f0-89ce-9836936fd8a9"
+                ]
+              },
+              "attr_eryfh37kl_mjikkmod": {
+                "id": "attr_eryfh37kl_mjikkmod",
+                "name": "name",
+                "type": "ClassAttribute",
+                "owner": "class_06blhjj3h_mjikkmod",
+                "bounds": {
+                  "x": -59.5,
+                  "y": -109.5,
+                  "width": 349,
+                  "height": 25
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "f9608e0e-745d-4113-85ad-cd06b1900c09": {
+                "id": "f9608e0e-745d-4113-85ad-cd06b1900c09",
+                "name": "web_page",
+                "type": "ClassAttribute",
+                "owner": "class_06blhjj3h_mjikkmod",
+                "bounds": {
+                  "x": -59.5,
+                  "y": -84.5,
+                  "width": 349,
+                  "height": 30
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "4391886d-13b5-4fa0-9894-09f1894af27f": {
+                "id": "4391886d-13b5-4fa0-9894-09f1894af27f",
+                "name": "address",
+                "type": "ClassAttribute",
+                "owner": "class_06blhjj3h_mjikkmod",
+                "bounds": {
+                  "x": -59.5,
+                  "y": -54.5,
+                  "width": 349,
+                  "height": 30
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "a487fd85-dec0-47b9-bd37-71ff92026963": {
+                "id": "a487fd85-dec0-47b9-bd37-71ff92026963",
+                "name": "telephone",
+                "type": "ClassAttribute",
+                "owner": "class_06blhjj3h_mjikkmod",
+                "bounds": {
+                  "x": -59.5,
+                  "y": -24.5,
+                  "width": 349,
+                  "height": 30
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "35ef5329-889b-40f0-89ce-9836936fd8a9": {
+                "id": "35ef5329-889b-40f0-89ce-9836936fd8a9",
+                "name": "+ cheapest_book_by(author:Author): str",
+                "type": "ClassMethod",
+                "owner": "class_06blhjj3h_mjikkmod",
+                "bounds": {
+                  "x": -59.5,
+                  "y": 5.5,
+                  "width": 349,
+                  "height": 30
+                },
+                "code": "def cheapest_book_by(author:Author) -> str {\n    cheapest:Book = null;\n\tprice = 1000000000.0;\n\tfor(book in this.books){\n        if(book.authors.contains(author)\n\t\t\t&& book.price <= price){\n            cheapest = book;\n\t\t\tprice = book.price;\n\t\t}\n    }\n\treturn cheapest.title;\n}",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "bal",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "class_d3f0di6lb_mjikkmoe": {
+                "id": "class_d3f0di6lb_mjikkmoe",
+                "name": "Author",
+                "type": "Class",
+                "owner": null,
+                "bounds": {
+                  "x": 10,
+                  "y": -380,
+                  "width": 220,
+                  "height": 95
+                },
+                "attributes": [
+                  "attr_p3zqpt65k_mjikkmoe",
+                  "4321afe8-8ec2-48da-a0ec-b2ce9ccaf1db"
+                ],
+                "methods": []
+              },
+              "attr_p3zqpt65k_mjikkmoe": {
+                "id": "attr_p3zqpt65k_mjikkmoe",
+                "name": "name",
+                "type": "ClassAttribute",
+                "owner": "class_d3f0di6lb_mjikkmoe",
+                "bounds": {
+                  "x": 10.5,
+                  "y": -339.5,
+                  "width": 219,
+                  "height": 25
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "4321afe8-8ec2-48da-a0ec-b2ce9ccaf1db": {
+                "id": "4321afe8-8ec2-48da-a0ec-b2ce9ccaf1db",
+                "name": "birth",
+                "type": "ClassAttribute",
+                "owner": "class_d3f0di6lb_mjikkmoe",
+                "bounds": {
+                  "x": 10.5,
+                  "y": -314.5,
+                  "width": 219,
+                  "height": 30
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "date",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "50ffa27f-f8a9-438b-b81b-174266f39952": {
+                "id": "50ffa27f-f8a9-438b-b81b-174266f39952",
+                "name": "Genre",
+                "type": "Enumeration",
+                "owner": null,
+                "bounds": {
+                  "x": -710,
+                  "y": -220,
+                  "width": 160,
+                  "height": 350
+                },
+                "attributes": [
+                  "bfadf7ef-e6a4-43e3-b267-672be745c9c7",
+                  "15d10eca-11e8-4894-8b27-d815dbc62596",
+                  "55346119-1f08-48c5-9629-b5223ea766e0",
+                  "67e73142-470c-4795-8864-96f08365ce49",
+                  "4ba07b68-1fd2-40fc-ad63-05766965aaad",
+                  "52114e47-c8c1-404a-847c-0b877de007e0",
+                  "65937dfa-011b-425e-a292-7d66dff5cd36",
+                  "994869fb-9b98-450f-add4-a2ee88a15c7f",
+                  "45fa6842-da64-4878-b875-c536f06f1d50",
+                  "6d81aaec-327a-42b9-89db-a17e54bb7b5a"
+                ],
+                "methods": []
+              },
+              "bfadf7ef-e6a4-43e3-b267-672be745c9c7": {
+                "id": "bfadf7ef-e6a4-43e3-b267-672be745c9c7",
+                "name": "Poetry",
+                "type": "ClassAttribute",
+                "owner": "50ffa27f-f8a9-438b-b81b-174266f39952",
+                "bounds": {
+                  "x": -709.5,
+                  "y": -169.5,
+                  "width": 159,
+                  "height": 30
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "15d10eca-11e8-4894-8b27-d815dbc62596": {
+                "id": "15d10eca-11e8-4894-8b27-d815dbc62596",
+                "name": "Thriller",
+                "type": "ClassAttribute",
+                "owner": "50ffa27f-f8a9-438b-b81b-174266f39952",
+                "bounds": {
+                  "x": -709.5,
+                  "y": -139.5,
+                  "width": 159,
+                  "height": 30
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "55346119-1f08-48c5-9629-b5223ea766e0": {
+                "id": "55346119-1f08-48c5-9629-b5223ea766e0",
+                "name": "History",
+                "type": "ClassAttribute",
+                "owner": "50ffa27f-f8a9-438b-b81b-174266f39952",
+                "bounds": {
+                  "x": -709.5,
+                  "y": -109.5,
+                  "width": 159,
+                  "height": 30
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "67e73142-470c-4795-8864-96f08365ce49": {
+                "id": "67e73142-470c-4795-8864-96f08365ce49",
+                "name": "Technology",
+                "type": "ClassAttribute",
+                "owner": "50ffa27f-f8a9-438b-b81b-174266f39952",
+                "bounds": {
+                  "x": -709.5,
+                  "y": -79.5,
+                  "width": 159,
+                  "height": 30
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "4ba07b68-1fd2-40fc-ad63-05766965aaad": {
+                "id": "4ba07b68-1fd2-40fc-ad63-05766965aaad",
+                "name": "Romance",
+                "type": "ClassAttribute",
+                "owner": "50ffa27f-f8a9-438b-b81b-174266f39952",
+                "bounds": {
+                  "x": -709.5,
+                  "y": -49.5,
+                  "width": 159,
+                  "height": 30
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "52114e47-c8c1-404a-847c-0b877de007e0": {
+                "id": "52114e47-c8c1-404a-847c-0b877de007e0",
+                "name": "Horror",
+                "type": "ClassAttribute",
+                "owner": "50ffa27f-f8a9-438b-b81b-174266f39952",
+                "bounds": {
+                  "x": -709.5,
+                  "y": -19.5,
+                  "width": 159,
+                  "height": 30
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "65937dfa-011b-425e-a292-7d66dff5cd36": {
+                "id": "65937dfa-011b-425e-a292-7d66dff5cd36",
+                "name": "Adventure",
+                "type": "ClassAttribute",
+                "owner": "50ffa27f-f8a9-438b-b81b-174266f39952",
+                "bounds": {
+                  "x": -709.5,
+                  "y": 10.5,
+                  "width": 159,
+                  "height": 30
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "994869fb-9b98-450f-add4-a2ee88a15c7f": {
+                "id": "994869fb-9b98-450f-add4-a2ee88a15c7f",
+                "name": "Philosophy",
+                "type": "ClassAttribute",
+                "owner": "50ffa27f-f8a9-438b-b81b-174266f39952",
+                "bounds": {
+                  "x": -709.5,
+                  "y": 40.5,
+                  "width": 159,
+                  "height": 30
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "45fa6842-da64-4878-b875-c536f06f1d50": {
+                "id": "45fa6842-da64-4878-b875-c536f06f1d50",
+                "name": "Cookbooks",
+                "type": "ClassAttribute",
+                "owner": "50ffa27f-f8a9-438b-b81b-174266f39952",
+                "bounds": {
+                  "x": -709.5,
+                  "y": 70.5,
+                  "width": 159,
+                  "height": 30
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "6d81aaec-327a-42b9-89db-a17e54bb7b5a": {
+                "id": "6d81aaec-327a-42b9-89db-a17e54bb7b5a",
+                "name": "Fantasy",
+                "type": "ClassAttribute",
+                "owner": "50ffa27f-f8a9-438b-b81b-174266f39952",
+                "bounds": {
+                  "x": -709.5,
+                  "y": 100.5,
+                  "width": 159,
+                  "height": 30
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false
+              },
+              "de57bf9a-a91f-4c69-9ad0-4879e2222edd": {
+                "id": "de57bf9a-a91f-4c69-9ad0-4879e2222edd",
+                "name": "",
+                "type": "ClassOCLConstraint",
+                "owner": null,
+                "bounds": {
+                  "x": -710,
+                  "y": -380,
+                  "width": 210,
+                  "height": 90
+                },
+                "constraint": "context Book inv inv1: self.pages> 10"
+              }
+            },
+            "relationships": {
+              "rel_z26fdxrdq_mjikkmoe": {
+                "id": "rel_z26fdxrdq_mjikkmoe",
+                "name": "books",
+                "type": "ClassBidirectional",
+                "owner": null,
+                "bounds": {
+                  "x": -194,
+                  "y": -247.5,
+                  "width": 134,
+                  "height": 228
+                },
+                "path": [
+                  {
+                    "x": 134,
+                    "y": 190
+                  },
+                  {
+                    "x": 67,
+                    "y": 190
+                  },
+                  {
+                    "x": 67,
+                    "y": 10
+                  },
+                  {
+                    "x": 0,
+                    "y": 10
+                  }
+                ],
+                "source": {
+                  "direction": "Left",
+                  "element": "class_06blhjj3h_mjikkmod",
+                  "multiplicity": "1..*",
+                  "role": "library",
+                  "bounds": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "target": {
+                  "direction": "Right",
+                  "element": "class_oho5ergc3_mjikkmod",
+                  "multiplicity": "*",
+                  "role": "books",
+                  "bounds": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "isManuallyLayouted": false
+              },
+              "rel_0ys2qxzq1_mjikkmoe": {
+                "id": "rel_0ys2qxzq1_mjikkmoe",
+                "name": "books",
+                "type": "ClassBidirectional",
+                "owner": null,
+                "bounds": {
+                  "x": -194,
+                  "y": -325,
+                  "width": 204,
+                  "height": 48
+                },
+                "path": [
+                  {
+                    "x": 204,
+                    "y": 10
+                  },
+                  {
+                    "x": 0,
+                    "y": 10
+                  }
+                ],
+                "source": {
+                  "direction": "Left",
+                  "element": "class_d3f0di6lb_mjikkmoe",
+                  "multiplicity": "1..*",
+                  "role": "authors",
+                  "bounds": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "target": {
+                  "direction": "Right",
+                  "element": "class_oho5ergc3_mjikkmod",
+                  "multiplicity": "*",
+                  "role": "books",
+                  "bounds": {
+                    "x": 0,
+                    "y": 0,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "isManuallyLayouted": false
+              }
+            },
+            "assessments": {}
+          },
+          "lastUpdate": "2026-05-06T11:31:20.817Z"
+        }
+      ],
+      "AgentDiagram": [
+        {
+          "id": "c4adbd57-a9f2-4cb2-904f-adf653cd268c",
+          "title": "Library Agent",
+          "model": {
+            "version": "3.0.0",
+            "type": "AgentDiagram",
+            "size": {
+              "width": 2326,
+              "height": 1540
+            },
+            "interactive": {
+              "elements": {},
+              "relationships": {}
+            },
+            "elements": {
+              "initial_72th6ksf3_mm9b38u1": {
+                "id": "initial_72th6ksf3_mm9b38u1",
+                "name": "",
+                "type": "StateInitialNode",
+                "owner": null,
+                "bounds": {
+                  "x": -1143,
+                  "y": -503,
+                  "width": 45,
+                  "height": 45
+                }
+              },
+              "intent_jtmr4apyg_mm9b38u1": {
+                "id": "intent_jtmr4apyg_mm9b38u1",
+                "name": "OpeningHours",
+                "type": "AgentIntent",
+                "owner": null,
+                "bounds": {
+                  "x": -680,
+                  "y": -100,
+                  "width": 410,
+                  "height": 190
+                },
+                "bodies": [
+                  "intentBody_jn9sy9wl2_mm9b38u1",
+                  "intentBody_61dj9fnk0_mm9b38u1",
+                  "intentBody_b8jkj9t1s_mm9b38u1",
+                  "intentBody_jl9eozt0r_mm9b38u1"
+                ],
+                "intent_description": "Asking for the opening hours of the library."
+              },
+              "intentBody_jn9sy9wl2_mm9b38u1": {
+                "id": "intentBody_jn9sy9wl2_mm9b38u1",
+                "name": "what are the opening hours?",
+                "type": "AgentIntentBody",
+                "owner": "intent_jtmr4apyg_mm9b38u1",
+                "bounds": {
+                  "x": -679.5,
+                  "y": -29.5,
+                  "width": 409,
+                  "height": 30
+                }
+              },
+              "intentBody_61dj9fnk0_mm9b38u1": {
+                "id": "intentBody_61dj9fnk0_mm9b38u1",
+                "name": "library hours",
+                "type": "AgentIntentBody",
+                "owner": "intent_jtmr4apyg_mm9b38u1",
+                "bounds": {
+                  "x": -679.5,
+                  "y": 0.5,
+                  "width": 409,
+                  "height": 30
+                }
+              },
+              "intentBody_b8jkj9t1s_mm9b38u1": {
+                "id": "intentBody_b8jkj9t1s_mm9b38u1",
+                "name": "when do you open?",
+                "type": "AgentIntentBody",
+                "owner": "intent_jtmr4apyg_mm9b38u1",
+                "bounds": {
+                  "x": -679.5,
+                  "y": 30.5,
+                  "width": 409,
+                  "height": 30
+                }
+              },
+              "intentBody_jl9eozt0r_mm9b38u1": {
+                "id": "intentBody_jl9eozt0r_mm9b38u1",
+                "name": "hours of operation",
+                "type": "AgentIntentBody",
+                "owner": "intent_jtmr4apyg_mm9b38u1",
+                "bounds": {
+                  "x": -679.5,
+                  "y": 60.5,
+                  "width": 409,
+                  "height": 30
+                }
+              },
+              "intent_ggq3p9gv8_mm9b38u1": {
+                "id": "intent_ggq3p9gv8_mm9b38u1",
+                "name": "CheapestBook",
+                "type": "AgentIntent",
+                "owner": null,
+                "bounds": {
+                  "x": -250,
+                  "y": -100,
+                  "width": 490,
+                  "height": 130
+                },
+                "bodies": [
+                  "intentBody_06wxt0vga_mm9b38u1",
+                  "intentBody_14tgxxf1f_mm9b38u1",
+                  "intentBody_j2ugmtuh8_mm9b38u1"
+                ],
+                "intent_description": ""
+              },
+              "intentBody_06wxt0vga_mm9b38u1": {
+                "id": "intentBody_06wxt0vga_mm9b38u1",
+                "name": "how to get the title of the cheapest book of an author?",
+                "type": "AgentIntentBody",
+                "owner": "intent_ggq3p9gv8_mm9b38u1",
+                "bounds": {
+                  "x": -249.5,
+                  "y": -59.5,
+                  "width": 489,
+                  "height": 30
+                }
+              },
+              "intentBody_14tgxxf1f_mm9b38u1": {
+                "id": "intentBody_14tgxxf1f_mm9b38u1",
+                "name": "I want to know the cheapest book",
+                "type": "AgentIntentBody",
+                "owner": "intent_ggq3p9gv8_mm9b38u1",
+                "bounds": {
+                  "x": -249.5,
+                  "y": -29.5,
+                  "width": 489,
+                  "height": 30
+                }
+              },
+              "intentBody_j2ugmtuh8_mm9b38u1": {
+                "id": "intentBody_j2ugmtuh8_mm9b38u1",
+                "name": "which is the cheapest book?",
+                "type": "AgentIntentBody",
+                "owner": "intent_ggq3p9gv8_mm9b38u1",
+                "bounds": {
+                  "x": -249.5,
+                  "y": 0.5,
+                  "width": 489,
+                  "height": 30
+                }
+              },
+              "intent_zuidaui0x_mm9b38u1": {
+                "id": "intent_zuidaui0x_mm9b38u1",
+                "name": "Contact",
+                "type": "AgentIntent",
+                "owner": null,
+                "bounds": {
+                  "x": -1130,
+                  "y": -100,
+                  "width": 430,
+                  "height": 160
+                },
+                "bodies": [
+                  "intentBody_9kmxc6vnq_mm9b38u1",
+                  "intentBody_mxczpzj8h_mm9b38u1",
+                  "intentBody_8yqem5n2k_mm9b38u1"
+                ],
+                "intent_description": "Requesting to speak with a human assistant."
+              },
+              "intentBody_9kmxc6vnq_mm9b38u1": {
+                "id": "intentBody_9kmxc6vnq_mm9b38u1",
+                "name": "I need to speak to someone",
+                "type": "AgentIntentBody",
+                "owner": "intent_zuidaui0x_mm9b38u1",
+                "bounds": {
+                  "x": -1129.5,
+                  "y": -29.5,
+                  "width": 429,
+                  "height": 30
+                }
+              },
+              "intentBody_mxczpzj8h_mm9b38u1": {
+                "id": "intentBody_mxczpzj8h_mm9b38u1",
+                "name": "contact support",
+                "type": "AgentIntentBody",
+                "owner": "intent_zuidaui0x_mm9b38u1",
+                "bounds": {
+                  "x": -1129.5,
+                  "y": 0.5,
+                  "width": 429,
+                  "height": 30
+                }
+              },
+              "intentBody_8yqem5n2k_mm9b38u1": {
+                "id": "intentBody_8yqem5n2k_mm9b38u1",
+                "name": "human assistance",
+                "type": "AgentIntentBody",
+                "owner": "intent_zuidaui0x_mm9b38u1",
+                "bounds": {
+                  "x": -1129.5,
+                  "y": 30.5,
+                  "width": 429,
+                  "height": 30
+                }
+              },
+              "state_zl3bfe65n_mm9b38u1": {
+                "id": "state_zl3bfe65n_mm9b38u1",
+                "name": "Idle",
+                "type": "AgentState",
+                "owner": null,
+                "bounds": {
+                  "x": -480,
+                  "y": -520,
+                  "width": 260,
+                  "height": 70
+                },
+                "bodies": [
+                  "body_wybm5pc31_mm9b38u1"
+                ],
+                "fallbackBodies": []
+              },
+              "body_wybm5pc31_mm9b38u1": {
+                "id": "body_wybm5pc31_mm9b38u1",
+                "name": "How can I assist you today?",
+                "type": "AgentStateBody",
+                "owner": "state_zl3bfe65n_mm9b38u1",
+                "bounds": {
+                  "x": -479.5,
+                  "y": -479.5,
+                  "width": 259,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "state_j5tnma02n_mm9b38u1": {
+                "id": "state_j5tnma02n_mm9b38u1",
+                "name": "OpeningHoursState",
+                "type": "AgentState",
+                "owner": null,
+                "bounds": {
+                  "x": 80,
+                  "y": -530,
+                  "width": 420,
+                  "height": 100
+                },
+                "bodies": [
+                  "body_a8ph8sxrt_mm9b38u1",
+                  "fb1432f7-1778-4c8b-90f3-e471e86cec31"
+                ],
+                "fallbackBodies": []
+              },
+              "body_a8ph8sxrt_mm9b38u1": {
+                "id": "body_a8ph8sxrt_mm9b38u1",
+                "name": "Our opening hours are Monday–Friday 9 AM–6 PM.",
+                "type": "AgentStateBody",
+                "owner": "state_j5tnma02n_mm9b38u1",
+                "bounds": {
+                  "x": 80.5,
+                  "y": -489.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "fb1432f7-1778-4c8b-90f3-e471e86cec31": {
+                "id": "fb1432f7-1778-4c8b-90f3-e471e86cec31",
+                "name": "Saturday 10 AM–4 PM. Closed Sunday.",
+                "type": "AgentStateBody",
+                "owner": "state_j5tnma02n_mm9b38u1",
+                "bounds": {
+                  "x": 80.5,
+                  "y": -459.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "state_krso67h8q_mm9b38u1": {
+                "id": "state_krso67h8q_mm9b38u1",
+                "name": "CheapestBookState",
+                "type": "AgentState",
+                "owner": null,
+                "bounds": {
+                  "x": 80,
+                  "y": -750,
+                  "width": 420,
+                  "height": 190
+                },
+                "bodies": [
+                  "body_38x5jthwr_mm9b38u1",
+                  "body_0yl3shkws_mm9b38u1",
+                  "b533e6a5-cc51-4f0d-a269-98bf81a02c31",
+                  "7c8e27fb-8cce-4f3d-9cc4-19ef5a963b8a",
+                  "b779be48-1bc4-4984-9274-00c91203552a"
+                ],
+                "fallbackBodies": []
+              },
+              "body_38x5jthwr_mm9b38u1": {
+                "id": "body_38x5jthwr_mm9b38u1",
+                "name": "To get the cheapest book of an author, follow these steps:",
+                "type": "AgentStateBody",
+                "owner": "state_krso67h8q_mm9b38u1",
+                "bounds": {
+                  "x": 80.5,
+                  "y": -709.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "body_0yl3shkws_mm9b38u1": {
+                "id": "body_0yl3shkws_mm9b38u1",
+                "name": "1. Go to the Library tab.",
+                "type": "AgentStateBody",
+                "owner": "state_krso67h8q_mm9b38u1",
+                "bounds": {
+                  "x": 80.5,
+                  "y": -679.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "b533e6a5-cc51-4f0d-a269-98bf81a02c31": {
+                "id": "b533e6a5-cc51-4f0d-a269-98bf81a02c31",
+                "name": "2. In the table, select the library where you want to search.",
+                "type": "AgentStateBody",
+                "owner": "state_krso67h8q_mm9b38u1",
+                "bounds": {
+                  "x": 80.5,
+                  "y": -649.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "7c8e27fb-8cce-4f3d-9cc4-19ef5a963b8a": {
+                "id": "7c8e27fb-8cce-4f3d-9cc4-19ef5a963b8a",
+                "name": "3. Click on “Cheapest Book”.",
+                "type": "AgentStateBody",
+                "owner": "state_krso67h8q_mm9b38u1",
+                "bounds": {
+                  "x": 80.5,
+                  "y": -619.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "b779be48-1bc4-4984-9274-00c91203552a": {
+                "id": "b779be48-1bc4-4984-9274-00c91203552a",
+                "name": "4. Select an author and click “Execute”.",
+                "type": "AgentStateBody",
+                "owner": "state_krso67h8q_mm9b38u1",
+                "bounds": {
+                  "x": 80.5,
+                  "y": -589.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "state_5emfhqwzt_mm9b38u1": {
+                "id": "state_5emfhqwzt_mm9b38u1",
+                "name": "ContactState",
+                "type": "AgentState",
+                "owner": null,
+                "bounds": {
+                  "x": 80,
+                  "y": -330,
+                  "width": 420,
+                  "height": 100
+                },
+                "bodies": [
+                  "body_b6vkku4r1_mm9b38u1",
+                  "body_8i8n5kbs0_mm9b38u1"
+                ],
+                "fallbackBodies": []
+              },
+              "body_b6vkku4r1_mm9b38u1": {
+                "id": "body_b6vkku4r1_mm9b38u1",
+                "name": "You can contact a librarian at library@example.com or call +1 555-123-4567.",
+                "type": "AgentStateBody",
+                "owner": "state_5emfhqwzt_mm9b38u1",
+                "bounds": {
+                  "x": 80.5,
+                  "y": -289.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "body_8i8n5kbs0_mm9b38u1": {
+                "id": "body_8i8n5kbs0_mm9b38u1",
+                "name": "They will get back to you shortly.",
+                "type": "AgentStateBody",
+                "owner": "state_5emfhqwzt_mm9b38u1",
+                "bounds": {
+                  "x": 80.5,
+                  "y": -259.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "46badadf-e50d-481e-8246-3ba2393fce47": {
+                "id": "46badadf-e50d-481e-8246-3ba2393fce47",
+                "name": "Greeting",
+                "type": "AgentState",
+                "owner": null,
+                "bounds": {
+                  "x": -999,
+                  "y": -539,
+                  "width": 420,
+                  "height": 70
+                },
+                "bodies": [
+                  "e3aad61a-89b4-46a6-8c16-6f80b861d717"
+                ],
+                "fallbackBodies": []
+              },
+              "e3aad61a-89b4-46a6-8c16-6f80b861d717": {
+                "id": "e3aad61a-89b4-46a6-8c16-6f80b861d717",
+                "name": "Welcome to the library support system!",
+                "type": "AgentStateBody",
+                "owner": "46badadf-e50d-481e-8246-3ba2393fce47",
+                "bounds": {
+                  "x": -998.5,
+                  "y": -498.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "0edea0d9-cfa4-48e4-ae68-dfd226aa9f13": {
+                "id": "0edea0d9-cfa4-48e4-ae68-dfd226aa9f13",
+                "name": "Other",
+                "type": "AgentIntent",
+                "owner": null,
+                "bounds": {
+                  "x": 260,
+                  "y": -100,
+                  "width": 250,
+                  "height": 70
+                },
+                "bodies": [],
+                "intent_description": "Any other question."
+              }
+            },
+            "relationships": {
+              "transition_ixdyt9fr7_mm9b38u1": {
+                "id": "transition_ixdyt9fr7_mm9b38u1",
+                "name": "",
+                "type": "AgentStateTransitionInit",
+                "owner": null,
+                "bounds": {
+                  "x": -1098,
+                  "y": -504,
+                  "width": 99,
+                  "height": 23.5
+                },
+                "path": [
+                  {
+                    "x": 0,
+                    "y": 23.5
+                  },
+                  {
+                    "x": 49.5,
+                    "y": 23.5
+                  },
+                  {
+                    "x": 49.5,
+                    "y": 0
+                  },
+                  {
+                    "x": 99,
+                    "y": 0
+                  }
+                ],
+                "source": {
+                  "direction": "Right",
+                  "element": "initial_72th6ksf3_mm9b38u1"
+                },
+                "target": {
+                  "direction": "Left",
+                  "element": "46badadf-e50d-481e-8246-3ba2393fce47"
+                },
+                "isManuallyLayouted": false
+              },
+              "transition_x8h483xz2_mm9b38u1": {
+                "id": "transition_x8h483xz2_mm9b38u1",
+                "name": "",
+                "type": "AgentStateTransition",
+                "owner": null,
+                "bounds": {
+                  "x": -220,
+                  "y": -485,
+                  "width": 300,
+                  "height": 1
+                },
+                "path": [
+                  {
+                    "x": 0,
+                    "y": 0
+                  },
+                  {
+                    "x": 300,
+                    "y": 0
+                  }
+                ],
+                "source": {
+                  "direction": "Upright",
+                  "element": "state_zl3bfe65n_mm9b38u1"
+                },
+                "target": {
+                  "direction": "Upleft",
+                  "element": "state_j5tnma02n_mm9b38u1"
+                },
+                "isManuallyLayouted": false,
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "when_intent_matched",
+                  "intentName": "OpeningHours"
+                },
+                "custom": {
+                  "condition": []
+                }
+              },
+              "transition_53oz6z5cc_mm9b38u1": {
+                "id": "transition_53oz6z5cc_mm9b38u1",
+                "name": "",
+                "type": "AgentStateTransition",
+                "owner": null,
+                "bounds": {
+                  "x": -285,
+                  "y": -655,
+                  "width": 365,
+                  "height": 135
+                },
+                "path": [
+                  {
+                    "x": 0,
+                    "y": 135
+                  },
+                  {
+                    "x": 0,
+                    "y": 0
+                  },
+                  {
+                    "x": 365,
+                    "y": 0
+                  }
+                ],
+                "source": {
+                  "direction": "Topright",
+                  "element": "state_zl3bfe65n_mm9b38u1"
+                },
+                "target": {
+                  "direction": "Left",
+                  "element": "state_krso67h8q_mm9b38u1"
+                },
+                "isManuallyLayouted": false,
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "when_intent_matched",
+                  "intentName": "CheapestBook"
+                },
+                "custom": {
+                  "condition": []
+                }
+              },
+              "transition_jc0mk7kpn_mm9b38u1": {
+                "id": "transition_jc0mk7kpn_mm9b38u1",
+                "name": "",
+                "type": "AgentStateTransition",
+                "owner": null,
+                "bounds": {
+                  "x": -285,
+                  "y": -450,
+                  "width": 365,
+                  "height": 170
+                },
+                "path": [
+                  {
+                    "x": 0,
+                    "y": 0
+                  },
+                  {
+                    "x": 0,
+                    "y": 170
+                  },
+                  {
+                    "x": 365,
+                    "y": 170
+                  }
+                ],
+                "source": {
+                  "direction": "Bottomright",
+                  "element": "state_zl3bfe65n_mm9b38u1"
+                },
+                "target": {
+                  "direction": "Left",
+                  "element": "state_5emfhqwzt_mm9b38u1"
+                },
+                "isManuallyLayouted": false,
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "when_intent_matched",
+                  "intentName": "Contact"
+                },
+                "custom": {
+                  "condition": []
+                }
+              },
+              "transition_zuuhzl5f9_mm9b38u1": {
+                "id": "transition_zuuhzl5f9_mm9b38u1",
+                "name": "",
+                "type": "AgentStateTransition",
+                "owner": null,
+                "bounds": {
+                  "x": -350,
+                  "y": -702.5,
+                  "width": 430,
+                  "height": 182.5
+                },
+                "path": [
+                  {
+                    "x": 430,
+                    "y": 0
+                  },
+                  {
+                    "x": 0,
+                    "y": 0
+                  },
+                  {
+                    "x": 0,
+                    "y": 182.5
+                  }
+                ],
+                "source": {
+                  "direction": "Upleft",
+                  "element": "state_krso67h8q_mm9b38u1"
+                },
+                "target": {
+                  "direction": "Up",
+                  "element": "state_zl3bfe65n_mm9b38u1"
+                },
+                "isManuallyLayouted": false,
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "auto",
+                  "conditionValue": ""
+                },
+                "custom": {
+                  "condition": []
+                }
+              },
+              "transition_rjozmqoco_mm9b38u1": {
+                "id": "transition_rjozmqoco_mm9b38u1",
+                "name": "",
+                "type": "AgentStateTransition",
+                "owner": null,
+                "bounds": {
+                  "x": -350,
+                  "y": -450,
+                  "width": 640,
+                  "height": 260
+                },
+                "path": [
+                  {
+                    "x": 640,
+                    "y": 220
+                  },
+                  {
+                    "x": 640,
+                    "y": 260
+                  },
+                  {
+                    "x": 0,
+                    "y": 260
+                  },
+                  {
+                    "x": 0,
+                    "y": 0
+                  }
+                ],
+                "source": {
+                  "direction": "Down",
+                  "element": "state_5emfhqwzt_mm9b38u1"
+                },
+                "target": {
+                  "direction": "Down",
+                  "element": "state_zl3bfe65n_mm9b38u1"
+                },
+                "isManuallyLayouted": false,
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "auto",
+                  "conditionValue": ""
+                },
+                "custom": {
+                  "condition": []
+                }
+              },
+              "5f574d18-6641-4c80-bd19-92b862b47b7c": {
+                "id": "5f574d18-6641-4c80-bd19-92b862b47b7c",
+                "name": "",
+                "type": "AgentStateTransition",
+                "owner": null,
+                "bounds": {
+                  "x": -220,
+                  "y": -467.5,
+                  "width": 405,
+                  "height": 77.5
+                },
+                "path": [
+                  {
+                    "x": 405,
+                    "y": 37.5
+                  },
+                  {
+                    "x": 405,
+                    "y": 77.5
+                  },
+                  {
+                    "x": 150,
+                    "y": 77.5
+                  },
+                  {
+                    "x": 150,
+                    "y": 0
+                  },
+                  {
+                    "x": 0,
+                    "y": 0
+                  }
+                ],
+                "source": {
+                  "direction": "Bottomleft",
+                  "element": "state_j5tnma02n_mm9b38u1"
+                },
+                "target": {
+                  "direction": "Downright",
+                  "element": "state_zl3bfe65n_mm9b38u1"
+                },
+                "isManuallyLayouted": false,
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "auto",
+                  "conditionValue": ""
+                },
+                "custom": {
+                  "condition": []
+                }
+              },
+              "5cf30015-c8cf-47be-8ad0-80bbba94d35e": {
+                "id": "5cf30015-c8cf-47be-8ad0-80bbba94d35e",
+                "name": "",
+                "type": "AgentStateTransition",
+                "owner": null,
+                "bounds": {
+                  "x": -579,
+                  "y": -494.5,
+                  "width": 99,
+                  "height": 1
+                },
+                "path": [
+                  {
+                    "x": 0,
+                    "y": 0
+                  },
+                  {
+                    "x": 99,
+                    "y": 0
+                  }
+                ],
+                "source": {
+                  "direction": "Downright",
+                  "element": "46badadf-e50d-481e-8246-3ba2393fce47"
+                },
+                "target": {
+                  "direction": "Left",
+                  "element": "state_zl3bfe65n_mm9b38u1"
+                },
+                "isManuallyLayouted": false,
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "auto",
+                  "conditionValue": ""
+                },
+                "custom": {
+                  "condition": []
+                }
+              }
+            },
+            "assessments": {}
+          },
+          "lastUpdate": "2026-05-06T11:31:19.611Z"
+        }
+      ],
+      "GUINoCodeDiagram": [
+        {
+          "id": "6cf9ac83-e5bf-4ab1-bee0-edb0cbba2682",
+          "title": "GUI Diagram",
+          "model": {
+            "pages": [
+              {
+                "name": "Book",
+                "frames": [
+                  {
+                    "component": {
+                      "type": "wrapper",
+                      "stylable": [
+                        "background",
+                        "background-color",
+                        "background-image",
+                        "background-repeat",
+                        "background-attachment",
+                        "background-position",
+                        "background-size"
+                      ],
+                      "components": [
+                        {
+                          "attributes": {
+                            "id": "iir99"
+                          },
+                          "components": [
+                            {
+                              "tagName": "nav",
+                              "attributes": {
+                                "id": "ihyzm"
+                              },
+                              "components": [
+                                {
+                                  "tagName": "h2",
+                                  "type": "text",
+                                  "attributes": {
+                                    "id": "i7thg"
+                                  },
+                                  "components": [
+                                    {
+                                      "type": "textnode",
+                                      "content": "BESSER"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "attributes": {
+                                    "id": "iwntp"
+                                  },
+                                  "components": [
+                                    {
+                                      "type": "link",
+                                      "attributes": {
+                                        "href": "/book",
+                                        "id": "ih8h6"
+                                      },
+                                      "components": [
+                                        {
+                                          "type": "textnode",
+                                          "content": "Book"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "link",
+                                      "attributes": {
+                                        "href": "/library",
+                                        "id": "i9l4g"
+                                      },
+                                      "components": [
+                                        {
+                                          "type": "textnode",
+                                          "content": "Library"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "link",
+                                      "attributes": {
+                                        "href": "/author",
+                                        "id": "io6eh"
+                                      },
+                                      "components": [
+                                        {
+                                          "type": "textnode",
+                                          "content": "Author"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "attributes": {
+                                    "id": "ixx2i"
+                                  },
+                                  "components": [
+                                    {
+                                      "type": "textnode",
+                                      "content": "© 2026 BESSER. All rights reserved."
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "tagName": "main",
+                              "attributes": {
+                                "id": "i0mrm"
+                              },
+                              "components": [
+                                {
+                                  "tagName": "h1",
+                                  "type": "text",
+                                  "attributes": {
+                                    "id": "iyjpg"
+                                  },
+                                  "components": [
+                                    {
+                                      "type": "textnode",
+                                      "content": "Book"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "tagName": "p",
+                                  "type": "text",
+                                  "attributes": {
+                                    "id": "itizf"
+                                  },
+                                  "components": [
+                                    {
+                                      "type": "textnode",
+                                      "content": "Manage Book data"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "table",
+                                  "style": "",
+                                  "attributes": {
+                                    "chart-color": "#2c3e50",
+                                    "chart-title": "Book List",
+                                    "data-source": "class_oho5ergc3_mjikkmod",
+                                    "show-header": "true",
+                                    "striped-rows": "false",
+                                    "show-pagination": "true",
+                                    "rows-per-page": "5",
+                                    "action-buttons": "true",
+                                    "columns": [
+                                      {
+                                        "field": "title",
+                                        "label": "Title",
+                                        "columnType": "field",
+                                        "_expanded": false
+                                      },
+                                      {
+                                        "field": "pages",
+                                        "label": "Pages",
+                                        "columnType": "field",
+                                        "_expanded": false
+                                      },
+                                      {
+                                        "field": "stock",
+                                        "label": "Stock",
+                                        "columnType": "field",
+                                        "_expanded": false
+                                      },
+                                      {
+                                        "field": "price",
+                                        "label": "Price",
+                                        "columnType": "field",
+                                        "_expanded": false
+                                      },
+                                      {
+                                        "field": "release",
+                                        "label": "Release",
+                                        "columnType": "field",
+                                        "_expanded": false
+                                      },
+                                      {
+                                        "field": "genre",
+                                        "label": "Genre",
+                                        "columnType": "field",
+                                        "_expanded": false
+                                      },
+                                      {
+                                        "field": "library",
+                                        "label": "Library",
+                                        "columnType": "lookup",
+                                        "lookupEntity": "class_06blhjj3h_mjikkmod",
+                                        "lookupField": "name",
+                                        "_expanded": false
+                                      },
+                                      {
+                                        "field": "authors",
+                                        "label": "Authors",
+                                        "columnType": "lookup",
+                                        "lookupEntity": "class_d3f0di6lb_mjikkmoe",
+                                        "lookupField": "name",
+                                        "_expanded": false
+                                      }
+                                    ],
+                                    "id": "table-book-0",
+                                    "filter": ""
+                                  },
+                                  "chart-title": "Book List",
+                                  "data-source": "class_oho5ergc3_mjikkmod",
+                                  "show-header": "true",
+                                  "striped-rows": "false",
+                                  "show-pagination": "true",
+                                  "action-buttons": "true",
+                                  "rows-per-page": "5",
+                                  "filter": "",
+                                  "columns": [
+                                    {
+                                      "field": "title",
+                                      "label": "Title",
+                                      "columnType": "field",
+                                      "_expanded": false
+                                    },
+                                    {
+                                      "field": "pages",
+                                      "label": "Pages",
+                                      "columnType": "field",
+                                      "_expanded": false
+                                    },
+                                    {
+                                      "field": "stock",
+                                      "label": "Stock",
+                                      "columnType": "field",
+                                      "_expanded": false
+                                    },
+                                    {
+                                      "field": "price",
+                                      "label": "Price",
+                                      "columnType": "field",
+                                      "_expanded": false
+                                    },
+                                    {
+                                      "field": "release",
+                                      "label": "Release",
+                                      "columnType": "field",
+                                      "_expanded": false
+                                    },
+                                    {
+                                      "field": "genre",
+                                      "label": "Genre",
+                                      "columnType": "field",
+                                      "_expanded": false
+                                    },
+                                    {
+                                      "field": "library",
+                                      "label": "Library",
+                                      "columnType": "lookup",
+                                      "lookupEntity": "class_06blhjj3h_mjikkmod",
+                                      "lookupField": "name",
+                                      "_expanded": false
+                                    },
+                                    {
+                                      "field": "authors",
+                                      "label": "Authors",
+                                      "columnType": "lookup",
+                                      "lookupEntity": "class_d3f0di6lb_mjikkmoe",
+                                      "lookupField": "name",
+                                      "_expanded": false
+                                    }
+                                  ],
+                                  "components": [
+                                    {
+                                      "type": "tbody",
+                                      "draggable": [
+                                        "table"
+                                      ],
+                                      "droppable": [
+                                        "tr"
+                                      ],
+                                      "components": [
+                                        {
+                                          "type": "row",
+                                          "draggable": [
+                                            "thead",
+                                            "tbody",
+                                            "tfoot"
+                                          ],
+                                          "droppable": [
+                                            "th",
+                                            "td"
+                                          ],
+                                          "classes": [
+                                            "row"
+                                          ],
+                                          "components": [
+                                            {
+                                              "type": "cell",
+                                              "draggable": [
+                                                "tr"
+                                              ],
+                                              "classes": [
+                                                "cell"
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "chart-color": "#2c3e50"
+                                },
+                                {
+                                  "attributes": {
+                                    "id": "ioq13"
+                                  },
+                                  "components": [
+                                    {
+                                      "type": "action-button",
+                                      "content": "+ decrease_stock",
+                                      "style": "",
+                                      "classes": [
+                                        "action-button-component"
+                                      ],
+                                      "attributes": {
+                                        "type": "button",
+                                        "data-button-label": "+ decrease_stock",
+                                        "data-action-type": "run-method",
+                                        "data-method-class": "class_oho5ergc3_mjikkmod",
+                                        "data-method": "method_rb01uirsh_mjikkmod",
+                                        "data-instance-source": "table-book-0",
+                                        "id": "idgyv",
+                                        "data-confirmation": "false",
+                                        "data-confirmation-message": "Are you sure?",
+                                        "button-label": "+ decrease_stock",
+                                        "data-method-name": "method_rb01uirsh_mjikkmod"
+                                      },
+                                      "button-label": "+ decrease_stock",
+                                      "action-type": "run-method",
+                                      "method-class": "class_oho5ergc3_mjikkmod",
+                                      "method": "method_rb01uirsh_mjikkmod",
+                                      "instance-source": "table-book-0",
+                                      "components": [
+                                        {
+                                          "type": "textnode",
+                                          "content": "+ decrease_stock"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "agent-component",
+                                      "style": "",
+                                      "classes": [
+                                        "agent-component"
+                                      ],
+                                      "attributes": {
+                                        "agent-name": "Library Agent",
+                                        "agent-title": "BESSER Agent",
+                                        "id": "im47u"
+                                      },
+                                      "agent-name": "Library Agent",
+                                      "agent-title": "BESSER Agent"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "head": {
+                        "type": "head"
+                      },
+                      "docEl": {
+                        "tagName": "html"
+                      }
+                    },
+                    "id": "7zIM2Z3WJTpK8vKO"
+                  }
+                ],
+                "id": "page-book-0",
+                "route_path": "/book"
+              },
+              {
+                "name": "Library",
+                "frames": [
+                  {
+                    "component": {
+                      "type": "wrapper",
+                      "stylable": [
+                        "background",
+                        "background-color",
+                        "background-image",
+                        "background-repeat",
+                        "background-attachment",
+                        "background-position",
+                        "background-size"
+                      ],
+                      "components": [
+                        {
+                          "attributes": {
+                            "id": "ipfo8"
+                          },
+                          "components": [
+                            {
+                              "tagName": "nav",
+                              "attributes": {
+                                "id": "i5v1l"
+                              },
+                              "components": [
+                                {
+                                  "tagName": "h2",
+                                  "type": "text",
+                                  "attributes": {
+                                    "id": "iopqh"
+                                  },
+                                  "components": [
+                                    {
+                                      "type": "textnode",
+                                      "content": "BESSER"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "attributes": {
+                                    "id": "iui4i"
+                                  },
+                                  "components": [
+                                    {
+                                      "type": "link",
+                                      "attributes": {
+                                        "href": "/book",
+                                        "id": "ix6dg"
+                                      },
+                                      "components": [
+                                        {
+                                          "type": "textnode",
+                                          "content": "Book"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "link",
+                                      "attributes": {
+                                        "href": "/library",
+                                        "id": "ixrwm"
+                                      },
+                                      "components": [
+                                        {
+                                          "type": "textnode",
+                                          "content": "Library"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "link",
+                                      "attributes": {
+                                        "href": "/author",
+                                        "id": "iauyc"
+                                      },
+                                      "components": [
+                                        {
+                                          "type": "textnode",
+                                          "content": "Author"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "attributes": {
+                                    "id": "iijek"
+                                  },
+                                  "components": [
+                                    {
+                                      "type": "textnode",
+                                      "content": "© 2026 BESSER. All rights reserved."
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "tagName": "main",
+                              "attributes": {
+                                "id": "i845n"
+                              },
+                              "components": [
+                                {
+                                  "tagName": "h1",
+                                  "type": "text",
+                                  "attributes": {
+                                    "id": "ihqgf"
+                                  },
+                                  "components": [
+                                    {
+                                      "type": "textnode",
+                                      "content": "Library"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "tagName": "p",
+                                  "type": "text",
+                                  "attributes": {
+                                    "id": "ij47n"
+                                  },
+                                  "components": [
+                                    {
+                                      "type": "textnode",
+                                      "content": "Manage Library data"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "table",
+                                  "style": "",
+                                  "attributes": {
+                                    "chart-color": "#2c3e50",
+                                    "chart-title": "Library List",
+                                    "data-source": "class_06blhjj3h_mjikkmod",
+                                    "show-header": "true",
+                                    "striped-rows": "false",
+                                    "show-pagination": "true",
+                                    "rows-per-page": "5",
+                                    "action-buttons": "true",
+                                    "columns": [
+                                      {
+                                        "field": "name",
+                                        "label": "Name",
+                                        "columnType": "field",
+                                        "_expanded": false
+                                      },
+                                      {
+                                        "field": "web_page",
+                                        "label": "Web Page",
+                                        "columnType": "field",
+                                        "_expanded": false
+                                      },
+                                      {
+                                        "field": "address",
+                                        "label": "Address",
+                                        "columnType": "field",
+                                        "_expanded": false
+                                      },
+                                      {
+                                        "field": "telephone",
+                                        "label": "Telephone",
+                                        "columnType": "field",
+                                        "_expanded": false
+                                      },
+                                      {
+                                        "field": "books",
+                                        "label": "Books",
+                                        "columnType": "lookup",
+                                        "lookupEntity": "class_oho5ergc3_mjikkmod",
+                                        "lookupField": "title",
+                                        "_expanded": false
+                                      }
+                                    ],
+                                    "id": "table-library-1",
+                                    "filter": ""
+                                  },
+                                  "chart-title": "Library List",
+                                  "data-source": "class_06blhjj3h_mjikkmod",
+                                  "show-header": "true",
+                                  "striped-rows": "false",
+                                  "show-pagination": "true",
+                                  "action-buttons": "true",
+                                  "rows-per-page": "5",
+                                  "filter": "",
+                                  "columns": [
+                                    {
+                                      "field": "name",
+                                      "label": "Name",
+                                      "columnType": "field",
+                                      "_expanded": false
+                                    },
+                                    {
+                                      "field": "web_page",
+                                      "label": "Web Page",
+                                      "columnType": "field",
+                                      "_expanded": false
+                                    },
+                                    {
+                                      "field": "address",
+                                      "label": "Address",
+                                      "columnType": "field",
+                                      "_expanded": false
+                                    },
+                                    {
+                                      "field": "telephone",
+                                      "label": "Telephone",
+                                      "columnType": "field",
+                                      "_expanded": false
+                                    },
+                                    {
+                                      "field": "books",
+                                      "label": "Books",
+                                      "columnType": "lookup",
+                                      "lookupEntity": "class_oho5ergc3_mjikkmod",
+                                      "lookupField": "title",
+                                      "_expanded": false
+                                    }
+                                  ],
+                                  "components": [
+                                    {
+                                      "type": "tbody",
+                                      "draggable": [
+                                        "table"
+                                      ],
+                                      "droppable": [
+                                        "tr"
+                                      ],
+                                      "components": [
+                                        {
+                                          "type": "row",
+                                          "draggable": [
+                                            "thead",
+                                            "tbody",
+                                            "tfoot"
+                                          ],
+                                          "droppable": [
+                                            "th",
+                                            "td"
+                                          ],
+                                          "classes": [
+                                            "row"
+                                          ],
+                                          "components": [
+                                            {
+                                              "type": "cell",
+                                              "draggable": [
+                                                "tr"
+                                              ],
+                                              "classes": [
+                                                "cell"
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "chart-color": "#2c3e50"
+                                },
+                                {
+                                  "attributes": {
+                                    "id": "i0iia"
+                                  },
+                                  "components": [
+                                    {
+                                      "type": "action-button",
+                                      "style": "",
+                                      "classes": [
+                                        "action-button-component"
+                                      ],
+                                      "attributes": {
+                                        "type": "button",
+                                        "data-button-label": "+ cheapest_book_by",
+                                        "data-action-type": "run-method",
+                                        "data-method-class": "class_06blhjj3h_mjikkmod",
+                                        "data-method": "35ef5329-889b-40f0-89ce-9836936fd8a9",
+                                        "data-instance-source": "table-library-1",
+                                        "id": "ir5xw"
+                                      },
+                                      "button-label": "+ cheapest_book_by",
+                                      "action-type": "run-method",
+                                      "method-class": "class_06blhjj3h_mjikkmod",
+                                      "method": "35ef5329-889b-40f0-89ce-9836936fd8a9",
+                                      "instance-source": "table-library-1",
+                                      "components": [
+                                        {
+                                          "type": "textnode",
+                                          "content": "+ cheapest_book_by"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "head": {
+                        "type": "head"
+                      },
+                      "docEl": {
+                        "tagName": "html"
+                      }
+                    },
+                    "id": "63D2k7g9B5xhx1hQ"
+                  }
+                ],
+                "id": "page-library-1",
+                "route_path": "/library"
+              },
+              {
+                "name": "Author",
+                "frames": [
+                  {
+                    "component": {
+                      "type": "wrapper",
+                      "stylable": [
+                        "background",
+                        "background-color",
+                        "background-image",
+                        "background-repeat",
+                        "background-attachment",
+                        "background-position",
+                        "background-size"
+                      ],
+                      "components": [
+                        {
+                          "attributes": {
+                            "id": "in05f"
+                          },
+                          "components": [
+                            {
+                              "tagName": "nav",
+                              "attributes": {
+                                "id": "is7w8"
+                              },
+                              "components": [
+                                {
+                                  "tagName": "h2",
+                                  "type": "text",
+                                  "attributes": {
+                                    "id": "i3xv3"
+                                  },
+                                  "components": [
+                                    {
+                                      "type": "textnode",
+                                      "content": "BESSER"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "attributes": {
+                                    "id": "itt6j"
+                                  },
+                                  "components": [
+                                    {
+                                      "type": "link",
+                                      "attributes": {
+                                        "href": "/book",
+                                        "id": "ibxxn"
+                                      },
+                                      "components": [
+                                        {
+                                          "type": "textnode",
+                                          "content": "Book"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "link",
+                                      "attributes": {
+                                        "href": "/library",
+                                        "id": "ik9yu"
+                                      },
+                                      "components": [
+                                        {
+                                          "type": "textnode",
+                                          "content": "Library"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "link",
+                                      "attributes": {
+                                        "href": "/author",
+                                        "id": "ibnlk"
+                                      },
+                                      "components": [
+                                        {
+                                          "type": "textnode",
+                                          "content": "Author"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "attributes": {
+                                    "id": "il285"
+                                  },
+                                  "components": [
+                                    {
+                                      "type": "textnode",
+                                      "content": "© 2026 BESSER. All rights reserved."
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "tagName": "main",
+                              "attributes": {
+                                "id": "ih5us"
+                              },
+                              "components": [
+                                {
+                                  "tagName": "h1",
+                                  "type": "text",
+                                  "attributes": {
+                                    "id": "iqnfa"
+                                  },
+                                  "components": [
+                                    {
+                                      "type": "textnode",
+                                      "content": "Author"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "tagName": "p",
+                                  "type": "text",
+                                  "attributes": {
+                                    "id": "i8odx"
+                                  },
+                                  "components": [
+                                    {
+                                      "type": "textnode",
+                                      "content": "Manage Author data"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "table",
+                                  "style": "",
+                                  "classes": [
+                                    "has-data-binding"
+                                  ],
+                                  "attributes": {
+                                    "chart-color": "#2c3e50",
+                                    "chart-title": "Author List",
+                                    "data-source": "class_d3f0di6lb_mjikkmoe",
+                                    "show-header": "true",
+                                    "striped-rows": "false",
+                                    "show-pagination": "true",
+                                    "rows-per-page": "5",
+                                    "action-buttons": "true",
+                                    "columns": [
+                                      {
+                                        "field": "name",
+                                        "label": "Name",
+                                        "columnType": "field",
+                                        "_expanded": false
+                                      },
+                                      {
+                                        "field": "birth",
+                                        "label": "Birth",
+                                        "columnType": "field",
+                                        "_expanded": false
+                                      },
+                                      {
+                                        "field": "books",
+                                        "label": "Books",
+                                        "columnType": "lookup",
+                                        "lookupEntity": "class_oho5ergc3_mjikkmod",
+                                        "lookupField": "title",
+                                        "_expanded": false
+                                      }
+                                    ],
+                                    "id": "table-author-2",
+                                    "filter": ""
+                                  },
+                                  "chart-title": "Author List",
+                                  "data-source": "class_d3f0di6lb_mjikkmoe",
+                                  "show-header": "true",
+                                  "striped-rows": "false",
+                                  "show-pagination": "true",
+                                  "action-buttons": "true",
+                                  "rows-per-page": "5",
+                                  "filter": "",
+                                  "columns": [
+                                    {
+                                      "field": "name",
+                                      "label": "Name",
+                                      "columnType": "field",
+                                      "_expanded": false
+                                    },
+                                    {
+                                      "field": "birth",
+                                      "label": "Birth",
+                                      "columnType": "field",
+                                      "_expanded": false
+                                    },
+                                    {
+                                      "field": "books",
+                                      "label": "Books",
+                                      "columnType": "lookup",
+                                      "lookupEntity": "class_oho5ergc3_mjikkmod",
+                                      "lookupField": "title",
+                                      "_expanded": false
+                                    }
+                                  ],
+                                  "components": [
+                                    {
+                                      "type": "tbody",
+                                      "draggable": [
+                                        "table"
+                                      ],
+                                      "droppable": [
+                                        "tr"
+                                      ],
+                                      "components": [
+                                        {
+                                          "type": "row",
+                                          "draggable": [
+                                            "thead",
+                                            "tbody",
+                                            "tfoot"
+                                          ],
+                                          "droppable": [
+                                            "th",
+                                            "td"
+                                          ],
+                                          "classes": [
+                                            "row"
+                                          ],
+                                          "components": [
+                                            {
+                                              "type": "cell",
+                                              "draggable": [
+                                                "tr"
+                                              ],
+                                              "classes": [
+                                                "cell"
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "chart-color": "#2c3e50"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "head": {
+                        "type": "head"
+                      },
+                      "docEl": {
+                        "tagName": "html"
+                      }
+                    },
+                    "id": "XruvDjQhozYlWgE8"
+                  }
+                ],
+                "id": "page-author-2",
+                "route_path": "/author"
+              }
+            ],
+            "styles": [
+              {
+                "selectors": [
+                  "#i7thg"
+                ],
+                "style": {
+                  "margin-top": "0",
+                  "font-size": "24px",
+                  "margin-bottom": "30px",
+                  "font-weight": "bold"
+                }
+              },
+              {
+                "selectors": [
+                  "#ih8h6"
+                ],
+                "style": {
+                  "color": "white",
+                  "text-decoration": "none",
+                  "padding": "10px 15px",
+                  "display": "block",
+                  "background": "rgba(255,255,255,0.2)",
+                  "border-radius": "4px",
+                  "margin-bottom": "5px"
+                }
+              },
+              {
+                "selectors": [
+                  "#i9l4g"
+                ],
+                "style": {
+                  "color": "white",
+                  "text-decoration": "none",
+                  "padding": "10px 15px",
+                  "display": "block",
+                  "background": "transparent",
+                  "border-radius": "4px",
+                  "margin-bottom": "5px"
+                }
+              },
+              {
+                "selectors": [
+                  "#io6eh"
+                ],
+                "style": {
+                  "color": "white",
+                  "text-decoration": "none",
+                  "padding": "10px 15px",
+                  "display": "block",
+                  "background": "transparent",
+                  "border-radius": "4px",
+                  "margin-bottom": "5px"
+                }
+              },
+              {
+                "selectors": [
+                  "#iwntp"
+                ],
+                "style": {
+                  "display": "flex",
+                  "flex-direction": "column",
+                  "flex": "1"
+                }
+              },
+              {
+                "selectors": [
+                  "#ixx2i"
+                ],
+                "style": {
+                  "margin-top": "auto",
+                  "padding-top": "20px",
+                  "border-top": "1px solid rgba(255,255,255,0.2)",
+                  "font-size": "11px",
+                  "opacity": "0.8",
+                  "text-align": "center"
+                }
+              },
+              {
+                "selectors": [
+                  "#ihyzm"
+                ],
+                "style": {
+                  "width": "250px",
+                  "background": "linear-gradient(135deg, #4b3c82 0%, #5a3d91 100%)",
+                  "color": "white",
+                  "padding": "20px",
+                  "overflow-y": "auto",
+                  "display": "flex",
+                  "flex-direction": "column"
+                }
+              },
+              {
+                "selectors": [
+                  "#iyjpg"
+                ],
+                "style": {
+                  "margin-top": "0",
+                  "color": "#333",
+                  "font-size": "32px",
+                  "margin-bottom": "10px"
+                }
+              },
+              {
+                "selectors": [
+                  "#itizf"
+                ],
+                "style": {
+                  "color": "#666",
+                  "margin-bottom": "30px"
+                }
+              },
+              {
+                "selectors": [
+                  "#table-book-0"
+                ],
+                "style": {
+                  "width": "100%",
+                  "min-height": "400px"
+                }
+              },
+              {
+                "selectors": [
+                  "#idgyv"
+                ],
+                "style": {
+                  "display": "inline-flex",
+                  "align-items": "center",
+                  "padding": "6px 14px",
+                  "background": "linear-gradient(90deg, #2563eb 0%, #1e40af 100%)",
+                  "color": "#fff",
+                  "text-decoration": "none",
+                  "border-radius": "4px",
+                  "font-size": "13px",
+                  "font-weight": "600",
+                  "letter-spacing": "0.01em",
+                  "cursor": "pointer",
+                  "border": "none",
+                  "box-shadow": "0 1px 4px rgba(37,99,235,0.10)",
+                  "transition": "background 0.2s"
+                }
+              },
+              {
+                "selectors": [
+                  "#ioq13"
+                ],
+                "style": {
+                  "margin-top": "20px",
+                  "display": "flex",
+                  "gap": "10px",
+                  "flex-wrap": "wrap"
+                }
+              },
+              {
+                "selectors": [
+                  "#i0mrm"
+                ],
+                "style": {
+                  "flex": "1",
+                  "padding": "40px",
+                  "overflow-y": "auto",
+                  "background": "#f5f5f5"
+                }
+              },
+              {
+                "selectors": [
+                  "#iir99"
+                ],
+                "style": {
+                  "display": "flex",
+                  "height": "100vh",
+                  "font-family": "Arial, sans-serif"
+                }
+              },
+              {
+                "selectors": [
+                  "#iopqh"
+                ],
+                "style": {
+                  "margin-top": "0",
+                  "font-size": "24px",
+                  "margin-bottom": "30px",
+                  "font-weight": "bold"
+                }
+              },
+              {
+                "selectors": [
+                  "#ix6dg"
+                ],
+                "style": {
+                  "color": "white",
+                  "text-decoration": "none",
+                  "padding": "10px 15px",
+                  "display": "block",
+                  "background": "transparent",
+                  "border-radius": "4px",
+                  "margin-bottom": "5px"
+                }
+              },
+              {
+                "selectors": [
+                  "#ixrwm"
+                ],
+                "style": {
+                  "color": "white",
+                  "text-decoration": "none",
+                  "padding": "10px 15px",
+                  "display": "block",
+                  "background": "rgba(255,255,255,0.2)",
+                  "border-radius": "4px",
+                  "margin-bottom": "5px"
+                }
+              },
+              {
+                "selectors": [
+                  "#iauyc"
+                ],
+                "style": {
+                  "color": "white",
+                  "text-decoration": "none",
+                  "padding": "10px 15px",
+                  "display": "block",
+                  "background": "transparent",
+                  "border-radius": "4px",
+                  "margin-bottom": "5px"
+                }
+              },
+              {
+                "selectors": [
+                  "#iui4i"
+                ],
+                "style": {
+                  "display": "flex",
+                  "flex-direction": "column",
+                  "flex": "1"
+                }
+              },
+              {
+                "selectors": [
+                  "#iijek"
+                ],
+                "style": {
+                  "margin-top": "auto",
+                  "padding-top": "20px",
+                  "border-top": "1px solid rgba(255,255,255,0.2)",
+                  "font-size": "11px",
+                  "opacity": "0.8",
+                  "text-align": "center"
+                }
+              },
+              {
+                "selectors": [
+                  "#i5v1l"
+                ],
+                "style": {
+                  "width": "250px",
+                  "background": "linear-gradient(135deg, #4b3c82 0%, #5a3d91 100%)",
+                  "color": "white",
+                  "padding": "20px",
+                  "overflow-y": "auto",
+                  "display": "flex",
+                  "flex-direction": "column"
+                }
+              },
+              {
+                "selectors": [
+                  "#ihqgf"
+                ],
+                "style": {
+                  "margin-top": "0",
+                  "color": "#333",
+                  "font-size": "32px",
+                  "margin-bottom": "10px"
+                }
+              },
+              {
+                "selectors": [
+                  "#ij47n"
+                ],
+                "style": {
+                  "color": "#666",
+                  "margin-bottom": "30px"
+                }
+              },
+              {
+                "selectors": [
+                  "#table-library-1"
+                ],
+                "style": {
+                  "width": "100%",
+                  "min-height": "400px"
+                }
+              },
+              {
+                "selectors": [
+                  "#ir5xw"
+                ],
+                "style": {
+                  "display": "inline-flex",
+                  "align-items": "center",
+                  "padding": "6px 14px",
+                  "background": "linear-gradient(90deg, #2563eb 0%, #1e40af 100%)",
+                  "color": "#fff",
+                  "text-decoration": "none",
+                  "border-radius": "4px",
+                  "font-size": "13px",
+                  "font-weight": "600",
+                  "letter-spacing": "0.01em",
+                  "cursor": "pointer",
+                  "border": "none",
+                  "box-shadow": "0 1px 4px rgba(37,99,235,0.10)",
+                  "transition": "background 0.2s"
+                }
+              },
+              {
+                "selectors": [
+                  "#i0iia"
+                ],
+                "style": {
+                  "margin-top": "20px",
+                  "display": "flex",
+                  "gap": "10px",
+                  "flex-wrap": "wrap"
+                }
+              },
+              {
+                "selectors": [
+                  "#i845n"
+                ],
+                "style": {
+                  "flex": "1",
+                  "padding": "40px",
+                  "overflow-y": "auto",
+                  "background": "#f5f5f5"
+                }
+              },
+              {
+                "selectors": [
+                  "#ipfo8"
+                ],
+                "style": {
+                  "display": "flex",
+                  "height": "100vh",
+                  "font-family": "Arial, sans-serif"
+                }
+              },
+              {
+                "selectors": [
+                  "#i3xv3"
+                ],
+                "style": {
+                  "margin-top": "0",
+                  "font-size": "24px",
+                  "margin-bottom": "30px",
+                  "font-weight": "bold"
+                }
+              },
+              {
+                "selectors": [
+                  "#ibxxn"
+                ],
+                "style": {
+                  "color": "white",
+                  "text-decoration": "none",
+                  "padding": "10px 15px",
+                  "display": "block",
+                  "background": "transparent",
+                  "border-radius": "4px",
+                  "margin-bottom": "5px"
+                }
+              },
+              {
+                "selectors": [
+                  "#ik9yu"
+                ],
+                "style": {
+                  "color": "white",
+                  "text-decoration": "none",
+                  "padding": "10px 15px",
+                  "display": "block",
+                  "background": "transparent",
+                  "border-radius": "4px",
+                  "margin-bottom": "5px"
+                }
+              },
+              {
+                "selectors": [
+                  "#ibnlk"
+                ],
+                "style": {
+                  "color": "white",
+                  "text-decoration": "none",
+                  "padding": "10px 15px",
+                  "display": "block",
+                  "background": "rgba(255,255,255,0.2)",
+                  "border-radius": "4px",
+                  "margin-bottom": "5px"
+                }
+              },
+              {
+                "selectors": [
+                  "#itt6j"
+                ],
+                "style": {
+                  "display": "flex",
+                  "flex-direction": "column",
+                  "flex": "1"
+                }
+              },
+              {
+                "selectors": [
+                  "#il285"
+                ],
+                "style": {
+                  "margin-top": "auto",
+                  "padding-top": "20px",
+                  "border-top": "1px solid rgba(255,255,255,0.2)",
+                  "font-size": "11px",
+                  "opacity": "0.8",
+                  "text-align": "center"
+                }
+              },
+              {
+                "selectors": [
+                  "#is7w8"
+                ],
+                "style": {
+                  "width": "250px",
+                  "background": "linear-gradient(135deg, #4b3c82 0%, #5a3d91 100%)",
+                  "color": "white",
+                  "padding": "20px",
+                  "overflow-y": "auto",
+                  "display": "flex",
+                  "flex-direction": "column"
+                }
+              },
+              {
+                "selectors": [
+                  "#iqnfa"
+                ],
+                "style": {
+                  "margin-top": "0",
+                  "color": "#333",
+                  "font-size": "32px",
+                  "margin-bottom": "10px"
+                }
+              },
+              {
+                "selectors": [
+                  "#i8odx"
+                ],
+                "style": {
+                  "color": "#666",
+                  "margin-bottom": "30px"
+                }
+              },
+              {
+                "selectors": [
+                  "#table-author-2"
+                ],
+                "style": {
+                  "width": "100%",
+                  "min-height": "400px"
+                }
+              },
+              {
+                "selectors": [
+                  "#ih5us"
+                ],
+                "style": {
+                  "flex": "1",
+                  "padding": "40px",
+                  "overflow-y": "auto",
+                  "background": "#f5f5f5"
+                }
+              },
+              {
+                "selectors": [
+                  "#in05f"
+                ],
+                "style": {
+                  "display": "flex",
+                  "height": "100vh",
+                  "font-family": "Arial, sans-serif"
+                }
+              },
+              {
+                "selectors": [
+                  "#im47u"
+                ],
+                "style": {
+                  "width": "100%",
+                  "min-height": "400px"
+                }
+              }
+            ],
+            "assets": [],
+            "symbols": [],
+            "version": "0.21.13"
+          },
+          "lastUpdate": "2026-05-06T11:31:32.638Z"
+        }
+      ]
+    },
+    "settings": {
+      "defaultDiagramType": "ClassDiagram",
+      "autoSave": true,
+      "collaborationEnabled": false,
+      "perspectives": {
+        "ClassDiagram": true,
+        "ObjectDiagram": false,
+        "StateMachineDiagram": false,
+        "AgentDiagram": true,
+        "UserDiagram": false,
+        "GUINoCodeDiagram": true,
+        "QuantumCircuitDiagram": false,
+        "NNDiagram": false
+      }
+    }
+  },
+  "exportedAt": "2026-05-06T00:00:00.000Z",
+  "version": "2.0.0"
+}

--- a/packages/webapp/src/main/templates/pattern/project/personalized_gym_agent.json
+++ b/packages/webapp/src/main/templates/pattern/project/personalized_gym_agent.json
@@ -1,0 +1,3194 @@
+{
+  "project": {
+    "id": "f1d25c3f-3fff-45c7-ad25-70cf88c99f3e",
+    "type": "Project",
+    "schemaVersion": 4,
+    "name": "Personalized Gym Agent",
+    "description": "A personalized gym training agent: agent diagram coordinating user models for tailored workout planning.",
+    "owner": "BESSER User",
+    "createdAt": "2026-05-06T06:40:41.312Z",
+    "currentDiagramType": "UserDiagram",
+    "currentDiagramIndices": {
+      "ClassDiagram": 0,
+      "ObjectDiagram": 0,
+      "StateMachineDiagram": 0,
+      "AgentDiagram": 0,
+      "UserDiagram": 1,
+      "GUINoCodeDiagram": 0,
+      "QuantumCircuitDiagram": 0,
+      "NNDiagram": 0
+    },
+    "diagrams": {
+      "AgentDiagram": [
+        {
+          "id": "7ac41ba3-7e2b-44bd-9e47-46c377a9d757",
+          "title": "Gym Agent",
+          "model": {
+            "version": "3.0.0",
+            "type": "AgentDiagram",
+            "size": {
+              "width": 1300,
+              "height": 900
+            },
+            "interactive": {
+              "elements": {},
+              "relationships": {}
+            },
+            "elements": {
+              "c383f8b0-d915-439b-8bde-18a30da80fa3": {
+                "id": "c383f8b0-d915-439b-8bde-18a30da80fa3",
+                "name": "Muscles_intent",
+                "type": "AgentIntent",
+                "owner": null,
+                "bounds": {
+                  "x": -550,
+                  "y": -300,
+                  "width": 630,
+                  "height": 100
+                },
+                "bodies": [
+                  "6b718df7-70ef-4e1c-8c6b-c82133964f86"
+                ],
+                "intent_description": "Question about how to become muscular and which exercises to perform."
+              },
+              "6b718df7-70ef-4e1c-8c6b-c82133964f86": {
+                "id": "6b718df7-70ef-4e1c-8c6b-c82133964f86",
+                "name": "I want muscles",
+                "type": "AgentIntentBody",
+                "owner": "c383f8b0-d915-439b-8bde-18a30da80fa3",
+                "bounds": {
+                  "x": -549.5,
+                  "y": -229.5,
+                  "width": 629,
+                  "height": 30
+                }
+              },
+              "a009a9ba-7a03-4f79-9122-416d8b74a0bb": {
+                "id": "a009a9ba-7a03-4f79-9122-416d8b74a0bb",
+                "name": "Nutrition_intent",
+                "type": "AgentIntent",
+                "owner": null,
+                "bounds": {
+                  "x": -250,
+                  "y": -300,
+                  "width": 340,
+                  "height": 100
+                },
+                "bodies": [
+                  "192db72d-4d0e-49b0-b49c-5050fb0dbb68"
+                ],
+                "intent_description": "Question about nutrition in gym."
+              },
+              "192db72d-4d0e-49b0-b49c-5050fb0dbb68": {
+                "id": "192db72d-4d0e-49b0-b49c-5050fb0dbb68",
+                "name": "Which food to eat?",
+                "type": "AgentIntentBody",
+                "owner": "a009a9ba-7a03-4f79-9122-416d8b74a0bb",
+                "bounds": {
+                  "x": -249.5,
+                  "y": -229.5,
+                  "width": 339,
+                  "height": 30
+                }
+              },
+              "90d28305-378e-4bad-b3ea-61c3ddaa5921": {
+                "id": "90d28305-378e-4bad-b3ea-61c3ddaa5921",
+                "name": "Other",
+                "type": "AgentIntent",
+                "owner": null,
+                "bounds": {
+                  "x": 50,
+                  "y": -300,
+                  "width": 500,
+                  "height": 70
+                },
+                "bodies": [],
+                "intent_description": "Any question that does not fit in \"Muscles\" or \"Nutrition\""
+              },
+              "731e886c-9cef-4fa7-ba6d-72aa25c32d4f": {
+                "id": "731e886c-9cef-4fa7-ba6d-72aa25c32d4f",
+                "name": "",
+                "type": "StateInitialNode",
+                "owner": null,
+                "bounds": {
+                  "x": -580,
+                  "y": -60,
+                  "width": 45,
+                  "height": 45
+                }
+              },
+              "c10f03ca-2073-4002-8d1b-e42536008f4c": {
+                "id": "c10f03ca-2073-4002-8d1b-e42536008f4c",
+                "name": "Initial",
+                "type": "AgentState",
+                "owner": null,
+                "bounds": {
+                  "x": -280,
+                  "y": -80,
+                  "width": 330,
+                  "height": 70
+                },
+                "bodies": [
+                  "82783f5d-8ef3-47f7-8feb-9651bdf73d63"
+                ],
+                "fallbackBodies": []
+              },
+              "82783f5d-8ef3-47f7-8feb-9651bdf73d63": {
+                "id": "82783f5d-8ef3-47f7-8feb-9651bdf73d63",
+                "name": "Hi, I am your buddy, the fitness agent.",
+                "type": "AgentStateBody",
+                "owner": "c10f03ca-2073-4002-8d1b-e42536008f4c",
+                "bounds": {
+                  "x": -279.5,
+                  "y": -39.5,
+                  "width": 329,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8": {
+                "id": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                "name": "Idle",
+                "type": "AgentState",
+                "owner": null,
+                "bounds": {
+                  "x": 210,
+                  "y": -80,
+                  "width": 420,
+                  "height": 100
+                },
+                "bodies": [
+                  "d91b1fe8-cd6c-4b20-928c-70021c0f044d"
+                ],
+                "fallbackBodies": [
+                  "10a044fe-f0bd-41e8-ae27-0f2c2afc2cac"
+                ]
+              },
+              "d91b1fe8-cd6c-4b20-928c-70021c0f044d": {
+                "id": "d91b1fe8-cd6c-4b20-928c-70021c0f044d",
+                "name": "I am here to answer any questions regarding exercises, nutrition and recovery.",
+                "type": "AgentStateBody",
+                "owner": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                "bounds": {
+                  "x": 210.5,
+                  "y": -39.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "10a044fe-f0bd-41e8-ae27-0f2c2afc2cac": {
+                "id": "10a044fe-f0bd-41e8-ae27-0f2c2afc2cac",
+                "name": "I focus on gym and fitness topics only dude.",
+                "type": "AgentStateFallbackBody",
+                "owner": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                "bounds": {
+                  "x": 210.5,
+                  "y": -9.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "aa0bf687-2e08-4cba-aa98-335bcce5ecc7": {
+                "id": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+                "name": "TrainingPlan",
+                "type": "AgentState",
+                "owner": null,
+                "bounds": {
+                  "x": -280,
+                  "y": 140,
+                  "width": 420,
+                  "height": 130
+                },
+                "bodies": [
+                  "d55e541d-6530-44ad-8d86-0ae51039bd72",
+                  "964f437d-ab33-4e0d-bd1c-e36387c879eb",
+                  "31249e62-6b58-48fb-af98-e55090d683e1"
+                ],
+                "fallbackBodies": []
+              },
+              "d55e541d-6530-44ad-8d86-0ae51039bd72": {
+                "id": "d55e541d-6530-44ad-8d86-0ae51039bd72",
+                "name": "Focus on accessible compound upper-body and core movements like bench press or machine chest press, overhead press, seated rows, lat pulldowns/assisted pull-ups, dips or triceps pushdowns, face pulls, and anti-rotation core work (e.g., Pallof press), using seated or strap-stabilized setups as needed.",
+                "type": "AgentStateBody",
+                "owner": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+                "bounds": {
+                  "x": -279.5,
+                  "y": 180.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "964f437d-ab33-4e0d-bd1c-e36387c879eb": {
+                "id": "964f437d-ab33-4e0d-bd1c-e36387c879eb",
+                "name": "Train 3\u20135 times per week, progressively increasing resistance on upper-body and core-focused exercises while eating enough protein and calories to support growth; balance pushing and pulling to protect your shoulders and allow adequate recovery.",
+                "type": "AgentStateBody",
+                "owner": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+                "bounds": {
+                  "x": -279.5,
+                  "y": 210.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "31249e62-6b58-48fb-af98-e55090d683e1": {
+                "id": "31249e62-6b58-48fb-af98-e55090d683e1",
+                "name": "Get good sleep and stay consistent\u2014muscle comes from steady effort over time.",
+                "type": "AgentStateBody",
+                "owner": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+                "bounds": {
+                  "x": -279.5,
+                  "y": 240.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "110dac05-6c3a-4fd1-a747-6df88d09cf77": {
+                "id": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                "name": "Nutrition",
+                "type": "AgentState",
+                "owner": null,
+                "bounds": {
+                  "x": 210,
+                  "y": 140,
+                  "width": 420,
+                  "height": 190
+                },
+                "bodies": [
+                  "3fa5c3b5-3e12-4968-b16c-1f80a98693c1",
+                  "5c6dad70-8209-4de6-ae7a-5a9747fada8a",
+                  "ac38d464-9f06-48cf-b6c5-76e721298f92",
+                  "49fc07e1-484c-4459-b5b9-b223c5d7b129",
+                  "0bcfa6cb-74c0-43c8-867b-2fc966c53671"
+                ],
+                "fallbackBodies": []
+              },
+              "3fa5c3b5-3e12-4968-b16c-1f80a98693c1": {
+                "id": "3fa5c3b5-3e12-4968-b16c-1f80a98693c1",
+                "name": "Nutrition basics: Eat mostly whole foods (lean protein, vegetables, fruits, whole grains, healthy fats). Protein: ~1.6\u20132.2 g per kg of body weight daily..",
+                "type": "AgentStateBody",
+                "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                "bounds": {
+                  "x": 210.5,
+                  "y": 180.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "5c6dad70-8209-4de6-ae7a-5a9747fada8a": {
+                "id": "5c6dad70-8209-4de6-ae7a-5a9747fada8a",
+                "name": "Match calories to your goal: slight surplus to gain muscle, deficit to lose fat, maintenance to stay the same.",
+                "type": "AgentStateBody",
+                "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                "bounds": {
+                  "x": 210.5,
+                  "y": 210.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "ac38d464-9f06-48cf-b6c5-76e721298f92": {
+                "id": "ac38d464-9f06-48cf-b6c5-76e721298f92",
+                "name": "Carbs fuel training; fats support hormones.",
+                "type": "AgentStateBody",
+                "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                "bounds": {
+                  "x": 210.5,
+                  "y": 240.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "49fc07e1-484c-4459-b5b9-b223c5d7b129": {
+                "id": "49fc07e1-484c-4459-b5b9-b223c5d7b129",
+                "name": "Drink plenty of water and limit ultra-processed foods and alcohol.",
+                "type": "AgentStateBody",
+                "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                "bounds": {
+                  "x": 210.5,
+                  "y": 270.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "0bcfa6cb-74c0-43c8-867b-2fc966c53671": {
+                "id": "0bcfa6cb-74c0-43c8-867b-2fc966c53671",
+                "name": "Be consistent \u2014 results come from habits, not perfection",
+                "type": "AgentStateBody",
+                "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                "bounds": {
+                  "x": 210.5,
+                  "y": 300.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text"
+              },
+              "a22b9877-2809-426e-8b72-504ef7abcce0": {
+                "id": "a22b9877-2809-426e-8b72-504ef7abcce0",
+                "name": "OtherQuestions",
+                "type": "AgentState",
+                "owner": null,
+                "bounds": {
+                  "x": -280,
+                  "y": 360,
+                  "width": 180,
+                  "height": 70
+                },
+                "bodies": [
+                  "3721c5e6-19b1-4811-8b00-17415913c3aa"
+                ],
+                "fallbackBodies": []
+              },
+              "3721c5e6-19b1-4811-8b00-17415913c3aa": {
+                "id": "3721c5e6-19b1-4811-8b00-17415913c3aa",
+                "name": "AI response \ud83e\ude84",
+                "type": "AgentStateBody",
+                "owner": "a22b9877-2809-426e-8b72-504ef7abcce0",
+                "bounds": {
+                  "x": -279.5,
+                  "y": 400.5,
+                  "width": 179,
+                  "height": 30
+                },
+                "replyType": "llm"
+              }
+            },
+            "relationships": {
+              "7ac61ff1-1e47-4e69-8d38-8fd9be6ab17d": {
+                "id": "7ac61ff1-1e47-4e69-8d38-8fd9be6ab17d",
+                "name": "",
+                "type": "AgentStateTransitionInit",
+                "owner": null,
+                "bounds": {
+                  "x": -535,
+                  "y": -37.5,
+                  "width": 255,
+                  "height": 1
+                },
+                "path": [
+                  {
+                    "x": 0,
+                    "y": 0
+                  },
+                  {
+                    "x": 255,
+                    "y": 0
+                  }
+                ],
+                "source": {
+                  "direction": "Right",
+                  "element": "731e886c-9cef-4fa7-ba6d-72aa25c32d4f",
+                  "bounds": {
+                    "x": -535,
+                    "y": -37.5,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "target": {
+                  "direction": "Left",
+                  "element": "c10f03ca-2073-4002-8d1b-e42536008f4c",
+                  "bounds": {
+                    "x": -280,
+                    "y": -45,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "isManuallyLayouted": false
+              },
+              "b3c5c9c2-81fc-4a12-985e-9e885ef6e9d0": {
+                "id": "b3c5c9c2-81fc-4a12-985e-9e885ef6e9d0",
+                "name": "",
+                "type": "AgentStateTransition",
+                "owner": null,
+                "bounds": {
+                  "x": 50,
+                  "y": -45,
+                  "width": 160,
+                  "height": 1
+                },
+                "path": [
+                  {
+                    "x": 0,
+                    "y": 0
+                  },
+                  {
+                    "x": 160,
+                    "y": 0
+                  }
+                ],
+                "source": {
+                  "direction": "Right",
+                  "element": "c10f03ca-2073-4002-8d1b-e42536008f4c",
+                  "bounds": {
+                    "x": -120,
+                    "y": -30,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "target": {
+                  "direction": "Left",
+                  "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                  "bounds": {
+                    "x": 210,
+                    "y": -30,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "isManuallyLayouted": false,
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "auto",
+                  "conditionValue": ""
+                },
+                "custom": {
+                  "condition": []
+                }
+              },
+              "48858dc4-d788-4f13-858b-3010ae2f4ead": {
+                "id": "48858dc4-d788-4f13-858b-3010ae2f4ead",
+                "name": "",
+                "type": "AgentStateTransition",
+                "owner": null,
+                "bounds": {
+                  "x": 140,
+                  "y": -30,
+                  "width": 70,
+                  "height": 235
+                },
+                "path": [
+                  {
+                    "x": 70,
+                    "y": 0
+                  },
+                  {
+                    "x": 30,
+                    "y": 0
+                  },
+                  {
+                    "x": 30,
+                    "y": 110
+                  },
+                  {
+                    "x": 40,
+                    "y": 110
+                  },
+                  {
+                    "x": 40,
+                    "y": 235
+                  },
+                  {
+                    "x": 0,
+                    "y": 235
+                  }
+                ],
+                "source": {
+                  "direction": "Left",
+                  "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                  "bounds": {
+                    "x": 210,
+                    "y": -30,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "target": {
+                  "direction": "Right",
+                  "element": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+                  "bounds": {
+                    "x": -120,
+                    "y": 190,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "isManuallyLayouted": false,
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "when_intent_matched",
+                  "intentName": "Muscles_intent"
+                },
+                "custom": {
+                  "condition": []
+                }
+              },
+              "425913e8-31ab-4ac5-908a-4f35fb7d732d": {
+                "id": "425913e8-31ab-4ac5-908a-4f35fb7d732d",
+                "name": "",
+                "type": "AgentStateTransition",
+                "owner": null,
+                "bounds": {
+                  "x": -100,
+                  "y": -30,
+                  "width": 310,
+                  "height": 425
+                },
+                "path": [
+                  {
+                    "x": 310,
+                    "y": 0
+                  },
+                  {
+                    "x": 155,
+                    "y": 0
+                  },
+                  {
+                    "x": 155,
+                    "y": 425
+                  },
+                  {
+                    "x": 0,
+                    "y": 425
+                  }
+                ],
+                "source": {
+                  "direction": "Left",
+                  "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                  "bounds": {
+                    "x": 210,
+                    "y": -30,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "target": {
+                  "direction": "Right",
+                  "element": "a22b9877-2809-426e-8b72-504ef7abcce0",
+                  "bounds": {
+                    "x": -120,
+                    "y": 410,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "isManuallyLayouted": false,
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "when_intent_matched",
+                  "intentName": "Other"
+                },
+                "custom": {
+                  "condition": []
+                }
+              },
+              "9f2ff8c7-b6dc-4246-b6ff-f1b1d1293a60": {
+                "id": "9f2ff8c7-b6dc-4246-b6ff-f1b1d1293a60",
+                "name": "",
+                "type": "AgentStateTransition",
+                "owner": null,
+                "bounds": {
+                  "x": 420,
+                  "y": 20,
+                  "width": 1,
+                  "height": 120
+                },
+                "path": [
+                  {
+                    "x": 0,
+                    "y": 0
+                  },
+                  {
+                    "x": 0,
+                    "y": 120
+                  }
+                ],
+                "source": {
+                  "direction": "Down",
+                  "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                  "bounds": {
+                    "x": 290,
+                    "y": 20,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "target": {
+                  "direction": "Up",
+                  "element": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                  "bounds": {
+                    "x": 290,
+                    "y": 140,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "isManuallyLayouted": false,
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "when_intent_matched",
+                  "intentName": "Nutrition_intent"
+                },
+                "custom": {
+                  "condition": []
+                }
+              },
+              "a5bf1da3-2426-43fb-827c-cc13ee896460": {
+                "id": "a5bf1da3-2426-43fb-827c-cc13ee896460",
+                "name": "",
+                "type": "AgentStateTransition",
+                "owner": null,
+                "bounds": {
+                  "x": 140,
+                  "y": -30,
+                  "width": 70,
+                  "height": 235
+                },
+                "path": [
+                  {
+                    "x": 0,
+                    "y": 235
+                  },
+                  {
+                    "x": 40,
+                    "y": 235
+                  },
+                  {
+                    "x": 40,
+                    "y": 110
+                  },
+                  {
+                    "x": 30,
+                    "y": 110
+                  },
+                  {
+                    "x": 30,
+                    "y": 0
+                  },
+                  {
+                    "x": 70,
+                    "y": 0
+                  }
+                ],
+                "source": {
+                  "direction": "Right",
+                  "element": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+                  "bounds": {
+                    "x": -120,
+                    "y": 190,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "target": {
+                  "direction": "Left",
+                  "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                  "bounds": {
+                    "x": 210,
+                    "y": -30,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "isManuallyLayouted": false,
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "auto",
+                  "conditionValue": ""
+                },
+                "custom": {
+                  "condition": []
+                }
+              },
+              "25914e9b-e4dd-461f-9b4a-10229b76b618": {
+                "id": "25914e9b-e4dd-461f-9b4a-10229b76b618",
+                "name": "",
+                "type": "AgentStateTransition",
+                "owner": null,
+                "bounds": {
+                  "x": 420,
+                  "y": 20,
+                  "width": 1,
+                  "height": 120
+                },
+                "path": [
+                  {
+                    "x": 0,
+                    "y": 120
+                  },
+                  {
+                    "x": 0,
+                    "y": 0
+                  }
+                ],
+                "source": {
+                  "direction": "Up",
+                  "element": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                  "bounds": {
+                    "x": 290,
+                    "y": 140,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "target": {
+                  "direction": "Down",
+                  "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                  "bounds": {
+                    "x": 290,
+                    "y": 20,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "isManuallyLayouted": false,
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "auto",
+                  "conditionValue": ""
+                },
+                "custom": {
+                  "condition": []
+                }
+              },
+              "0efab80b-2e8c-45a3-a998-78ccd579fbd9": {
+                "id": "0efab80b-2e8c-45a3-a998-78ccd579fbd9",
+                "name": "",
+                "type": "AgentStateTransition",
+                "owner": null,
+                "bounds": {
+                  "x": -100,
+                  "y": -30,
+                  "width": 310,
+                  "height": 425
+                },
+                "path": [
+                  {
+                    "x": 0,
+                    "y": 425
+                  },
+                  {
+                    "x": 155,
+                    "y": 425
+                  },
+                  {
+                    "x": 155,
+                    "y": 0
+                  },
+                  {
+                    "x": 310,
+                    "y": 0
+                  }
+                ],
+                "source": {
+                  "direction": "Right",
+                  "element": "a22b9877-2809-426e-8b72-504ef7abcce0",
+                  "bounds": {
+                    "x": -120,
+                    "y": 410,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "target": {
+                  "direction": "Left",
+                  "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                  "bounds": {
+                    "x": 210,
+                    "y": -30,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "isManuallyLayouted": false,
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "auto",
+                  "conditionValue": ""
+                },
+                "custom": {
+                  "condition": []
+                }
+              },
+              "0b385217-ea53-481d-8222-52dda332e351": {
+                "id": "0b385217-ea53-481d-8222-52dda332e351",
+                "name": "",
+                "type": "AgentStateTransitionInit",
+                "owner": null,
+                "bounds": {
+                  "x": -535,
+                  "y": -37.5,
+                  "width": 255,
+                  "height": 1
+                },
+                "path": [
+                  {
+                    "x": 0,
+                    "y": 0
+                  },
+                  {
+                    "x": 255,
+                    "y": 0
+                  }
+                ],
+                "source": {
+                  "direction": "Right",
+                  "element": "731e886c-9cef-4fa7-ba6d-72aa25c32d4f",
+                  "bounds": {
+                    "x": -535,
+                    "y": -37.5,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "target": {
+                  "direction": "Left",
+                  "element": "c10f03ca-2073-4002-8d1b-e42536008f4c",
+                  "bounds": {
+                    "x": -280,
+                    "y": -45,
+                    "width": 0,
+                    "height": 0
+                  }
+                },
+                "isManuallyLayouted": false
+              }
+            },
+            "assessments": {}
+          },
+          "lastUpdate": "2026-05-06T13:49:26.796Z",
+          "config": {
+            "agentLanguage": "original",
+            "inputModalities": [
+              "text"
+            ],
+            "outputModalities": [
+              "text"
+            ],
+            "agentPlatform": "streamlit",
+            "responseTiming": "instant",
+            "agentStyle": "original",
+            "llm": {
+              "provider": "openai",
+              "model": "gpt-5"
+            },
+            "languageComplexity": "original",
+            "sentenceLength": "original",
+            "interfaceStyle": {
+              "size": 16,
+              "font": "sans",
+              "lineSpacing": 1.5,
+              "alignment": "left",
+              "color": "var(--apollon-primary-contrast)",
+              "contrast": "medium"
+            },
+            "voiceStyle": {
+              "gender": "male",
+              "speed": 1
+            },
+            "avatar": null,
+            "useAbbreviations": false,
+            "adaptContentToUserProfile": true,
+            "userProfileName": "ParaplegicUser",
+            "intentRecognitionTechnology": "llm-based",
+            "personalizedVariants": [
+              {
+                "id": "b8d65359-7826-4ce3-a8dc-da01ce8865d7:75032e14-e116-4f62-8526-0bd8473283d5",
+                "profileId": "b8d65359-7826-4ce3-a8dc-da01ce8865d7",
+                "profileName": "Teenager",
+                "configurationId": "75032e14-e116-4f62-8526-0bd8473283d5",
+                "configurationName": "CoolConfig",
+                "createdAt": "2026-05-06T13:45:22.587Z",
+                "model": {
+                  "version": "3.0.0",
+                  "type": "AgentDiagram",
+                  "size": {
+                    "width": 1980,
+                    "height": 640
+                  },
+                  "interactive": {
+                    "elements": {},
+                    "relationships": {}
+                  },
+                  "elements": {
+                    "ccd1dced-243c-49c4-9a00-80e7f772327a": {
+                      "id": "ccd1dced-243c-49c4-9a00-80e7f772327a",
+                      "name": "I want muscles",
+                      "type": "AgentIntentBody",
+                      "owner": "566a781d-eb9d-4f80-bd98-8882ed800717",
+                      "bounds": {
+                        "x": -550,
+                        "y": -300,
+                        "width": 160,
+                        "height": 30
+                      }
+                    },
+                    "566a781d-eb9d-4f80-bd98-8882ed800717": {
+                      "id": "566a781d-eb9d-4f80-bd98-8882ed800717",
+                      "name": "Muscles_intent",
+                      "type": "AgentIntent",
+                      "owner": null,
+                      "bounds": {
+                        "x": -550,
+                        "y": -300,
+                        "width": 160,
+                        "height": 100
+                      },
+                      "bodies": [
+                        "ccd1dced-243c-49c4-9a00-80e7f772327a"
+                      ],
+                      "intent_description": "Question about how to become muscular and which exercises to perform."
+                    },
+                    "651f4205-d406-482c-8bb4-975fdf9e456f": {
+                      "id": "651f4205-d406-482c-8bb4-975fdf9e456f",
+                      "name": "Which food to eat?",
+                      "type": "AgentIntentBody",
+                      "owner": "1766afa2-4953-4cc8-9bb0-af48953503f3",
+                      "bounds": {
+                        "x": -250,
+                        "y": -300,
+                        "width": 160,
+                        "height": 30
+                      }
+                    },
+                    "1766afa2-4953-4cc8-9bb0-af48953503f3": {
+                      "id": "1766afa2-4953-4cc8-9bb0-af48953503f3",
+                      "name": "Nutrition_intent",
+                      "type": "AgentIntent",
+                      "owner": null,
+                      "bounds": {
+                        "x": -250,
+                        "y": -300,
+                        "width": 160,
+                        "height": 100
+                      },
+                      "bodies": [
+                        "651f4205-d406-482c-8bb4-975fdf9e456f"
+                      ],
+                      "intent_description": "Question about nutrition in gym."
+                    },
+                    "4037bf46-f138-4c9c-a891-c8f5639a19a0": {
+                      "id": "4037bf46-f138-4c9c-a891-c8f5639a19a0",
+                      "name": "Other",
+                      "type": "AgentIntent",
+                      "owner": null,
+                      "bounds": {
+                        "x": 50,
+                        "y": -300,
+                        "width": 160,
+                        "height": 100
+                      },
+                      "bodies": [],
+                      "intent_description": "Any question that does not fit in \"Muscles\" or \"Nutrition\""
+                    },
+                    "730ca64d-597c-4fd8-a756-5d98d475edb8": {
+                      "id": "730ca64d-597c-4fd8-a756-5d98d475edb8",
+                      "name": "",
+                      "type": "StateInitialNode",
+                      "owner": null,
+                      "bounds": {
+                        "x": -580,
+                        "y": -60,
+                        "width": 45,
+                        "height": 45
+                      }
+                    },
+                    "3effee26-ddc1-4180-8dfc-4f54d929c334": {
+                      "id": "3effee26-ddc1-4180-8dfc-4f54d929c334",
+                      "name": "Initial",
+                      "type": "AgentState",
+                      "owner": null,
+                      "bounds": {
+                        "x": -280,
+                        "y": -80,
+                        "width": 160,
+                        "height": 100
+                      },
+                      "bodies": [
+                        "e082c986-9bb3-45be-8f43-2e6b8af7a9d7"
+                      ],
+                      "fallbackBodies": []
+                    },
+                    "07601353-ee34-4ca9-bbe4-bdd711e624c4": {
+                      "id": "07601353-ee34-4ca9-bbe4-bdd711e624c4",
+                      "name": "Idle",
+                      "type": "AgentState",
+                      "owner": null,
+                      "bounds": {
+                        "x": 210,
+                        "y": -80,
+                        "width": 160,
+                        "height": 100
+                      },
+                      "bodies": [
+                        "ac420544-4ccf-4a49-9b3f-0c1eb9278f7e"
+                      ],
+                      "fallbackBodies": [
+                        "3e3e5cbe-d409-4601-9cb2-11b371cfb064"
+                      ]
+                    },
+                    "8f57a878-84ca-409d-b89d-cc62fc815507": {
+                      "id": "8f57a878-84ca-409d-b89d-cc62fc815507",
+                      "name": "TrainingPlan",
+                      "type": "AgentState",
+                      "owner": null,
+                      "bounds": {
+                        "x": -280,
+                        "y": 140,
+                        "width": 160,
+                        "height": 100
+                      },
+                      "bodies": [
+                        "bb125833-aa05-440d-922a-1684c5faea6f",
+                        "4403443a-176c-4c34-b4c1-59566a6cee15",
+                        "f7f7c51d-0768-4d06-ab4d-fe498e2665e7"
+                      ],
+                      "fallbackBodies": []
+                    },
+                    "c6bea043-ca61-463e-8c51-753602773b9a": {
+                      "id": "c6bea043-ca61-463e-8c51-753602773b9a",
+                      "name": "Nutrition",
+                      "type": "AgentState",
+                      "owner": null,
+                      "bounds": {
+                        "x": 210,
+                        "y": 140,
+                        "width": 160,
+                        "height": 100
+                      },
+                      "bodies": [
+                        "741a9bfa-d1ca-4ecf-b131-c0648fc0652a",
+                        "7c1a4721-5f81-4330-b2a7-b0e395c52aa3",
+                        "8c518247-6c3f-418a-9384-bb5272521b2b",
+                        "8c96e0a0-670e-4c28-9ef0-b81fef0b1e8d",
+                        "2c319d4a-9344-4a61-95d8-134fd903c053"
+                      ],
+                      "fallbackBodies": []
+                    },
+                    "b5895c6c-fdf9-4f1f-813f-ef8baaa7a008": {
+                      "id": "b5895c6c-fdf9-4f1f-813f-ef8baaa7a008",
+                      "name": "OtherQuestions",
+                      "type": "AgentState",
+                      "owner": null,
+                      "bounds": {
+                        "x": -280,
+                        "y": 360,
+                        "width": 160,
+                        "height": 100
+                      },
+                      "bodies": [
+                        "4499b560-b246-4b3f-b703-d9709836b98e"
+                      ],
+                      "fallbackBodies": []
+                    },
+                    "e082c986-9bb3-45be-8f43-2e6b8af7a9d7": {
+                      "id": "e082c986-9bb3-45be-8f43-2e6b8af7a9d7",
+                      "name": "Hi! I\u2019m your fitness helper and guide.",
+                      "type": "AgentStateBody",
+                      "owner": "3effee26-ddc1-4180-8dfc-4f54d929c334",
+                      "bounds": {
+                        "x": -280,
+                        "y": -80,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "ac420544-4ccf-4a49-9b3f-0c1eb9278f7e": {
+                      "id": "ac420544-4ccf-4a49-9b3f-0c1eb9278f7e",
+                      "name": "I can answer questions about workouts, food, and recovery.",
+                      "type": "AgentStateBody",
+                      "owner": "07601353-ee34-4ca9-bbe4-bdd711e624c4",
+                      "bounds": {
+                        "x": 210,
+                        "y": -80,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "3e3e5cbe-d409-4601-9cb2-11b371cfb064": {
+                      "id": "3e3e5cbe-d409-4601-9cb2-11b371cfb064",
+                      "name": "I only talk about gym and fitness.",
+                      "type": "AgentStateFallbackBody",
+                      "owner": "07601353-ee34-4ca9-bbe4-bdd711e624c4",
+                      "bounds": {
+                        "x": 210,
+                        "y": -80,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "bb125833-aa05-440d-922a-1684c5faea6f": {
+                      "id": "bb125833-aa05-440d-922a-1684c5faea6f",
+                      "name": "Focus on big, heavy lifts to build muscle: squats, deadlifts, bench press, overhead press, and rows.",
+                      "type": "AgentStateBody",
+                      "owner": "8f57a878-84ca-409d-b89d-cc62fc815507",
+                      "bounds": {
+                        "x": -280,
+                        "y": 140,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "4403443a-176c-4c34-b4c1-59566a6cee15": {
+                      "id": "4403443a-176c-4c34-b4c1-59566a6cee15",
+                      "name": "Train 3\u20135 days a week. Add a little weight over time. Eat enough protein and calories to grow.",
+                      "type": "AgentStateBody",
+                      "owner": "8f57a878-84ca-409d-b89d-cc62fc815507",
+                      "bounds": {
+                        "x": -280,
+                        "y": 140,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "f7f7c51d-0768-4d06-ab4d-fe498e2665e7": {
+                      "id": "f7f7c51d-0768-4d06-ab4d-fe498e2665e7",
+                      "name": "Sleep well and be consistent. Muscle grows with steady effort over time.",
+                      "type": "AgentStateBody",
+                      "owner": "8f57a878-84ca-409d-b89d-cc62fc815507",
+                      "bounds": {
+                        "x": -280,
+                        "y": 140,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "741a9bfa-d1ca-4ecf-b131-c0648fc0652a": {
+                      "id": "741a9bfa-d1ca-4ecf-b131-c0648fc0652a",
+                      "name": "Eat mostly whole foods: lean protein, vegetables, fruit, whole grains, and healthy fats. Aim for 1.6 to 2.2 grams of protein per kilogram of body weight each day.",
+                      "type": "AgentStateBody",
+                      "owner": "c6bea043-ca61-463e-8c51-753602773b9a",
+                      "bounds": {
+                        "x": 210,
+                        "y": 140,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "7c1a4721-5f81-4330-b2a7-b0e395c52aa3": {
+                      "id": "7c1a4721-5f81-4330-b2a7-b0e395c52aa3",
+                      "name": "Match calories to your goal: eat a little more to gain muscle, eat less to lose fat, eat the same to stay the same.",
+                      "type": "AgentStateBody",
+                      "owner": "c6bea043-ca61-463e-8c51-753602773b9a",
+                      "bounds": {
+                        "x": 210,
+                        "y": 140,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "8c518247-6c3f-418a-9384-bb5272521b2b": {
+                      "id": "8c518247-6c3f-418a-9384-bb5272521b2b",
+                      "name": "Carbs give you energy for training. Fats help your hormones.",
+                      "type": "AgentStateBody",
+                      "owner": "c6bea043-ca61-463e-8c51-753602773b9a",
+                      "bounds": {
+                        "x": 210,
+                        "y": 140,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "8c96e0a0-670e-4c28-9ef0-b81fef0b1e8d": {
+                      "id": "8c96e0a0-670e-4c28-9ef0-b81fef0b1e8d",
+                      "name": "Drink plenty of water. Limit highly processed foods and alcohol.",
+                      "type": "AgentStateBody",
+                      "owner": "c6bea043-ca61-463e-8c51-753602773b9a",
+                      "bounds": {
+                        "x": 210,
+                        "y": 140,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "2c319d4a-9344-4a61-95d8-134fd903c053": {
+                      "id": "2c319d4a-9344-4a61-95d8-134fd903c053",
+                      "name": "Be consistent. Results come from good habits, not perfection.",
+                      "type": "AgentStateBody",
+                      "owner": "c6bea043-ca61-463e-8c51-753602773b9a",
+                      "bounds": {
+                        "x": 210,
+                        "y": 140,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "4499b560-b246-4b3f-b703-d9709836b98e": {
+                      "id": "4499b560-b246-4b3f-b703-d9709836b98e",
+                      "name": "AI response \ud83e\ude84",
+                      "type": "AgentStateBody",
+                      "owner": "b5895c6c-fdf9-4f1f-813f-ef8baaa7a008",
+                      "bounds": {
+                        "x": -280,
+                        "y": 360,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "llm"
+                    }
+                  },
+                  "relationships": {
+                    "4b6aa5dd-81c4-4ae8-a6bf-d6aa587831d1": {
+                      "id": "4b6aa5dd-81c4-4ae8-a6bf-d6aa587831d1",
+                      "name": "",
+                      "type": "AgentStateTransitionInit",
+                      "owner": null,
+                      "source": {
+                        "direction": "Right",
+                        "element": "730ca64d-597c-4fd8-a756-5d98d475edb8",
+                        "bounds": {
+                          "x": -535,
+                          "y": -37.5,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "target": {
+                        "direction": "Left",
+                        "element": "3effee26-ddc1-4180-8dfc-4f54d929c334",
+                        "bounds": {
+                          "x": -280,
+                          "y": -45,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "bounds": {
+                        "x": -535,
+                        "y": -37.5,
+                        "width": 255,
+                        "height": 1
+                      },
+                      "path": [
+                        {
+                          "x": -535,
+                          "y": -37.5
+                        },
+                        {
+                          "x": -280,
+                          "y": -37.5
+                        }
+                      ],
+                      "isManuallyLayouted": false
+                    },
+                    "5f4c44a4-fdd5-4039-8896-30544b0780ba": {
+                      "id": "5f4c44a4-fdd5-4039-8896-30544b0780ba",
+                      "name": "",
+                      "type": "AgentStateTransition",
+                      "owner": null,
+                      "bounds": {
+                        "x": -130,
+                        "y": -40,
+                        "width": 350,
+                        "height": 20
+                      },
+                      "path": [
+                        {
+                          "x": -120,
+                          "y": -30
+                        },
+                        {
+                          "x": 45,
+                          "y": -30
+                        },
+                        {
+                          "x": 45,
+                          "y": -30
+                        },
+                        {
+                          "x": 210,
+                          "y": -30
+                        }
+                      ],
+                      "source": {
+                        "direction": "Right",
+                        "element": "3effee26-ddc1-4180-8dfc-4f54d929c334",
+                        "bounds": {
+                          "x": -120,
+                          "y": -30,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "target": {
+                        "direction": "Left",
+                        "element": "07601353-ee34-4ca9-bbe4-bdd711e624c4",
+                        "bounds": {
+                          "x": 210,
+                          "y": -30,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "isManuallyLayouted": false,
+                      "transitionType": "predefined",
+                      "predefined": {
+                        "predefinedType": "auto",
+                        "conditionValue": ""
+                      },
+                      "custom": {
+                        "event": "None",
+                        "condition": []
+                      }
+                    },
+                    "b49bbd98-4465-4534-8bdc-e6861d4ff6b3": {
+                      "id": "b49bbd98-4465-4534-8bdc-e6861d4ff6b3",
+                      "name": "",
+                      "type": "AgentStateTransition",
+                      "owner": null,
+                      "bounds": {
+                        "x": -130,
+                        "y": -40,
+                        "width": 350,
+                        "height": 240
+                      },
+                      "path": [
+                        {
+                          "x": 210,
+                          "y": -30
+                        },
+                        {
+                          "x": 45,
+                          "y": -30
+                        },
+                        {
+                          "x": 45,
+                          "y": 190
+                        },
+                        {
+                          "x": -120,
+                          "y": 190
+                        }
+                      ],
+                      "source": {
+                        "direction": "Left",
+                        "element": "07601353-ee34-4ca9-bbe4-bdd711e624c4",
+                        "bounds": {
+                          "x": 210,
+                          "y": -30,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "target": {
+                        "direction": "Right",
+                        "element": "8f57a878-84ca-409d-b89d-cc62fc815507",
+                        "bounds": {
+                          "x": -120,
+                          "y": 190,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "isManuallyLayouted": false,
+                      "transitionType": "predefined",
+                      "predefined": {
+                        "predefinedType": "when_intent_matched",
+                        "intentName": "Muscles_intent"
+                      },
+                      "custom": {
+                        "event": "None",
+                        "condition": []
+                      }
+                    },
+                    "8b843917-2912-4965-a82b-0fbb16f9fefa": {
+                      "id": "8b843917-2912-4965-a82b-0fbb16f9fefa",
+                      "name": "",
+                      "type": "AgentStateTransition",
+                      "owner": null,
+                      "bounds": {
+                        "x": -130,
+                        "y": -40,
+                        "width": 350,
+                        "height": 460
+                      },
+                      "path": [
+                        {
+                          "x": 210,
+                          "y": -30
+                        },
+                        {
+                          "x": 45,
+                          "y": -30
+                        },
+                        {
+                          "x": 45,
+                          "y": 410
+                        },
+                        {
+                          "x": -120,
+                          "y": 410
+                        }
+                      ],
+                      "source": {
+                        "direction": "Left",
+                        "element": "07601353-ee34-4ca9-bbe4-bdd711e624c4",
+                        "bounds": {
+                          "x": 210,
+                          "y": -30,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "target": {
+                        "direction": "Right",
+                        "element": "b5895c6c-fdf9-4f1f-813f-ef8baaa7a008",
+                        "bounds": {
+                          "x": -120,
+                          "y": 410,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "isManuallyLayouted": false,
+                      "transitionType": "predefined",
+                      "predefined": {
+                        "predefinedType": "when_intent_matched",
+                        "intentName": "Other"
+                      },
+                      "custom": {
+                        "event": "None",
+                        "condition": []
+                      }
+                    },
+                    "43f309b8-9635-4b51-82ed-445d4b6b4d66": {
+                      "id": "43f309b8-9635-4b51-82ed-445d4b6b4d66",
+                      "name": "",
+                      "type": "AgentStateTransition",
+                      "owner": null,
+                      "bounds": {
+                        "x": 280,
+                        "y": 10,
+                        "width": 20,
+                        "height": 140
+                      },
+                      "path": [
+                        {
+                          "x": 290,
+                          "y": 20
+                        },
+                        {
+                          "x": 290,
+                          "y": 80
+                        },
+                        {
+                          "x": 290,
+                          "y": 80
+                        },
+                        {
+                          "x": 290,
+                          "y": 140
+                        }
+                      ],
+                      "source": {
+                        "direction": "Down",
+                        "element": "07601353-ee34-4ca9-bbe4-bdd711e624c4",
+                        "bounds": {
+                          "x": 290,
+                          "y": 20,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "target": {
+                        "direction": "Up",
+                        "element": "c6bea043-ca61-463e-8c51-753602773b9a",
+                        "bounds": {
+                          "x": 290,
+                          "y": 140,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "isManuallyLayouted": false,
+                      "transitionType": "predefined",
+                      "predefined": {
+                        "predefinedType": "when_intent_matched",
+                        "intentName": "Nutrition_intent"
+                      },
+                      "custom": {
+                        "event": "None",
+                        "condition": []
+                      }
+                    },
+                    "6969907b-b7bb-4e23-bae9-daeaffa6a7c0": {
+                      "id": "6969907b-b7bb-4e23-bae9-daeaffa6a7c0",
+                      "name": "",
+                      "type": "AgentStateTransition",
+                      "owner": null,
+                      "bounds": {
+                        "x": -130,
+                        "y": -40,
+                        "width": 350,
+                        "height": 240
+                      },
+                      "path": [
+                        {
+                          "x": -120,
+                          "y": 190
+                        },
+                        {
+                          "x": 45,
+                          "y": 190
+                        },
+                        {
+                          "x": 45,
+                          "y": -30
+                        },
+                        {
+                          "x": 210,
+                          "y": -30
+                        }
+                      ],
+                      "source": {
+                        "direction": "Right",
+                        "element": "8f57a878-84ca-409d-b89d-cc62fc815507",
+                        "bounds": {
+                          "x": -120,
+                          "y": 190,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "target": {
+                        "direction": "Left",
+                        "element": "07601353-ee34-4ca9-bbe4-bdd711e624c4",
+                        "bounds": {
+                          "x": 210,
+                          "y": -30,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "isManuallyLayouted": false,
+                      "transitionType": "predefined",
+                      "predefined": {
+                        "predefinedType": "auto",
+                        "conditionValue": ""
+                      },
+                      "custom": {
+                        "event": "None",
+                        "condition": []
+                      }
+                    },
+                    "4ba46b8a-28d1-48ee-b9e0-bc8c3aa82c61": {
+                      "id": "4ba46b8a-28d1-48ee-b9e0-bc8c3aa82c61",
+                      "name": "",
+                      "type": "AgentStateTransition",
+                      "owner": null,
+                      "bounds": {
+                        "x": 280,
+                        "y": 10,
+                        "width": 20,
+                        "height": 140
+                      },
+                      "path": [
+                        {
+                          "x": 290,
+                          "y": 140
+                        },
+                        {
+                          "x": 290,
+                          "y": 80
+                        },
+                        {
+                          "x": 290,
+                          "y": 80
+                        },
+                        {
+                          "x": 290,
+                          "y": 20
+                        }
+                      ],
+                      "source": {
+                        "direction": "Up",
+                        "element": "c6bea043-ca61-463e-8c51-753602773b9a",
+                        "bounds": {
+                          "x": 290,
+                          "y": 140,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "target": {
+                        "direction": "Down",
+                        "element": "07601353-ee34-4ca9-bbe4-bdd711e624c4",
+                        "bounds": {
+                          "x": 290,
+                          "y": 20,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "isManuallyLayouted": false,
+                      "transitionType": "predefined",
+                      "predefined": {
+                        "predefinedType": "auto",
+                        "conditionValue": ""
+                      },
+                      "custom": {
+                        "event": "None",
+                        "condition": []
+                      }
+                    },
+                    "2dead912-e083-4203-8a76-9d434ef3b39b": {
+                      "id": "2dead912-e083-4203-8a76-9d434ef3b39b",
+                      "name": "",
+                      "type": "AgentStateTransition",
+                      "owner": null,
+                      "bounds": {
+                        "x": -130,
+                        "y": -40,
+                        "width": 350,
+                        "height": 460
+                      },
+                      "path": [
+                        {
+                          "x": -120,
+                          "y": 410
+                        },
+                        {
+                          "x": 45,
+                          "y": 410
+                        },
+                        {
+                          "x": 45,
+                          "y": -30
+                        },
+                        {
+                          "x": 210,
+                          "y": -30
+                        }
+                      ],
+                      "source": {
+                        "direction": "Right",
+                        "element": "b5895c6c-fdf9-4f1f-813f-ef8baaa7a008",
+                        "bounds": {
+                          "x": -120,
+                          "y": 410,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "target": {
+                        "direction": "Left",
+                        "element": "07601353-ee34-4ca9-bbe4-bdd711e624c4",
+                        "bounds": {
+                          "x": 210,
+                          "y": -30,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "isManuallyLayouted": false,
+                      "transitionType": "predefined",
+                      "predefined": {
+                        "predefinedType": "auto",
+                        "conditionValue": ""
+                      },
+                      "custom": {
+                        "event": "None",
+                        "condition": []
+                      }
+                    },
+                    "d1414fb9-bcf4-4e45-a74c-b7bb93d87d78": {
+                      "id": "d1414fb9-bcf4-4e45-a74c-b7bb93d87d78",
+                      "name": "",
+                      "type": "AgentStateTransitionInit",
+                      "owner": null,
+                      "source": {
+                        "direction": "Right",
+                        "element": "730ca64d-597c-4fd8-a756-5d98d475edb8",
+                        "bounds": {
+                          "x": -535,
+                          "y": -37.5,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "target": {
+                        "direction": "Left",
+                        "element": "3effee26-ddc1-4180-8dfc-4f54d929c334",
+                        "bounds": {
+                          "x": -280,
+                          "y": -45,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "bounds": {
+                        "x": -535,
+                        "y": -37.5,
+                        "width": 255,
+                        "height": 1
+                      },
+                      "path": [
+                        {
+                          "x": -535,
+                          "y": -37.5
+                        },
+                        {
+                          "x": -280,
+                          "y": -37.5
+                        }
+                      ],
+                      "isManuallyLayouted": false
+                    }
+                  },
+                  "assessments": {}
+                }
+              },
+              {
+                "id": "8892dc19-bacc-4de4-8f27-9ae32842dbbf:ef384a51-8bd6-45bb-952c-03a0944827d8",
+                "profileId": "8892dc19-bacc-4de4-8f27-9ae32842dbbf",
+                "profileName": "ParaplegicUser",
+                "configurationId": "ef384a51-8bd6-45bb-952c-03a0944827d8",
+                "configurationName": "paraplegicprofile",
+                "createdAt": "2026-05-06T13:49:25.848Z",
+                "model": {
+                  "version": "3.0.0",
+                  "type": "AgentDiagram",
+                  "size": {
+                    "width": 1980,
+                    "height": 640
+                  },
+                  "interactive": {
+                    "elements": {},
+                    "relationships": {}
+                  },
+                  "elements": {
+                    "6b718df7-70ef-4e1c-8c6b-c82133964f86": {
+                      "id": "6b718df7-70ef-4e1c-8c6b-c82133964f86",
+                      "name": "I want muscles",
+                      "type": "AgentIntentBody",
+                      "owner": "c383f8b0-d915-439b-8bde-18a30da80fa3",
+                      "bounds": {
+                        "x": -550,
+                        "y": -300,
+                        "width": 160,
+                        "height": 30
+                      }
+                    },
+                    "c383f8b0-d915-439b-8bde-18a30da80fa3": {
+                      "id": "c383f8b0-d915-439b-8bde-18a30da80fa3",
+                      "name": "Muscles_intent",
+                      "type": "AgentIntent",
+                      "owner": null,
+                      "bounds": {
+                        "x": -550,
+                        "y": -300,
+                        "width": 160,
+                        "height": 100
+                      },
+                      "bodies": [
+                        "6b718df7-70ef-4e1c-8c6b-c82133964f86"
+                      ],
+                      "intent_description": "Question about how to become muscular and which exercises to perform."
+                    },
+                    "192db72d-4d0e-49b0-b49c-5050fb0dbb68": {
+                      "id": "192db72d-4d0e-49b0-b49c-5050fb0dbb68",
+                      "name": "Which food to eat?",
+                      "type": "AgentIntentBody",
+                      "owner": "a009a9ba-7a03-4f79-9122-416d8b74a0bb",
+                      "bounds": {
+                        "x": -250,
+                        "y": -300,
+                        "width": 160,
+                        "height": 30
+                      }
+                    },
+                    "a009a9ba-7a03-4f79-9122-416d8b74a0bb": {
+                      "id": "a009a9ba-7a03-4f79-9122-416d8b74a0bb",
+                      "name": "Nutrition_intent",
+                      "type": "AgentIntent",
+                      "owner": null,
+                      "bounds": {
+                        "x": -250,
+                        "y": -300,
+                        "width": 160,
+                        "height": 100
+                      },
+                      "bodies": [
+                        "192db72d-4d0e-49b0-b49c-5050fb0dbb68"
+                      ],
+                      "intent_description": "Question about nutrition in gym."
+                    },
+                    "90d28305-378e-4bad-b3ea-61c3ddaa5921": {
+                      "id": "90d28305-378e-4bad-b3ea-61c3ddaa5921",
+                      "name": "Other",
+                      "type": "AgentIntent",
+                      "owner": null,
+                      "bounds": {
+                        "x": 50,
+                        "y": -300,
+                        "width": 160,
+                        "height": 100
+                      },
+                      "bodies": [],
+                      "intent_description": "Any question that does not fit in \"Muscles\" or \"Nutrition\""
+                    },
+                    "731e886c-9cef-4fa7-ba6d-72aa25c32d4f": {
+                      "id": "731e886c-9cef-4fa7-ba6d-72aa25c32d4f",
+                      "name": "",
+                      "type": "StateInitialNode",
+                      "owner": null,
+                      "bounds": {
+                        "x": -580,
+                        "y": -60,
+                        "width": 45,
+                        "height": 45
+                      }
+                    },
+                    "c10f03ca-2073-4002-8d1b-e42536008f4c": {
+                      "id": "c10f03ca-2073-4002-8d1b-e42536008f4c",
+                      "name": "Initial",
+                      "type": "AgentState",
+                      "owner": null,
+                      "bounds": {
+                        "x": -280,
+                        "y": -80,
+                        "width": 160,
+                        "height": 100
+                      },
+                      "bodies": [
+                        "82783f5d-8ef3-47f7-8feb-9651bdf73d63"
+                      ],
+                      "fallbackBodies": []
+                    },
+                    "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8": {
+                      "id": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                      "name": "Idle",
+                      "type": "AgentState",
+                      "owner": null,
+                      "bounds": {
+                        "x": 210,
+                        "y": -80,
+                        "width": 160,
+                        "height": 100
+                      },
+                      "bodies": [
+                        "d91b1fe8-cd6c-4b20-928c-70021c0f044d"
+                      ],
+                      "fallbackBodies": [
+                        "10a044fe-f0bd-41e8-ae27-0f2c2afc2cac"
+                      ]
+                    },
+                    "aa0bf687-2e08-4cba-aa98-335bcce5ecc7": {
+                      "id": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+                      "name": "TrainingPlan",
+                      "type": "AgentState",
+                      "owner": null,
+                      "bounds": {
+                        "x": -280,
+                        "y": 140,
+                        "width": 160,
+                        "height": 100
+                      },
+                      "bodies": [
+                        "d55e541d-6530-44ad-8d86-0ae51039bd72",
+                        "964f437d-ab33-4e0d-bd1c-e36387c879eb",
+                        "31249e62-6b58-48fb-af98-e55090d683e1"
+                      ],
+                      "fallbackBodies": []
+                    },
+                    "110dac05-6c3a-4fd1-a747-6df88d09cf77": {
+                      "id": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                      "name": "Nutrition",
+                      "type": "AgentState",
+                      "owner": null,
+                      "bounds": {
+                        "x": 210,
+                        "y": 140,
+                        "width": 160,
+                        "height": 100
+                      },
+                      "bodies": [
+                        "3fa5c3b5-3e12-4968-b16c-1f80a98693c1",
+                        "5c6dad70-8209-4de6-ae7a-5a9747fada8a",
+                        "ac38d464-9f06-48cf-b6c5-76e721298f92",
+                        "49fc07e1-484c-4459-b5b9-b223c5d7b129",
+                        "0bcfa6cb-74c0-43c8-867b-2fc966c53671"
+                      ],
+                      "fallbackBodies": []
+                    },
+                    "a22b9877-2809-426e-8b72-504ef7abcce0": {
+                      "id": "a22b9877-2809-426e-8b72-504ef7abcce0",
+                      "name": "OtherQuestions",
+                      "type": "AgentState",
+                      "owner": null,
+                      "bounds": {
+                        "x": -280,
+                        "y": 360,
+                        "width": 160,
+                        "height": 100
+                      },
+                      "bodies": [
+                        "3721c5e6-19b1-4811-8b00-17415913c3aa"
+                      ],
+                      "fallbackBodies": []
+                    },
+                    "82783f5d-8ef3-47f7-8feb-9651bdf73d63": {
+                      "id": "82783f5d-8ef3-47f7-8feb-9651bdf73d63",
+                      "name": "Hi, I am your buddy, the fitness agent.",
+                      "type": "AgentStateBody",
+                      "owner": "c10f03ca-2073-4002-8d1b-e42536008f4c",
+                      "bounds": {
+                        "x": -280,
+                        "y": -80,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "d91b1fe8-cd6c-4b20-928c-70021c0f044d": {
+                      "id": "d91b1fe8-cd6c-4b20-928c-70021c0f044d",
+                      "name": "I am here to answer any questions regarding exercises, nutrition and recovery.",
+                      "type": "AgentStateBody",
+                      "owner": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                      "bounds": {
+                        "x": 210,
+                        "y": -80,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "10a044fe-f0bd-41e8-ae27-0f2c2afc2cac": {
+                      "id": "10a044fe-f0bd-41e8-ae27-0f2c2afc2cac",
+                      "name": "I focus on gym and fitness topics only dude.",
+                      "type": "AgentStateFallbackBody",
+                      "owner": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                      "bounds": {
+                        "x": 210,
+                        "y": -80,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "d55e541d-6530-44ad-8d86-0ae51039bd72": {
+                      "id": "d55e541d-6530-44ad-8d86-0ae51039bd72",
+                      "name": "Focus on accessible compound upper-body and core movements like bench press or machine chest press, overhead press, seated rows, lat pulldowns/assisted pull-ups, dips or triceps pushdowns, face pulls, and anti-rotation core work (e.g., Pallof press), using seated or strap-stabilized setups as needed.",
+                      "type": "AgentStateBody",
+                      "owner": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+                      "bounds": {
+                        "x": -280,
+                        "y": 140,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "964f437d-ab33-4e0d-bd1c-e36387c879eb": {
+                      "id": "964f437d-ab33-4e0d-bd1c-e36387c879eb",
+                      "name": "Train 3\u20135 times per week, progressively increasing resistance on upper-body and core-focused exercises while eating enough protein and calories to support growth; balance pushing and pulling to protect your shoulders and allow adequate recovery.",
+                      "type": "AgentStateBody",
+                      "owner": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+                      "bounds": {
+                        "x": -280,
+                        "y": 140,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "31249e62-6b58-48fb-af98-e55090d683e1": {
+                      "id": "31249e62-6b58-48fb-af98-e55090d683e1",
+                      "name": "Get good sleep and stay consistent\u2014muscle comes from steady effort over time.",
+                      "type": "AgentStateBody",
+                      "owner": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+                      "bounds": {
+                        "x": -280,
+                        "y": 140,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "3fa5c3b5-3e12-4968-b16c-1f80a98693c1": {
+                      "id": "3fa5c3b5-3e12-4968-b16c-1f80a98693c1",
+                      "name": "Nutrition basics: Eat mostly whole foods (lean protein, vegetables, fruits, whole grains, healthy fats). Protein: ~1.6\u20132.2 g per kg of body weight daily..",
+                      "type": "AgentStateBody",
+                      "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                      "bounds": {
+                        "x": 210,
+                        "y": 140,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "5c6dad70-8209-4de6-ae7a-5a9747fada8a": {
+                      "id": "5c6dad70-8209-4de6-ae7a-5a9747fada8a",
+                      "name": "Match calories to your goal: slight surplus to gain muscle, deficit to lose fat, maintenance to stay the same.",
+                      "type": "AgentStateBody",
+                      "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                      "bounds": {
+                        "x": 210,
+                        "y": 140,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "ac38d464-9f06-48cf-b6c5-76e721298f92": {
+                      "id": "ac38d464-9f06-48cf-b6c5-76e721298f92",
+                      "name": "Carbs fuel training; fats support hormones.",
+                      "type": "AgentStateBody",
+                      "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                      "bounds": {
+                        "x": 210,
+                        "y": 140,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "49fc07e1-484c-4459-b5b9-b223c5d7b129": {
+                      "id": "49fc07e1-484c-4459-b5b9-b223c5d7b129",
+                      "name": "Drink plenty of water and limit ultra-processed foods and alcohol.",
+                      "type": "AgentStateBody",
+                      "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                      "bounds": {
+                        "x": 210,
+                        "y": 140,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "0bcfa6cb-74c0-43c8-867b-2fc966c53671": {
+                      "id": "0bcfa6cb-74c0-43c8-867b-2fc966c53671",
+                      "name": "Be consistent \u2014 results come from habits, not perfection",
+                      "type": "AgentStateBody",
+                      "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                      "bounds": {
+                        "x": 210,
+                        "y": 140,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "text"
+                    },
+                    "3721c5e6-19b1-4811-8b00-17415913c3aa": {
+                      "id": "3721c5e6-19b1-4811-8b00-17415913c3aa",
+                      "name": "AI response \ud83e\ude84",
+                      "type": "AgentStateBody",
+                      "owner": "a22b9877-2809-426e-8b72-504ef7abcce0",
+                      "bounds": {
+                        "x": -280,
+                        "y": 360,
+                        "width": 159,
+                        "height": 30
+                      },
+                      "replyType": "llm"
+                    }
+                  },
+                  "relationships": {
+                    "7ac61ff1-1e47-4e69-8d38-8fd9be6ab17d": {
+                      "id": "7ac61ff1-1e47-4e69-8d38-8fd9be6ab17d",
+                      "name": "",
+                      "type": "AgentStateTransitionInit",
+                      "owner": null,
+                      "source": {
+                        "direction": "Right",
+                        "element": "731e886c-9cef-4fa7-ba6d-72aa25c32d4f",
+                        "bounds": {
+                          "x": -535,
+                          "y": -37.5,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "target": {
+                        "direction": "Left",
+                        "element": "c10f03ca-2073-4002-8d1b-e42536008f4c",
+                        "bounds": {
+                          "x": -280,
+                          "y": -45,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "bounds": {
+                        "x": -535,
+                        "y": -37.5,
+                        "width": 255,
+                        "height": 1
+                      },
+                      "path": [
+                        {
+                          "x": -535,
+                          "y": -37.5
+                        },
+                        {
+                          "x": -280,
+                          "y": -37.5
+                        }
+                      ],
+                      "isManuallyLayouted": false
+                    },
+                    "b3c5c9c2-81fc-4a12-985e-9e885ef6e9d0": {
+                      "id": "b3c5c9c2-81fc-4a12-985e-9e885ef6e9d0",
+                      "name": "",
+                      "type": "AgentStateTransition",
+                      "owner": null,
+                      "bounds": {
+                        "x": -130,
+                        "y": -40,
+                        "width": 350,
+                        "height": 20
+                      },
+                      "path": [
+                        {
+                          "x": -120,
+                          "y": -30
+                        },
+                        {
+                          "x": 45,
+                          "y": -30
+                        },
+                        {
+                          "x": 45,
+                          "y": -30
+                        },
+                        {
+                          "x": 210,
+                          "y": -30
+                        }
+                      ],
+                      "source": {
+                        "direction": "Right",
+                        "element": "c10f03ca-2073-4002-8d1b-e42536008f4c",
+                        "bounds": {
+                          "x": -120,
+                          "y": -30,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "target": {
+                        "direction": "Left",
+                        "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                        "bounds": {
+                          "x": 210,
+                          "y": -30,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "isManuallyLayouted": false,
+                      "transitionType": "predefined",
+                      "predefined": {
+                        "predefinedType": "auto",
+                        "conditionValue": ""
+                      },
+                      "custom": {
+                        "event": "None",
+                        "condition": []
+                      }
+                    },
+                    "48858dc4-d788-4f13-858b-3010ae2f4ead": {
+                      "id": "48858dc4-d788-4f13-858b-3010ae2f4ead",
+                      "name": "",
+                      "type": "AgentStateTransition",
+                      "owner": null,
+                      "bounds": {
+                        "x": -130,
+                        "y": -40,
+                        "width": 350,
+                        "height": 240
+                      },
+                      "path": [
+                        {
+                          "x": 210,
+                          "y": -30
+                        },
+                        {
+                          "x": 45,
+                          "y": -30
+                        },
+                        {
+                          "x": 45,
+                          "y": 190
+                        },
+                        {
+                          "x": -120,
+                          "y": 190
+                        }
+                      ],
+                      "source": {
+                        "direction": "Left",
+                        "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                        "bounds": {
+                          "x": 210,
+                          "y": -30,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "target": {
+                        "direction": "Right",
+                        "element": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+                        "bounds": {
+                          "x": -120,
+                          "y": 190,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "isManuallyLayouted": false,
+                      "transitionType": "predefined",
+                      "predefined": {
+                        "predefinedType": "when_intent_matched",
+                        "intentName": "Muscles_intent"
+                      },
+                      "custom": {
+                        "event": "None",
+                        "condition": []
+                      }
+                    },
+                    "425913e8-31ab-4ac5-908a-4f35fb7d732d": {
+                      "id": "425913e8-31ab-4ac5-908a-4f35fb7d732d",
+                      "name": "",
+                      "type": "AgentStateTransition",
+                      "owner": null,
+                      "bounds": {
+                        "x": -130,
+                        "y": -40,
+                        "width": 350,
+                        "height": 460
+                      },
+                      "path": [
+                        {
+                          "x": 210,
+                          "y": -30
+                        },
+                        {
+                          "x": 45,
+                          "y": -30
+                        },
+                        {
+                          "x": 45,
+                          "y": 410
+                        },
+                        {
+                          "x": -120,
+                          "y": 410
+                        }
+                      ],
+                      "source": {
+                        "direction": "Left",
+                        "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                        "bounds": {
+                          "x": 210,
+                          "y": -30,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "target": {
+                        "direction": "Right",
+                        "element": "a22b9877-2809-426e-8b72-504ef7abcce0",
+                        "bounds": {
+                          "x": -120,
+                          "y": 410,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "isManuallyLayouted": false,
+                      "transitionType": "predefined",
+                      "predefined": {
+                        "predefinedType": "when_intent_matched",
+                        "intentName": "Other"
+                      },
+                      "custom": {
+                        "event": "None",
+                        "condition": []
+                      }
+                    },
+                    "9f2ff8c7-b6dc-4246-b6ff-f1b1d1293a60": {
+                      "id": "9f2ff8c7-b6dc-4246-b6ff-f1b1d1293a60",
+                      "name": "",
+                      "type": "AgentStateTransition",
+                      "owner": null,
+                      "bounds": {
+                        "x": 280,
+                        "y": 10,
+                        "width": 20,
+                        "height": 140
+                      },
+                      "path": [
+                        {
+                          "x": 290,
+                          "y": 20
+                        },
+                        {
+                          "x": 290,
+                          "y": 80
+                        },
+                        {
+                          "x": 290,
+                          "y": 80
+                        },
+                        {
+                          "x": 290,
+                          "y": 140
+                        }
+                      ],
+                      "source": {
+                        "direction": "Down",
+                        "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                        "bounds": {
+                          "x": 290,
+                          "y": 20,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "target": {
+                        "direction": "Up",
+                        "element": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                        "bounds": {
+                          "x": 290,
+                          "y": 140,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "isManuallyLayouted": false,
+                      "transitionType": "predefined",
+                      "predefined": {
+                        "predefinedType": "when_intent_matched",
+                        "intentName": "Nutrition_intent"
+                      },
+                      "custom": {
+                        "event": "None",
+                        "condition": []
+                      }
+                    },
+                    "a5bf1da3-2426-43fb-827c-cc13ee896460": {
+                      "id": "a5bf1da3-2426-43fb-827c-cc13ee896460",
+                      "name": "",
+                      "type": "AgentStateTransition",
+                      "owner": null,
+                      "bounds": {
+                        "x": -130,
+                        "y": -40,
+                        "width": 350,
+                        "height": 240
+                      },
+                      "path": [
+                        {
+                          "x": -120,
+                          "y": 190
+                        },
+                        {
+                          "x": 45,
+                          "y": 190
+                        },
+                        {
+                          "x": 45,
+                          "y": -30
+                        },
+                        {
+                          "x": 210,
+                          "y": -30
+                        }
+                      ],
+                      "source": {
+                        "direction": "Right",
+                        "element": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+                        "bounds": {
+                          "x": -120,
+                          "y": 190,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "target": {
+                        "direction": "Left",
+                        "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                        "bounds": {
+                          "x": 210,
+                          "y": -30,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "isManuallyLayouted": false,
+                      "transitionType": "predefined",
+                      "predefined": {
+                        "predefinedType": "auto",
+                        "conditionValue": ""
+                      },
+                      "custom": {
+                        "event": "None",
+                        "condition": []
+                      }
+                    },
+                    "25914e9b-e4dd-461f-9b4a-10229b76b618": {
+                      "id": "25914e9b-e4dd-461f-9b4a-10229b76b618",
+                      "name": "",
+                      "type": "AgentStateTransition",
+                      "owner": null,
+                      "bounds": {
+                        "x": 280,
+                        "y": 10,
+                        "width": 20,
+                        "height": 140
+                      },
+                      "path": [
+                        {
+                          "x": 290,
+                          "y": 140
+                        },
+                        {
+                          "x": 290,
+                          "y": 80
+                        },
+                        {
+                          "x": 290,
+                          "y": 80
+                        },
+                        {
+                          "x": 290,
+                          "y": 20
+                        }
+                      ],
+                      "source": {
+                        "direction": "Up",
+                        "element": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                        "bounds": {
+                          "x": 290,
+                          "y": 140,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "target": {
+                        "direction": "Down",
+                        "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                        "bounds": {
+                          "x": 290,
+                          "y": 20,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "isManuallyLayouted": false,
+                      "transitionType": "predefined",
+                      "predefined": {
+                        "predefinedType": "auto",
+                        "conditionValue": ""
+                      },
+                      "custom": {
+                        "event": "None",
+                        "condition": []
+                      }
+                    },
+                    "0efab80b-2e8c-45a3-a998-78ccd579fbd9": {
+                      "id": "0efab80b-2e8c-45a3-a998-78ccd579fbd9",
+                      "name": "",
+                      "type": "AgentStateTransition",
+                      "owner": null,
+                      "bounds": {
+                        "x": -130,
+                        "y": -40,
+                        "width": 350,
+                        "height": 460
+                      },
+                      "path": [
+                        {
+                          "x": -120,
+                          "y": 410
+                        },
+                        {
+                          "x": 45,
+                          "y": 410
+                        },
+                        {
+                          "x": 45,
+                          "y": -30
+                        },
+                        {
+                          "x": 210,
+                          "y": -30
+                        }
+                      ],
+                      "source": {
+                        "direction": "Right",
+                        "element": "a22b9877-2809-426e-8b72-504ef7abcce0",
+                        "bounds": {
+                          "x": -120,
+                          "y": 410,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "target": {
+                        "direction": "Left",
+                        "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                        "bounds": {
+                          "x": 210,
+                          "y": -30,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "isManuallyLayouted": false,
+                      "transitionType": "predefined",
+                      "predefined": {
+                        "predefinedType": "auto",
+                        "conditionValue": ""
+                      },
+                      "custom": {
+                        "event": "None",
+                        "condition": []
+                      }
+                    },
+                    "0b385217-ea53-481d-8222-52dda332e351": {
+                      "id": "0b385217-ea53-481d-8222-52dda332e351",
+                      "name": "",
+                      "type": "AgentStateTransitionInit",
+                      "owner": null,
+                      "source": {
+                        "direction": "Right",
+                        "element": "731e886c-9cef-4fa7-ba6d-72aa25c32d4f",
+                        "bounds": {
+                          "x": -535,
+                          "y": -37.5,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "target": {
+                        "direction": "Left",
+                        "element": "c10f03ca-2073-4002-8d1b-e42536008f4c",
+                        "bounds": {
+                          "x": -280,
+                          "y": -45,
+                          "width": 0,
+                          "height": 0
+                        }
+                      },
+                      "bounds": {
+                        "x": -535,
+                        "y": -37.5,
+                        "width": 255,
+                        "height": 1
+                      },
+                      "path": [
+                        {
+                          "x": -535,
+                          "y": -37.5
+                        },
+                        {
+                          "x": -280,
+                          "y": -37.5
+                        }
+                      ],
+                      "isManuallyLayouted": false
+                    }
+                  },
+                  "assessments": {}
+                }
+              }
+            ],
+            "activePersonalizedVariantId": "8892dc19-bacc-4de4-8f27-9ae32842dbbf:ef384a51-8bd6-45bb-952c-03a0944827d8"
+          }
+        }
+      ],
+      "UserDiagram": [
+        {
+          "id": "b8d65359-7826-4ce3-a8dc-da01ce8865d7",
+          "title": "Teenager",
+          "model": {
+            "version": "3.0.0",
+            "type": "UserDiagram",
+            "size": {
+              "width": 880,
+              "height": 700
+            },
+            "interactive": {
+              "elements": {},
+              "relationships": {}
+            },
+            "elements": {
+              "8b66ecde-05bb-43f9-a5ac-b1e1279e8cb3": {
+                "id": "8b66ecde-05bb-43f9-a5ac-b1e1279e8cb3",
+                "name": "user_1",
+                "type": "UserModelName",
+                "owner": null,
+                "bounds": {
+                  "x": -420,
+                  "y": -330,
+                  "width": 106,
+                  "height": 146
+                },
+                "icon": "7a88f848-8622-4bea-a17a-ff49a0dfdb96",
+                "attributes": [],
+                "methods": [],
+                "classId": "ce1e2d59-3d7c-4753-adb7-09ca96797f5a",
+                "className": "User"
+              },
+              "7a88f848-8622-4bea-a17a-ff49a0dfdb96": {
+                "id": "7a88f848-8622-4bea-a17a-ff49a0dfdb96",
+                "name": "icon",
+                "type": "UserModelIcon",
+                "owner": "8b66ecde-05bb-43f9-a5ac-b1e1279e8cb3",
+                "bounds": {
+                  "x": -419.5,
+                  "y": -284.5,
+                  "width": 106,
+                  "height": 96
+                },
+                "icon": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"96\" height=\"96\" viewBox=\"0 0 20 20\"> \t<g fill=\"none\"> \t\t<path fill=\"url(#fluentColorPerson200)\" d=\"M5.009 11A2 2 0 0 0 3 13c0 1.691.833 2.966 2.135 3.797C6.417 17.614 8.145 18 10 18s3.583-.386 4.865-1.203C16.167 15.967 17 14.69 17 13a2 2 0 0 0-2-2z\" /> \t\t<path fill=\"url(#fluentColorPerson201)\" d=\"M5.009 11A2 2 0 0 0 3 13c0 1.691.833 2.966 2.135 3.797C6.417 17.614 8.145 18 10 18s3.583-.386 4.865-1.203C16.167 15.967 17 14.69 17 13a2 2 0 0 0-2-2z\" /> \t\t<path fill=\"url(#fluentColorPerson202)\" d=\"M10 2a4 4 0 1 0 0 8a4 4 0 0 0 0-8\" /> \t\t<defs> \t\t\t<linearGradient id=\"fluentColorPerson200\" x1=\"6.329\" x2=\"8.591\" y1=\"11.931\" y2=\"19.153\" gradientUnits=\"userSpaceOnUse\"> \t\t\t\t<stop offset=\".125\" stop-color=\"#5baad0\" /> \t\t\t\t<stop offset=\"1\" stop-color=\"#282233\" /> \t\t\t</linearGradient> \t\t\t<linearGradient id=\"fluentColorPerson201\" x1=\"10\" x2=\"13.167\" y1=\"10.167\" y2=\"22\" gradientUnits=\"userSpaceOnUse\"> \t\t\t\t<stop stop-color=\"#537fff\" stop-opacity=\"0\" /> \t\t\t\t<stop offset=\"1\" stop-color=\"#e362f8\" /> \t\t\t</linearGradient> \t\t\t<linearGradient id=\"fluentColorPerson202\" x1=\"7.902\" x2=\"11.979\" y1=\"3.063\" y2=\"9.574\" gradientUnits=\"userSpaceOnUse\"> \t\t\t\t<stop offset=\".125\" stop-color=\"#5baad0\" /> \t\t\t\t<stop offset=\"1\" stop-color=\"#282233\" /> \t\t\t</linearGradient> \t\t</defs> \t</g> </svg>"
+              },
+              "61f3399d-3642-4d70-8170-fa67b7184867": {
+                "id": "61f3399d-3642-4d70-8170-fa67b7184867",
+                "name": "personal_Information_1",
+                "type": "UserModelName",
+                "owner": null,
+                "bounds": {
+                  "x": -320,
+                  "y": -50,
+                  "width": 192.11666870117188,
+                  "height": 146
+                },
+                "icon": "07c9ec2d-1fad-4ce3-bcb2-00f4c4694543",
+                "attributes": [
+                  "b4ecabb3-552e-47a3-9f12-5f34cd7737b2",
+                  "4377e8bc-3ba6-4b32-bb33-085db4871029",
+                  "9d85759c-def2-4e25-9a61-37d59c3aafc4",
+                  "361bd580-2082-4248-9876-30ce806c0aa9",
+                  "ee5c35bc-53df-4a4a-927b-0820161fb1cb",
+                  "faf495f9-a9e3-40d3-8767-b205a6682e76"
+                ],
+                "methods": [],
+                "classId": "5b6e9989-bda3-4434-8fac-89f649dc05d3",
+                "className": "Personal_Information"
+              },
+              "b4ecabb3-552e-47a3-9f12-5f34cd7737b2": {
+                "id": "b4ecabb3-552e-47a3-9f12-5f34cd7737b2",
+                "name": "age < 18",
+                "type": "UserModelAttribute",
+                "owner": "61f3399d-3642-4d70-8170-fa67b7184867",
+                "bounds": {
+                  "x": -320,
+                  "y": -50,
+                  "width": 120,
+                  "height": 10
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false,
+                "attributeId": "8f52769c-e1f5-42c6-9f54-4072b2a4ff8a",
+                "attributeOperator": "<"
+              },
+              "4377e8bc-3ba6-4b32-bb33-085db4871029": {
+                "id": "4377e8bc-3ba6-4b32-bb33-085db4871029",
+                "name": "lastName = ",
+                "type": "UserModelAttribute",
+                "owner": "61f3399d-3642-4d70-8170-fa67b7184867",
+                "bounds": {
+                  "x": -320,
+                  "y": -50,
+                  "width": 150,
+                  "height": 10
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false,
+                "attributeId": "199a7c8e-f49f-4b6a-bd16-849ab546ae8b",
+                "attributeOperator": "=="
+              },
+              "9d85759c-def2-4e25-9a61-37d59c3aafc4": {
+                "id": "9d85759c-def2-4e25-9a61-37d59c3aafc4",
+                "name": "firstName = ",
+                "type": "UserModelAttribute",
+                "owner": "61f3399d-3642-4d70-8170-fa67b7184867",
+                "bounds": {
+                  "x": -320,
+                  "y": -50,
+                  "width": 150,
+                  "height": 10
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false,
+                "attributeId": "6e156ae9-ca13-42f2-a3c8-bfae46ab38c4",
+                "attributeOperator": "=="
+              },
+              "361bd580-2082-4248-9876-30ce806c0aa9": {
+                "id": "361bd580-2082-4248-9876-30ce806c0aa9",
+                "name": "nationality_iso3166 = ",
+                "type": "UserModelAttribute",
+                "owner": "61f3399d-3642-4d70-8170-fa67b7184867",
+                "bounds": {
+                  "x": -320,
+                  "y": -50,
+                  "width": 220,
+                  "height": 10
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false,
+                "attributeId": "e21d4af5-77da-46b6-8059-8f0fc152ee8e",
+                "attributeOperator": "=="
+              },
+              "ee5c35bc-53df-4a4a-927b-0820161fb1cb": {
+                "id": "ee5c35bc-53df-4a4a-927b-0820161fb1cb",
+                "name": "address = ",
+                "type": "UserModelAttribute",
+                "owner": "61f3399d-3642-4d70-8170-fa67b7184867",
+                "bounds": {
+                  "x": -320,
+                  "y": -50,
+                  "width": 140,
+                  "height": 10
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false,
+                "attributeId": "adffe2ad-db08-4804-9a9e-28f75812efdc",
+                "attributeOperator": "=="
+              },
+              "faf495f9-a9e3-40d3-8767-b205a6682e76": {
+                "id": "faf495f9-a9e3-40d3-8767-b205a6682e76",
+                "name": "gender = ",
+                "type": "UserModelAttribute",
+                "owner": "61f3399d-3642-4d70-8170-fa67b7184867",
+                "bounds": {
+                  "x": -320,
+                  "y": -50,
+                  "width": 130,
+                  "height": 10
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false,
+                "attributeId": "5acf56a9-041c-41c9-8841-01d1885ddb12",
+                "attributeOperator": "=="
+              },
+              "07c9ec2d-1fad-4ce3-bcb2-00f4c4694543": {
+                "id": "07c9ec2d-1fad-4ce3-bcb2-00f4c4694543",
+                "name": "icon",
+                "type": "UserModelIcon",
+                "owner": "61f3399d-3642-4d70-8170-fa67b7184867",
+                "bounds": {
+                  "x": -319.5,
+                  "y": -4.5,
+                  "width": 192.11666870117188,
+                  "height": 96
+                },
+                "icon": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"128\" height=\"96\" viewBox=\"0 0 2048 1536\"> \t<path fill=\"#6798bf\" d=\"M896 1084q0-54-7.5-100.5t-24.5-90t-51-68.5t-81-25q-64 64-156 64t-156-64q-47 0-81 25t-51 68.5t-24.5 90T256 1084q0 55 31.5 93.5T363 1216h426q44 0 75.5-38.5T896 1084M768 640q0-80-56-136t-136-56t-136 56t-56 136t56 136t136 56t136-56t56-136m1024 480v-64q0-14-9-23t-23-9h-704q-14 0-23 9t-9 23v64q0 14 9 23t23 9h704q14 0 23-9t9-23m-384-256v-64q0-14-9-23t-23-9h-320q-14 0-23 9t-9 23v64q0 14 9 23t23 9h320q14 0 23-9t9-23m384 0v-64q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v64q0 14 9 23t23 9h192q14 0 23-9t9-23m0-256v-64q0-14-9-23t-23-9h-704q-14 0-23 9t-9 23v64q0 14 9 23t23 9h704q14 0 23-9t9-23M128 256h1792v-96q0-14-9-23t-23-9H160q-14 0-23 9t-9 23zm1920-96v1216q0 66-47 113t-113 47H160q-66 0-113-47T0 1376V160Q0 94 47 47T160 0h1728q66 0 113 47t47 113\" /> </svg>"
+              }
+            },
+            "relationships": {
+              "7092694b-c0de-471d-97f2-a0b9b689dd8c": {
+                "id": "7092694b-c0de-471d-97f2-a0b9b689dd8c",
+                "name": "",
+                "type": "ObjectLink",
+                "owner": null,
+                "bounds": {
+                  "x": -360,
+                  "y": -184,
+                  "width": 40,
+                  "height": 170.5
+                },
+                "path": [
+                  {
+                    "x": 19.5,
+                    "y": 0
+                  },
+                  {
+                    "x": 19.5,
+                    "y": 40
+                  },
+                  {
+                    "x": 0,
+                    "y": 40
+                  },
+                  {
+                    "x": 0,
+                    "y": 170.5
+                  },
+                  {
+                    "x": 40,
+                    "y": 170.5
+                  }
+                ],
+                "source": {
+                  "direction": "Bottomright",
+                  "element": "8b66ecde-05bb-43f9-a5ac-b1e1279e8cb3"
+                },
+                "target": {
+                  "direction": "Upleft",
+                  "element": "61f3399d-3642-4d70-8170-fa67b7184867"
+                },
+                "isManuallyLayouted": false
+              }
+            },
+            "assessments": {}
+          },
+          "lastUpdate": "2026-05-06T10:01:15.764Z"
+        },
+        {
+          "id": "8892dc19-bacc-4de4-8f27-9ae32842dbbf",
+          "title": "ParaplegicUser",
+          "model": {
+            "version": "3.0.0",
+            "type": "UserDiagram",
+            "size": {
+              "width": 920,
+              "height": 363.5
+            },
+            "interactive": {
+              "elements": {},
+              "relationships": {}
+            },
+            "elements": {
+              "488449e0-5ad0-44db-a739-d505876ddfcb": {
+                "id": "488449e0-5ad0-44db-a739-d505876ddfcb",
+                "name": "user_1",
+                "type": "UserModelName",
+                "owner": null,
+                "bounds": {
+                  "x": -440,
+                  "y": -160,
+                  "width": 106,
+                  "height": 146
+                },
+                "icon": "c41ce2a8-2a01-4f1e-9f4d-25908a7f82ea",
+                "attributes": [],
+                "methods": [],
+                "classId": "ce1e2d59-3d7c-4753-adb7-09ca96797f5a",
+                "className": "User"
+              },
+              "c41ce2a8-2a01-4f1e-9f4d-25908a7f82ea": {
+                "id": "c41ce2a8-2a01-4f1e-9f4d-25908a7f82ea",
+                "name": "icon",
+                "type": "UserModelIcon",
+                "owner": "488449e0-5ad0-44db-a739-d505876ddfcb",
+                "bounds": {
+                  "x": -439.5,
+                  "y": -114.5,
+                  "width": 106,
+                  "height": 96
+                },
+                "icon": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"96\" height=\"96\" viewBox=\"0 0 20 20\"> \t<g fill=\"none\"> \t\t<path fill=\"url(#fluentColorPerson200)\" d=\"M5.009 11A2 2 0 0 0 3 13c0 1.691.833 2.966 2.135 3.797C6.417 17.614 8.145 18 10 18s3.583-.386 4.865-1.203C16.167 15.967 17 14.69 17 13a2 2 0 0 0-2-2z\" /> \t\t<path fill=\"url(#fluentColorPerson201)\" d=\"M5.009 11A2 2 0 0 0 3 13c0 1.691.833 2.966 2.135 3.797C6.417 17.614 8.145 18 10 18s3.583-.386 4.865-1.203C16.167 15.967 17 14.69 17 13a2 2 0 0 0-2-2z\" /> \t\t<path fill=\"url(#fluentColorPerson202)\" d=\"M10 2a4 4 0 1 0 0 8a4 4 0 0 0 0-8\" /> \t\t<defs> \t\t\t<linearGradient id=\"fluentColorPerson200\" x1=\"6.329\" x2=\"8.591\" y1=\"11.931\" y2=\"19.153\" gradientUnits=\"userSpaceOnUse\"> \t\t\t\t<stop offset=\".125\" stop-color=\"#5baad0\" /> \t\t\t\t<stop offset=\"1\" stop-color=\"#282233\" /> \t\t\t</linearGradient> \t\t\t<linearGradient id=\"fluentColorPerson201\" x1=\"10\" x2=\"13.167\" y1=\"10.167\" y2=\"22\" gradientUnits=\"userSpaceOnUse\"> \t\t\t\t<stop stop-color=\"#537fff\" stop-opacity=\"0\" /> \t\t\t\t<stop offset=\"1\" stop-color=\"#e362f8\" /> \t\t\t</linearGradient> \t\t\t<linearGradient id=\"fluentColorPerson202\" x1=\"7.902\" x2=\"11.979\" y1=\"3.063\" y2=\"9.574\" gradientUnits=\"userSpaceOnUse\"> \t\t\t\t<stop offset=\".125\" stop-color=\"#5baad0\" /> \t\t\t\t<stop offset=\"1\" stop-color=\"#282233\" /> \t\t\t</linearGradient> \t\t</defs> \t</g> </svg>"
+              },
+              "7b9e7742-9b5f-4ba6-8538-2204e16c29c8": {
+                "id": "7b9e7742-9b5f-4ba6-8538-2204e16c29c8",
+                "name": "accessibility_1",
+                "type": "UserModelName",
+                "owner": null,
+                "bounds": {
+                  "x": -215.5,
+                  "y": -83.5,
+                  "width": 127.16666412353516,
+                  "height": 146
+                },
+                "icon": "ae92fda6-2f7b-4d4e-98fe-093e27a57e04",
+                "attributes": [],
+                "methods": [],
+                "classId": "8ccd65ae-e26d-4d7a-bcd0-ff21a2e2e076",
+                "className": "Accessibility"
+              },
+              "ae92fda6-2f7b-4d4e-98fe-093e27a57e04": {
+                "id": "ae92fda6-2f7b-4d4e-98fe-093e27a57e04",
+                "name": "icon",
+                "type": "UserModelIcon",
+                "owner": "7b9e7742-9b5f-4ba6-8538-2204e16c29c8",
+                "bounds": {
+                  "x": -215,
+                  "y": -38,
+                  "width": 127.16666412353516,
+                  "height": 96
+                },
+                "icon": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"96\" height=\"96\" viewBox=\"0 0 16 16\"> \t<path fill=\"#41779a\" d=\"M8 4.5A1.75 1.75 0 1 0 8 1a1.75 1.75 0 0 0 0 3.5M4.198 3.115a1.6 1.6 0 0 0-2.076.873a1.58 1.58 0 0 0 .87 2.07l1.695.685A.5.5 0 0 1 5 7.206V9.13a.5.5 0 0 1-.058.234l-1.755 3.3a1.591 1.591 0 1 0 2.81 1.495l1.783-3.353a.25.25 0 0 1 .441 0l1.783 3.353a1.591 1.591 0 1 0 2.81-1.494L11.06 9.362a.5.5 0 0 1-.06-.235v-1.92a.5.5 0 0 1 .313-.464l1.695-.685a1.58 1.58 0 0 0 .87-2.07a1.6 1.6 0 0 0-2.076-.873l-.781.316c-.256.103-.44.3-.545.518a2.75 2.75 0 0 1-4.952 0a1.05 1.05 0 0 0-.545-.518z\" /> </svg>"
+              },
+              "5df48dc0-89d1-4b15-9444-a27668a89966": {
+                "id": "5df48dc0-89d1-4b15-9444-a27668a89966",
+                "name": "disability_1",
+                "type": "UserModelName",
+                "owner": null,
+                "bounds": {
+                  "x": -61.5,
+                  "y": -18.5,
+                  "width": 106,
+                  "height": 146
+                },
+                "icon": "a9e24c06-767a-4fb4-9cce-f3b22a8de045",
+                "attributes": [
+                  "01d21950-b905-4a6e-a998-3b11e41f134c",
+                  "de95a359-aa2c-4ddb-9bc9-21816c6bc510",
+                  "4bde7832-5113-4458-9ab2-b4f7c8804dfb"
+                ],
+                "methods": [],
+                "classId": "b099bc5c-c80c-4143-bf86-b75a060d4d93",
+                "className": "Disability"
+              },
+              "01d21950-b905-4a6e-a998-3b11e41f134c": {
+                "id": "01d21950-b905-4a6e-a998-3b11e41f134c",
+                "name": "name == Paraplegia",
+                "type": "UserModelAttribute",
+                "owner": "5df48dc0-89d1-4b15-9444-a27668a89966",
+                "bounds": {
+                  "x": -61.5,
+                  "y": -18.5,
+                  "width": 210,
+                  "height": 10
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false,
+                "attributeId": "cb96a3aa-f446-4b1a-b5e9-c494668d5df1",
+                "attributeOperator": "=="
+              },
+              "de95a359-aa2c-4ddb-9bc9-21816c6bc510": {
+                "id": "de95a359-aa2c-4ddb-9bc9-21816c6bc510",
+                "name": "description == cannot use lower body",
+                "type": "UserModelAttribute",
+                "owner": "5df48dc0-89d1-4b15-9444-a27668a89966",
+                "bounds": {
+                  "x": -61.5,
+                  "y": -18.5,
+                  "width": 330,
+                  "height": 10
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false,
+                "attributeId": "9eb4de82-d6a9-46f6-94bc-1532d8774103",
+                "attributeOperator": "=="
+              },
+              "4bde7832-5113-4458-9ab2-b4f7c8804dfb": {
+                "id": "4bde7832-5113-4458-9ab2-b4f7c8804dfb",
+                "name": "affects == Mobility",
+                "type": "UserModelAttribute",
+                "owner": "5df48dc0-89d1-4b15-9444-a27668a89966",
+                "bounds": {
+                  "x": -61.5,
+                  "y": -18.5,
+                  "width": 190,
+                  "height": 10
+                },
+                "code": "",
+                "visibility": "public",
+                "attributeType": "str",
+                "implementationType": "none",
+                "stateMachineId": "",
+                "quantumCircuitId": "",
+                "isOptional": false,
+                "isDerived": false,
+                "isId": false,
+                "isExternalId": false,
+                "attributeId": "82c62904-19ae-45a0-b62a-60791bd696ee",
+                "attributeOperator": "=="
+              },
+              "a9e24c06-767a-4fb4-9cce-f3b22a8de045": {
+                "id": "a9e24c06-767a-4fb4-9cce-f3b22a8de045",
+                "name": "icon",
+                "type": "UserModelIcon",
+                "owner": "5df48dc0-89d1-4b15-9444-a27668a89966",
+                "bounds": {
+                  "x": -61,
+                  "y": 27,
+                  "width": 106,
+                  "height": 96
+                },
+                "icon": "<svg xmlns='http://www.w3.org/2000/svg' width='96' height='96' viewBox='0 0 24 24'> <g fill='none' stroke='#1e4b72' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5'><path d='M19.5 18h-1.323c-.328 0-.492 0-.619-.086s-.188-.238-.31-.543l-.497-1.242c-.121-.305-.182-.457-.31-.543c-.126-.086-.29-.086-.618-.086H13.5c-.471 0-.707 0-.854-.146c-.146-.147-.146-.383-.146-.854v-4m0-2.5v2.5m0 0h3.889M12.5 6a2 2 0 1 1 0-4a2 2 0 0 1 0 4' /><path d='M9.558 10c-2.87.48-5.058 2.964-5.058 5.958C4.5 19.295 7.217 22 10.57 22a6.07 6.07 0 0 0 4.93-2.517' /></g></svg>"
+              }
+            },
+            "relationships": {
+              "f3a88064-249c-4f0b-9fb8-9d8dcec56094": {
+                "id": "f3a88064-249c-4f0b-9fb8-9d8dcec56094",
+                "name": "",
+                "type": "ObjectLink",
+                "owner": null,
+                "bounds": {
+                  "x": -387,
+                  "y": -161.75,
+                  "width": 235.08333206176758,
+                  "height": 187.75
+                },
+                "path": [
+                  {
+                    "x": 0,
+                    "y": 147.75
+                  },
+                  {
+                    "x": 0,
+                    "y": 187.75
+                  },
+                  {
+                    "x": 93,
+                    "y": 187.75
+                  },
+                  {
+                    "x": 93,
+                    "y": 0
+                  },
+                  {
+                    "x": 235.08333206176758,
+                    "y": 0
+                  },
+                  {
+                    "x": 235.08333206176758,
+                    "y": 78.25
+                  }
+                ],
+                "source": {
+                  "direction": "Down",
+                  "element": "488449e0-5ad0-44db-a739-d505876ddfcb"
+                },
+                "target": {
+                  "direction": "Up",
+                  "element": "7b9e7742-9b5f-4ba6-8538-2204e16c29c8"
+                },
+                "isManuallyLayouted": false
+              },
+              "6f2a9605-d378-4737-82b8-eab065e12395": {
+                "id": "6f2a9605-d378-4737-82b8-eab065e12395",
+                "name": "",
+                "type": "ObjectLink",
+                "owner": null,
+                "bounds": {
+                  "x": -151.91666793823242,
+                  "y": -91,
+                  "width": 143.41666793823242,
+                  "height": 193.5
+                },
+                "path": [
+                  {
+                    "x": 0,
+                    "y": 153.5
+                  },
+                  {
+                    "x": 0,
+                    "y": 193.5
+                  },
+                  {
+                    "x": 103.58333206176758,
+                    "y": 193.5
+                  },
+                  {
+                    "x": 103.58333206176758,
+                    "y": 0
+                  },
+                  {
+                    "x": 143.41666793823242,
+                    "y": 0
+                  },
+                  {
+                    "x": 143.41666793823242,
+                    "y": 72.5
+                  }
+                ],
+                "source": {
+                  "direction": "Down",
+                  "element": "7b9e7742-9b5f-4ba6-8538-2204e16c29c8"
+                },
+                "target": {
+                  "direction": "Up",
+                  "element": "5df48dc0-89d1-4b15-9444-a27668a89966"
+                },
+                "isManuallyLayouted": false
+              }
+            },
+            "assessments": {}
+          },
+          "lastUpdate": "2026-05-06T13:49:34.689Z"
+        }
+      ]
+    },
+    "settings": {
+      "defaultDiagramType": "ClassDiagram",
+      "autoSave": true,
+      "collaborationEnabled": false,
+      "perspectives": {
+        "ClassDiagram": true,
+        "ObjectDiagram": true,
+        "StateMachineDiagram": true,
+        "AgentDiagram": true,
+        "UserDiagram": true,
+        "GUINoCodeDiagram": true,
+        "QuantumCircuitDiagram": true,
+        "NNDiagram": true
+      }
+    }
+  },
+  "exportedAt": "2026-05-06T13:49:40.997Z",
+  "version": "2.0.0"
+}


### PR DESCRIPTION
## Summary

Adds a **Full Project** tab to the Template Library, alongside the existing per-diagram pattern tabs. A full-project template carries an entire V2 project export envelope (`{ project, exportedAt, version }`), and loading it materializes a brand-new project via the same JSON import path the user-facing Import Project flow uses.

This complements the existing single-diagram pattern templates: those drop a model into a slot inside the active project, while full-project templates spin up a fresh project with several diagrams already wired together.

## Changes

- **`software-pattern-types.ts`** — new `SoftwarePatternCategory.FULL_PROJECT`, new `LIBRARY_FULL_STACK` pattern type, and a `FULL_PROJECT_DIAGRAM_TYPE = 'FullProject'` sentinel.
- **`template-types.ts`** — widen `TemplateDiagramType` to admit the sentinel.
- **`template-factory.ts`** — register `LIBRARY_FULL_STACK`, importing the bundled JSON.
- **`TemplateLibraryDialog.tsx`**
  - `Full Project` is the first category in the left sidebar.
  - `doLoadTemplate` branches on the sentinel: serializes the bundle to a `File`, calls `importProjectFromJson` (which generates a fresh project ID + `createdAt`), then `loadProjectThunk(newId)` to switch to it.
  - The per-diagram "Existing diagram detected — replace/new-tab" confirm is skipped for full-project templates (always a fresh project, no collision).
  - Cards in the Full Project tab summarize the included diagrams (e.g. `Class · Agent · GUI`) instead of showing a single diagram-type label.
- **`templates/pattern/project/library_full_stack.json`** — first bundled project: a Library management system with class diagram, agent, and GUI no-code page (with the agent component embedded) already wired together.

## Adding more full-project templates

1. Export the project from the editor (gives you a V2 envelope JSON).
2. Drop it into `packages/webapp/src/main/templates/pattern/project/`.
3. Add a new value to `SoftwarePatternType` and a `case` in `TemplateFactory.createSoftwarePattern` mapping it to `SoftwarePatternCategory.FULL_PROJECT` and the imported JSON.

## Test plan
- [ ] Open the Template Library → first tab is "Full Project" with a `Library (Full Stack)` card showing `Class · Agent · GUI`.
- [ ] Load it → new project opens with all three diagrams populated; existing project preserved in storage.
- [ ] Load it twice → two independent projects in storage (no ID collision).
- [ ] Other tabs still load single-diagram patterns as before, including the replace/new-tab confirm.
