### PR TITLE
feat(sidebar): default the workspace sidebar to expanded

### DIFF
--- a/packages/webapp/src/main/app/shell/WorkspaceShell.tsx
+++ b/packages/webapp/src/main/app/shell/WorkspaceShell.tsx
@@ -159,7 +159,9 @@ export const WorkspaceShell: React.FC<WorkspaceShellProps> = ({
   const importDiagramToProject = useImportDiagramToProjectWorkflow();
 
   // Local UI state
-  const [isSidebarExpanded, setIsSidebarExpanded] = useState(false);
+  // Sidebar starts expanded so diagram-type labels are visible; users can
+  // collapse it with the bottom toggle to reclaim canvas space.
+  const [isSidebarExpanded, setIsSidebarExpanded] = useState(true);
   const [isMobileDrawerOpen, setIsMobileDrawerOpen] = useState(false);
   const [projectNameDraft, setProjectNameDraft] = useState(currentProject?.name ?? '');
   const [diagramTitleDraft, setDiagramTitleDraft] = useState(diagram?.title ?? '');


### PR DESCRIPTION
## Summary

Start the desktop workspace sidebar **expanded** by default so diagram-type
labels are visible without any extra interaction. The existing bottom toggle
still collapses the sidebar to reclaim canvas space, and the mobile drawer is
unchanged.

This replaces the earlier hover-to-expand/pin/overlay approach with a single
one-line default change — simpler, no canvas occlusion, no new state.

## Test plan
- [ ] On load (desktop), the sidebar shows diagram-type labels (expanded).
- [ ] The bottom toggle collapses the sidebar to icons-only and expands it again.
- [ ] Mobile drawer (≤ md breakpoint) is unchanged.