### PR TITLE
fix(template): restore saved configs on personalized gym agent import

### DIFF
--- a/packages/webapp/src/main/features/agent-config/AgentConfigurationPanel.tsx
+++ b/packages/webapp/src/main/features/agent-config/AgentConfigurationPanel.tsx
@@ -1495,7 +1495,7 @@ export const AgentConfigurationPanel: React.FC = () => {
 
       <div className="mx-auto flex max-w-6xl flex-col gap-6">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight text-foreground">Agent Configuration</h1>
+          <h1 className="text-2xl font-bold tracking-tight text-foreground">Agent Customization</h1>
           <p className="mt-1 text-sm text-muted-foreground">
             Tailor your agent to a specific user profile from the User Diagram. Adjust how it talks, looks, and behaves to match that audience, then save the result as a named configuration you can switch between later.
           </p>
@@ -1537,24 +1537,24 @@ export const AgentConfigurationPanel: React.FC = () => {
         {activeTab === 'personalization' && (
           <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-muted/20 p-2">
             <span className="px-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              Load a saved configuration
+              Load a saved customization
             </span>
             {activeConfigId && (
-              <Badge variant="secondary" title={activeConfigName || 'Unnamed configuration'}>
+              <Badge variant="secondary" title={activeConfigName || 'Unnamed customization'}>
                 <span className="block max-w-[180px] truncate">
                   Active: {activeConfigName || 'Unnamed'}
                 </span>
               </Badge>
             )}
             <select
-              aria-label="Load a saved configuration"
+              aria-label="Load a saved customization"
               className="h-9 rounded-md border border-input bg-background px-2 py-1 text-sm transition-colors hover:border-brand/30 focus:border-brand/40 focus:outline-none focus:ring-2 focus:ring-brand/20"
               value={selectedConfigId}
               onChange={(event) => setSelectedConfigId(event.target.value)}
               disabled={savedConfigs.length === 0}
             >
               <option value="">
-                {savedConfigs.length === 0 ? 'No saved configurations yet' : 'Select a saved configuration'}
+                {savedConfigs.length === 0 ? 'No saved customizations yet' : 'Select a saved customization'}
               </option>
               {savedConfigs.map((entry) => (
                 <option key={entry.id} value={entry.id}>
@@ -2215,14 +2215,14 @@ export const AgentConfigurationPanel: React.FC = () => {
           <div className="grid gap-6 lg:grid-cols-2">
             <Card>
               <CardHeader>
-                <CardTitle>Save this configuration</CardTitle>
+                <CardTitle>Save this customization</CardTitle>
                 <CardDescription>
-                  When you're done filling in the form above, name your configuration and save it here. Saved configurations show up in the "Load a saved configuration" picker at the top of the page so you can switch between them later.
+                  When you're done filling in the form above, name your customization and save it here. Saved customizations show up in the "Load a saved customization" picker at the top of the page so you can switch between them later.
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="space-y-1.5">
-                  <Label htmlFor="configuration-name">Configuration Name</Label>
+                  <Label htmlFor="configuration-name">Customization Name</Label>
                   <Input
                     id="configuration-name"
                     value={configurationName}
@@ -2232,15 +2232,15 @@ export const AgentConfigurationPanel: React.FC = () => {
                   {activeConfigId ? (
                     <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
                       <Badge variant="secondary">Active</Badge>
-                      <span>{activeConfigName || 'Unnamed configuration'}</span>
+                      <span>{activeConfigName || 'Unnamed customization'}</span>
                     </div>
                   ) : (
-                    <p className="text-xs text-muted-foreground">Not linked to a saved configuration yet.</p>
+                    <p className="text-xs text-muted-foreground">Not linked to a saved customization yet.</p>
                   )}
                 </div>
 
                 <div className="space-y-1.5">
-                  <Label htmlFor="saved-configurations">Saved Configurations</Label>
+                  <Label htmlFor="saved-configurations">Saved Customizations</Label>
                   <select
                     id="saved-configurations"
                     className="h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
@@ -2249,7 +2249,7 @@ export const AgentConfigurationPanel: React.FC = () => {
                     disabled={savedConfigs.length === 0}
                   >
                     <option value="">
-                      {savedConfigs.length === 0 ? 'No saved configurations yet' : 'Select a configuration'}
+                      {savedConfigs.length === 0 ? 'No saved customizations yet' : 'Select a customization'}
                     </option>
                     {savedConfigs.map((entry) => (
                       <option key={entry.id} value={entry.id}>

--- a/packages/webapp/src/main/features/github/hooks/useGitHubRepo.ts
+++ b/packages/webapp/src/main/features/github/hooks/useGitHubRepo.ts
@@ -198,7 +198,12 @@ export const useGitHubRepo = () => {
         // and ship it alongside the deploy payload, so the backend can drop it
         // into the repo as `diagrams.json` and the file stays re-importable via
         // the editor's "Import Project" action.
-        const projectExport = buildProjectExportEnvelope(projectForBackend);
+        // Skip bundled personalization here — saved configurations and user
+        // profiles are local user state, not something we want pushed into a
+        // (potentially public) GitHub repo on every deploy.
+        const projectExport = buildProjectExportEnvelope(projectForBackend, undefined, {
+          includePersonalization: false,
+        });
 
         const requestBody = {
           ...projectForBackend,

--- a/packages/webapp/src/main/shared/dialogs/HelpGuideDialog.tsx
+++ b/packages/webapp/src/main/shared/dialogs/HelpGuideDialog.tsx
@@ -407,7 +407,7 @@ const sections: GuideSection[] = [
         },
       },
       {
-        title: 'Agent Configuration',
+        title: 'Agent Customization',
         body: (
           <div className="space-y-2">
             <p>

--- a/packages/webapp/src/main/shared/services/project-import/projectImport.ts
+++ b/packages/webapp/src/main/shared/services/project-import/projectImport.ts
@@ -8,14 +8,25 @@ import {
   getActiveDiagram,
 } from '../../types/project';
 import { ProjectStorageRepository } from '../storage/ProjectStorageRepository';
+import { LocalStorageRepository } from '../storage/local-storage-repository';
+import {
+  StoredAgentConfiguration,
+  StoredAgentProfileConfigurationMapping,
+  StoredUserProfile,
+} from '../storage/local-storage-types';
 import { BACKEND_URL } from '../../constants/constant';
-import { UMLDiagramType } from '@besser/wme';
+import { UMLDiagramType, UMLModel } from '@besser/wme';
 
 // Interface for V2 JSON export format
 interface V2ExportData {
   project: BesserProject;
   exportedAt: string;
   version: string;
+  agentConfigurations?: StoredAgentConfiguration[];
+  userProfiles?: StoredUserProfile[];
+  agentProfileMappings?: StoredAgentProfileConfigurationMapping[];
+  activeAgentConfigurationId?: string | null;
+  agentBaseModels?: Record<string, UMLModel>;
 }
 
 // Interface for legacy import validation (V1 format)
@@ -247,8 +258,16 @@ function isGUIModelEmpty(guiModel: any): boolean {
   return false;
 }
 
+interface ImportedPersonalization {
+  agentConfigurations?: StoredAgentConfiguration[];
+  userProfiles?: StoredUserProfile[];
+  agentProfileMappings?: StoredAgentProfileConfigurationMapping[];
+  activeAgentConfigurationId?: string | null;
+  agentBaseModels?: Record<string, UMLModel>;
+}
+
 // Store imported project using the project storage system
-function storeImportedProject(project: BesserProject): void {
+function storeImportedProject(project: BesserProject, personalization?: ImportedPersonalization): void {
   // Check if the imported GUI model is empty
   const importedGUIDiagram = getActiveDiagram(project, 'GUINoCodeDiagram');
   const importedGUIModel = importedGUIDiagram?.model;
@@ -274,6 +293,27 @@ function storeImportedProject(project: BesserProject): void {
   }
 
   ProjectStorageRepository.saveProject(project);
+
+  if (personalization) {
+    LocalStorageRepository.mergeImportedPersonalization(personalization);
+  }
+}
+
+function extractPersonalization(data: V2ExportData): ImportedPersonalization | undefined {
+  const has =
+    (Array.isArray(data.agentConfigurations) && data.agentConfigurations.length > 0) ||
+    (Array.isArray(data.userProfiles) && data.userProfiles.length > 0) ||
+    (Array.isArray(data.agentProfileMappings) && data.agentProfileMappings.length > 0) ||
+    (data.agentBaseModels && Object.keys(data.agentBaseModels).length > 0) ||
+    !!data.activeAgentConfigurationId;
+  if (!has) return undefined;
+  return {
+    agentConfigurations: data.agentConfigurations,
+    userProfiles: data.userProfiles,
+    agentProfileMappings: data.agentProfileMappings,
+    activeAgentConfigurationId: data.activeAgentConfigurationId,
+    agentBaseModels: data.agentBaseModels,
+  };
 }
 
 // Import from BUML (.py)
@@ -305,7 +345,7 @@ export async function importProjectFromBUML(file: File): Promise<BesserProject> 
       name: `${jsonData.project.name}`,
       createdAt: new Date().toISOString(),
     });
-    storeImportedProject(project);
+    storeImportedProject(project, extractPersonalization(jsonData));
     return project;
 
   } else if (validateLegacyImportData(jsonData)) {
@@ -348,7 +388,7 @@ export async function importProjectFromJson(file: File): Promise<BesserProject> 
           });
 
           // Store using project storage
-          storeImportedProject(importedProject);
+          storeImportedProject(importedProject, extractPersonalization(jsonData));
 
           console.log(`Project "${importedProject.name}" imported successfully (V2 format)`);
           resolve(importedProject);

--- a/packages/webapp/src/main/shared/services/storage/local-storage-repository.ts
+++ b/packages/webapp/src/main/shared/services/storage/local-storage-repository.ts
@@ -248,6 +248,10 @@ export const LocalStorageRepository = {
     return stored ? (JSON.parse(JSON.stringify(stored)) as UMLModel) : null;
   },
 
+  getAllAgentBaseModels: (): Record<string, UMLModel> => {
+    return JSON.parse(JSON.stringify(getStoredAgentBaseModels())) as Record<string, UMLModel>;
+  },
+
   saveUserProfile: (name: string, model: UMLModel) => {
     const trimmedName = name.trim();
     if (!trimmedName) {
@@ -427,6 +431,82 @@ export const LocalStorageRepository = {
     const legacyKey = legacyDeployLinkedRepoKey(projectId, target);
     if (legacyKey) {
       localStorage.removeItem(legacyKey);
+    }
+  },
+
+  /**
+   * Merge personalization data carried in a project-export envelope into
+   * existing localStorage state. Existing entries win on id collisions —
+   * the user's already-saved configurations / profiles / mappings are never
+   * overwritten by an import. Items with new ids are appended.
+   *
+   * ``activeAgentConfigurationId`` is applied only when the user has no
+   * active configuration set yet, so importing a project doesn't yank the
+   * active config out from under an in-progress session.
+   */
+  mergeImportedPersonalization: (data: {
+    agentConfigurations?: StoredAgentConfiguration[];
+    userProfiles?: StoredUserProfile[];
+    agentProfileMappings?: StoredAgentProfileConfigurationMapping[];
+    activeAgentConfigurationId?: string | null;
+    agentBaseModels?: Record<string, UMLModel>;
+  }): void => {
+    if (Array.isArray(data.userProfiles) && data.userProfiles.length > 0) {
+      const existing = getStoredUserProfiles();
+      const existingIds = new Set(existing.map((p) => p.id));
+      const merged = [...existing];
+      for (const incoming of data.userProfiles) {
+        if (!existingIds.has(incoming.id)) {
+          merged.push(JSON.parse(JSON.stringify(incoming)));
+        }
+      }
+      persistUserProfiles(merged);
+    }
+
+    if (Array.isArray(data.agentConfigurations) && data.agentConfigurations.length > 0) {
+      const existing = getStoredAgentConfigurations();
+      const existingIds = new Set(existing.map((c) => c.id));
+      const merged = [...existing];
+      for (const incoming of data.agentConfigurations) {
+        if (!existingIds.has(incoming.id)) {
+          merged.push(JSON.parse(JSON.stringify(incoming)));
+        }
+      }
+      persistAgentConfigurations(merged);
+    }
+
+    if (Array.isArray(data.agentProfileMappings) && data.agentProfileMappings.length > 0) {
+      const existing = getStoredAgentProfileMappings();
+      const existingIds = new Set(existing.map((m) => m.id));
+      const merged = [...existing];
+      for (const incoming of data.agentProfileMappings) {
+        if (!existingIds.has(incoming.id)) {
+          merged.push(JSON.parse(JSON.stringify(incoming)));
+        }
+      }
+      persistAgentProfileMappings(merged);
+    }
+
+    if (data.agentBaseModels && typeof data.agentBaseModels === 'object') {
+      const existing = getStoredAgentBaseModels();
+      const merged: AgentBaseModelMap = { ...existing };
+      for (const [diagramId, model] of Object.entries(data.agentBaseModels)) {
+        if (!(diagramId in merged) && model) {
+          merged[diagramId] = JSON.parse(JSON.stringify(model)) as UMLModel;
+        }
+      }
+      persistAgentBaseModels(merged);
+    }
+
+    if (
+      typeof data.activeAgentConfigurationId === 'string' &&
+      data.activeAgentConfigurationId &&
+      !localStorage.getItem(localStorageActiveAgentConfiguration)
+    ) {
+      const allConfigs = getStoredAgentConfigurations();
+      if (allConfigs.some((c) => c.id === data.activeAgentConfigurationId)) {
+        safeSetItem(localStorageActiveAgentConfiguration, data.activeAgentConfigurationId);
+      }
     }
   },
 

--- a/packages/webapp/src/main/shared/utils/projectExportUtils.ts
+++ b/packages/webapp/src/main/shared/utils/projectExportUtils.ts
@@ -1,4 +1,11 @@
+import { UMLModel } from '@besser/wme';
 import { BesserProject, ProjectDiagram, SupportedDiagramType, getActiveDiagram, diagramHasContent } from '../types/project';
+import { LocalStorageRepository } from '../services/storage/local-storage-repository';
+import {
+  StoredAgentConfiguration,
+  StoredAgentProfileConfigurationMapping,
+  StoredUserProfile,
+} from '../services/storage/local-storage-types';
 import { normalizeProjectName } from './projectName';
 
 export const PROJECT_EXPORT_VERSION = '2.0.0';
@@ -94,16 +101,57 @@ export interface ProjectExportEnvelope {
   project: ExportableProjectPayload;
   exportedAt: string;
   version: string;
+  /**
+   * Optional bundled personalization state. Lives in localStorage at runtime
+   * (besser_agentConfigs, besser_userProfiles, besser_agentProfileMappings,
+   * besser_agentBaseModels, besser_agentActiveConfig) — bundled here so an
+   * imported project can restore the user's saved configurations and profile
+   * mappings rather than landing with an empty Personalization tab.
+   */
+  agentConfigurations?: StoredAgentConfiguration[];
+  userProfiles?: StoredUserProfile[];
+  agentProfileMappings?: StoredAgentProfileConfigurationMapping[];
+  activeAgentConfigurationId?: string | null;
+  agentBaseModels?: Record<string, UMLModel>;
+}
+
+export interface BuildProjectExportEnvelopeOptions {
+  /**
+   * Bundle saved configurations / user profiles / mappings / base agent
+   * models into the envelope. Default: ``true``. Set to ``false`` for paths
+   * that publish the envelope to a third party (e.g. GitHub deploy) so user
+   * profiles don't end up in a public repo.
+   */
+  includePersonalization?: boolean;
 }
 
 /** Build a V2 project-export envelope (project + exportedAt + version). */
 export function buildProjectExportEnvelope(
   project: BesserProject,
   diagramTypes?: SupportedDiagramType[],
+  options: BuildProjectExportEnvelopeOptions = {},
 ): ProjectExportEnvelope {
-  return {
+  const includePersonalization = options.includePersonalization !== false;
+
+  const envelope: ProjectExportEnvelope = {
     project: buildExportableProjectPayload(project, diagramTypes),
     exportedAt: new Date().toISOString(),
     version: PROJECT_EXPORT_VERSION,
   };
+
+  if (includePersonalization) {
+    const agentConfigurations = LocalStorageRepository.getAgentConfigurations();
+    const userProfiles = LocalStorageRepository.getUserProfiles();
+    const agentProfileMappings = LocalStorageRepository.getAgentProfileConfigurationMappings();
+    const activeAgentConfigurationId = LocalStorageRepository.getActiveAgentConfigurationId();
+    const agentBaseModels = LocalStorageRepository.getAllAgentBaseModels();
+
+    if (agentConfigurations.length > 0) envelope.agentConfigurations = agentConfigurations;
+    if (userProfiles.length > 0) envelope.userProfiles = userProfiles;
+    if (agentProfileMappings.length > 0) envelope.agentProfileMappings = agentProfileMappings;
+    if (activeAgentConfigurationId) envelope.activeAgentConfigurationId = activeAgentConfigurationId;
+    if (Object.keys(agentBaseModels).length > 0) envelope.agentBaseModels = agentBaseModels;
+  }
+
+  return envelope;
 }

--- a/packages/webapp/src/main/templates/pattern/project/personalized_gym_agent.json
+++ b/packages/webapp/src/main/templates/pattern/project/personalized_gym_agent.json
@@ -27,351 +27,363 @@
             "version": "3.0.0",
             "type": "AgentDiagram",
             "size": {
-              "width": 1300,
-              "height": 900
+              "width": 1080,
+              "height": 400
             },
             "interactive": {
               "elements": {},
               "relationships": {}
             },
             "elements": {
-              "c383f8b0-d915-439b-8bde-18a30da80fa3": {
-                "id": "c383f8b0-d915-439b-8bde-18a30da80fa3",
-                "name": "Muscles_intent",
-                "type": "AgentIntent",
-                "owner": null,
-                "bounds": {
-                  "x": -550,
-                  "y": -300,
-                  "width": 630,
-                  "height": 100
-                },
-                "bodies": [
-                  "6b718df7-70ef-4e1c-8c6b-c82133964f86"
-                ],
-                "intent_description": "Question about how to become muscular and which exercises to perform."
-              },
-              "6b718df7-70ef-4e1c-8c6b-c82133964f86": {
-                "id": "6b718df7-70ef-4e1c-8c6b-c82133964f86",
-                "name": "I want muscles",
-                "type": "AgentIntentBody",
-                "owner": "c383f8b0-d915-439b-8bde-18a30da80fa3",
-                "bounds": {
-                  "x": -549.5,
-                  "y": -229.5,
-                  "width": 629,
-                  "height": 30
-                }
-              },
-              "a009a9ba-7a03-4f79-9122-416d8b74a0bb": {
-                "id": "a009a9ba-7a03-4f79-9122-416d8b74a0bb",
-                "name": "Nutrition_intent",
-                "type": "AgentIntent",
-                "owner": null,
-                "bounds": {
-                  "x": -250,
-                  "y": -300,
-                  "width": 340,
-                  "height": 100
-                },
-                "bodies": [
-                  "192db72d-4d0e-49b0-b49c-5050fb0dbb68"
-                ],
-                "intent_description": "Question about nutrition in gym."
-              },
-              "192db72d-4d0e-49b0-b49c-5050fb0dbb68": {
-                "id": "192db72d-4d0e-49b0-b49c-5050fb0dbb68",
-                "name": "Which food to eat?",
-                "type": "AgentIntentBody",
-                "owner": "a009a9ba-7a03-4f79-9122-416d8b74a0bb",
-                "bounds": {
-                  "x": -249.5,
-                  "y": -229.5,
-                  "width": 339,
-                  "height": 30
-                }
-              },
-              "90d28305-378e-4bad-b3ea-61c3ddaa5921": {
-                "id": "90d28305-378e-4bad-b3ea-61c3ddaa5921",
-                "name": "Other",
-                "type": "AgentIntent",
-                "owner": null,
-                "bounds": {
-                  "x": 50,
-                  "y": -300,
-                  "width": 500,
-                  "height": 70
-                },
-                "bodies": [],
-                "intent_description": "Any question that does not fit in \"Muscles\" or \"Nutrition\""
-              },
-              "731e886c-9cef-4fa7-ba6d-72aa25c32d4f": {
-                "id": "731e886c-9cef-4fa7-ba6d-72aa25c32d4f",
+              "699853eb-918b-4674-b08c-cf0af3cc61d7": {
+                "id": "699853eb-918b-4674-b08c-cf0af3cc61d7",
                 "name": "",
                 "type": "StateInitialNode",
                 "owner": null,
                 "bounds": {
-                  "x": -580,
-                  "y": -60,
+                  "x": -230,
+                  "y": -370,
                   "width": 45,
                   "height": 45
                 }
               },
-              "c10f03ca-2073-4002-8d1b-e42536008f4c": {
-                "id": "c10f03ca-2073-4002-8d1b-e42536008f4c",
-                "name": "Initial",
-                "type": "AgentState",
-                "owner": null,
-                "bounds": {
-                  "x": -280,
-                  "y": -80,
-                  "width": 330,
-                  "height": 70
-                },
-                "bodies": [
-                  "82783f5d-8ef3-47f7-8feb-9651bdf73d63"
-                ],
-                "fallbackBodies": []
-              },
-              "82783f5d-8ef3-47f7-8feb-9651bdf73d63": {
-                "id": "82783f5d-8ef3-47f7-8feb-9651bdf73d63",
-                "name": "Hi, I am your buddy, the fitness agent.",
-                "type": "AgentStateBody",
-                "owner": "c10f03ca-2073-4002-8d1b-e42536008f4c",
-                "bounds": {
-                  "x": -279.5,
-                  "y": -39.5,
-                  "width": 329,
-                  "height": 30
-                },
-                "replyType": "text"
-              },
-              "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8": {
-                "id": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+              "0cba5357-2c30-414b-8d74-ac74ac4ab158": {
+                "id": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
                 "name": "Idle",
                 "type": "AgentState",
                 "owner": null,
                 "bounds": {
-                  "x": 210,
-                  "y": -80,
+                  "x": -180,
+                  "y": -200,
                   "width": 420,
                   "height": 100
                 },
                 "bodies": [
-                  "d91b1fe8-cd6c-4b20-928c-70021c0f044d"
+                  "63a2c160-ebbb-457b-953a-93fd2e643224"
                 ],
                 "fallbackBodies": [
-                  "10a044fe-f0bd-41e8-ae27-0f2c2afc2cac"
+                  "1f369122-06c2-4050-ba54-4ea160f95a8c"
                 ]
               },
-              "d91b1fe8-cd6c-4b20-928c-70021c0f044d": {
-                "id": "d91b1fe8-cd6c-4b20-928c-70021c0f044d",
+              "63a2c160-ebbb-457b-953a-93fd2e643224": {
+                "id": "63a2c160-ebbb-457b-953a-93fd2e643224",
                 "name": "I am here to answer any questions regarding exercises, nutrition and recovery.",
                 "type": "AgentStateBody",
-                "owner": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                "owner": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
                 "bounds": {
-                  "x": 210.5,
-                  "y": -39.5,
+                  "x": -179.5,
+                  "y": -159.5,
                   "width": 419,
                   "height": 30
                 },
-                "replyType": "text"
+                "replyType": "text",
+                "ragDatabaseName": ""
               },
-              "10a044fe-f0bd-41e8-ae27-0f2c2afc2cac": {
-                "id": "10a044fe-f0bd-41e8-ae27-0f2c2afc2cac",
+              "1f369122-06c2-4050-ba54-4ea160f95a8c": {
+                "id": "1f369122-06c2-4050-ba54-4ea160f95a8c",
                 "name": "I focus on gym and fitness topics only dude.",
                 "type": "AgentStateFallbackBody",
-                "owner": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+                "owner": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
                 "bounds": {
-                  "x": 210.5,
-                  "y": -9.5,
+                  "x": -179.5,
+                  "y": -129.5,
                   "width": 419,
                   "height": 30
                 },
-                "replyType": "text"
+                "replyType": "text",
+                "ragDatabaseName": ""
               },
-              "aa0bf687-2e08-4cba-aa98-335bcce5ecc7": {
-                "id": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+              "8dba49ff-2fc1-4066-b124-19e2df7981e2": {
+                "id": "8dba49ff-2fc1-4066-b124-19e2df7981e2",
+                "name": "Muscles_intent",
+                "type": "AgentIntent",
+                "owner": null,
+                "bounds": {
+                  "x": -900,
+                  "y": -400,
+                  "width": 630,
+                  "height": 100
+                },
+                "bodies": [
+                  "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b"
+                ],
+                "intent_description": "Question about how to become muscular and which exercises to perform."
+              },
+              "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b": {
+                "id": "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b",
+                "name": "I want muscles",
+                "type": "AgentIntentBody",
+                "owner": "8dba49ff-2fc1-4066-b124-19e2df7981e2",
+                "bounds": {
+                  "x": -899.5,
+                  "y": -329.5,
+                  "width": 629,
+                  "height": 30
+                }
+              },
+              "68ccb630-b264-41a0-b70e-1e369bd5706c": {
+                "id": "68ccb630-b264-41a0-b70e-1e369bd5706c",
                 "name": "TrainingPlan",
                 "type": "AgentState",
                 "owner": null,
                 "bounds": {
-                  "x": -280,
-                  "y": 140,
+                  "x": -800,
+                  "y": -30,
                   "width": 420,
                   "height": 130
                 },
                 "bodies": [
-                  "d55e541d-6530-44ad-8d86-0ae51039bd72",
-                  "964f437d-ab33-4e0d-bd1c-e36387c879eb",
-                  "31249e62-6b58-48fb-af98-e55090d683e1"
+                  "aa261be5-9c53-4df1-a72f-5a107ce8f1b7",
+                  "747b8558-325d-4a15-baba-0d18a6602a8d",
+                  "900f7fd9-738a-4981-a7d9-6c7334621981"
                 ],
                 "fallbackBodies": []
               },
-              "d55e541d-6530-44ad-8d86-0ae51039bd72": {
-                "id": "d55e541d-6530-44ad-8d86-0ae51039bd72",
-                "name": "Focus on accessible compound upper-body and core movements like bench press or machine chest press, overhead press, seated rows, lat pulldowns/assisted pull-ups, dips or triceps pushdowns, face pulls, and anti-rotation core work (e.g., Pallof press), using seated or strap-stabilized setups as needed.",
+              "aa261be5-9c53-4df1-a72f-5a107ce8f1b7": {
+                "id": "aa261be5-9c53-4df1-a72f-5a107ce8f1b7",
+                "name": "Focus on heavy compound lifts like squats, deadlifts, bench press, overhead press, and rows to build overall muscle mass. ",
                 "type": "AgentStateBody",
-                "owner": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+                "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
                 "bounds": {
-                  "x": -279.5,
-                  "y": 180.5,
+                  "x": -799.5,
+                  "y": 10.5,
                   "width": 419,
                   "height": 30
                 },
-                "replyType": "text"
+                "replyType": "text",
+                "ragDatabaseName": ""
               },
-              "964f437d-ab33-4e0d-bd1c-e36387c879eb": {
-                "id": "964f437d-ab33-4e0d-bd1c-e36387c879eb",
-                "name": "Train 3\u20135 times per week, progressively increasing resistance on upper-body and core-focused exercises while eating enough protein and calories to support growth; balance pushing and pulling to protect your shoulders and allow adequate recovery.",
+              "747b8558-325d-4a15-baba-0d18a6602a8d": {
+                "id": "747b8558-325d-4a15-baba-0d18a6602a8d",
+                "name": "Train 3–5 times per week, progressively increasing the weight while eating enough protein and calories to support growth. ",
                 "type": "AgentStateBody",
-                "owner": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+                "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
                 "bounds": {
-                  "x": -279.5,
-                  "y": 210.5,
+                  "x": -799.5,
+                  "y": 40.5,
                   "width": 419,
                   "height": 30
                 },
-                "replyType": "text"
+                "replyType": "text",
+                "ragDatabaseName": ""
               },
-              "31249e62-6b58-48fb-af98-e55090d683e1": {
-                "id": "31249e62-6b58-48fb-af98-e55090d683e1",
-                "name": "Get good sleep and stay consistent\u2014muscle comes from steady effort over time.",
+              "900f7fd9-738a-4981-a7d9-6c7334621981": {
+                "id": "900f7fd9-738a-4981-a7d9-6c7334621981",
+                "name": "Get good sleep and stay consistent—muscle comes from steady effort over time.",
                 "type": "AgentStateBody",
-                "owner": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+                "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
                 "bounds": {
-                  "x": -279.5,
-                  "y": 240.5,
+                  "x": -799.5,
+                  "y": 70.5,
                   "width": 419,
                   "height": 30
                 },
-                "replyType": "text"
+                "replyType": "text",
+                "ragDatabaseName": ""
               },
-              "110dac05-6c3a-4fd1-a747-6df88d09cf77": {
-                "id": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+              "77976ef7-599d-4c49-9f4d-1ecb23239fe3": {
+                "id": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
+                "name": "Initial",
+                "type": "AgentState",
+                "owner": null,
+                "bounds": {
+                  "x": -100,
+                  "y": -370,
+                  "width": 420,
+                  "height": 70
+                },
+                "bodies": [
+                  "ad226172-93d8-4644-80c5-62825565dd24"
+                ],
+                "fallbackBodies": []
+              },
+              "ad226172-93d8-4644-80c5-62825565dd24": {
+                "id": "ad226172-93d8-4644-80c5-62825565dd24",
+                "name": "Hi, I am your buddy, the fitness agent.",
+                "type": "AgentStateBody",
+                "owner": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
+                "bounds": {
+                  "x": -99.5,
+                  "y": -329.5,
+                  "width": 419,
+                  "height": 30
+                },
+                "replyType": "text",
+                "ragDatabaseName": ""
+              },
+              "7610bbda-21ef-4637-a188-1da1352bea17": {
+                "id": "7610bbda-21ef-4637-a188-1da1352bea17",
                 "name": "Nutrition",
                 "type": "AgentState",
                 "owner": null,
                 "bounds": {
-                  "x": 210,
-                  "y": 140,
+                  "x": -150,
+                  "y": 130,
                   "width": 420,
                   "height": 190
                 },
                 "bodies": [
-                  "3fa5c3b5-3e12-4968-b16c-1f80a98693c1",
-                  "5c6dad70-8209-4de6-ae7a-5a9747fada8a",
-                  "ac38d464-9f06-48cf-b6c5-76e721298f92",
-                  "49fc07e1-484c-4459-b5b9-b223c5d7b129",
-                  "0bcfa6cb-74c0-43c8-867b-2fc966c53671"
+                  "bb7e67bd-ead9-4f14-93db-c18af0d806af",
+                  "13072ea8-9b51-45fe-927e-a9323627701b",
+                  "95241c3a-f8a2-4bf0-b169-5dcff5a926fb",
+                  "44904a03-ac46-4f9f-983a-f6a740b81c0e",
+                  "90dfba4f-6dec-4ca8-8c15-786ed36587a1"
                 ],
                 "fallbackBodies": []
               },
-              "3fa5c3b5-3e12-4968-b16c-1f80a98693c1": {
-                "id": "3fa5c3b5-3e12-4968-b16c-1f80a98693c1",
-                "name": "Nutrition basics: Eat mostly whole foods (lean protein, vegetables, fruits, whole grains, healthy fats). Protein: ~1.6\u20132.2 g per kg of body weight daily..",
+              "bb7e67bd-ead9-4f14-93db-c18af0d806af": {
+                "id": "bb7e67bd-ead9-4f14-93db-c18af0d806af",
+                "name": "Nutrition basics: Eat mostly whole foods (lean protein, vegetables, fruits, whole grains, healthy fats). Protein: ~1.6–2.2 g per kg of body weight daily..",
                 "type": "AgentStateBody",
-                "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
                 "bounds": {
-                  "x": 210.5,
-                  "y": 180.5,
+                  "x": -149.5,
+                  "y": 170.5,
                   "width": 419,
                   "height": 30
                 },
-                "replyType": "text"
+                "replyType": "text",
+                "ragDatabaseName": ""
               },
-              "5c6dad70-8209-4de6-ae7a-5a9747fada8a": {
-                "id": "5c6dad70-8209-4de6-ae7a-5a9747fada8a",
-                "name": "Match calories to your goal: slight surplus to gain muscle, deficit to lose fat, maintenance to stay the same.",
+              "13072ea8-9b51-45fe-927e-a9323627701b": {
+                "id": "13072ea8-9b51-45fe-927e-a9323627701b",
+                "name": "Match calories to your goal: slight surplus to gain muscle, deficit to lose fat, maintenance to stay the same. ",
                 "type": "AgentStateBody",
-                "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
                 "bounds": {
-                  "x": 210.5,
-                  "y": 210.5,
+                  "x": -149.5,
+                  "y": 200.5,
                   "width": 419,
                   "height": 30
                 },
-                "replyType": "text"
+                "replyType": "text",
+                "ragDatabaseName": ""
               },
-              "ac38d464-9f06-48cf-b6c5-76e721298f92": {
-                "id": "ac38d464-9f06-48cf-b6c5-76e721298f92",
-                "name": "Carbs fuel training; fats support hormones.",
+              "95241c3a-f8a2-4bf0-b169-5dcff5a926fb": {
+                "id": "95241c3a-f8a2-4bf0-b169-5dcff5a926fb",
+                "name": " Carbs fuel training; fats support hormones.",
                 "type": "AgentStateBody",
-                "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
                 "bounds": {
-                  "x": 210.5,
-                  "y": 240.5,
+                  "x": -149.5,
+                  "y": 230.5,
                   "width": 419,
                   "height": 30
                 },
-                "replyType": "text"
+                "replyType": "text",
+                "ragDatabaseName": ""
               },
-              "49fc07e1-484c-4459-b5b9-b223c5d7b129": {
-                "id": "49fc07e1-484c-4459-b5b9-b223c5d7b129",
-                "name": "Drink plenty of water and limit ultra-processed foods and alcohol.",
+              "44904a03-ac46-4f9f-983a-f6a740b81c0e": {
+                "id": "44904a03-ac46-4f9f-983a-f6a740b81c0e",
+                "name": " Drink plenty of water and limit ultra-processed foods and alcohol. ",
                 "type": "AgentStateBody",
-                "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
                 "bounds": {
-                  "x": 210.5,
-                  "y": 270.5,
+                  "x": -149.5,
+                  "y": 260.5,
                   "width": 419,
                   "height": 30
                 },
-                "replyType": "text"
+                "replyType": "text",
+                "ragDatabaseName": ""
               },
-              "0bcfa6cb-74c0-43c8-867b-2fc966c53671": {
-                "id": "0bcfa6cb-74c0-43c8-867b-2fc966c53671",
-                "name": "Be consistent \u2014 results come from habits, not perfection",
+              "90dfba4f-6dec-4ca8-8c15-786ed36587a1": {
+                "id": "90dfba4f-6dec-4ca8-8c15-786ed36587a1",
+                "name": "Be consistent — results come from habits, not perfection",
                 "type": "AgentStateBody",
-                "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+                "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
                 "bounds": {
-                  "x": 210.5,
-                  "y": 300.5,
+                  "x": -149.5,
+                  "y": 290.5,
                   "width": 419,
                   "height": 30
                 },
-                "replyType": "text"
+                "replyType": "text",
+                "ragDatabaseName": ""
               },
-              "a22b9877-2809-426e-8b72-504ef7abcce0": {
-                "id": "a22b9877-2809-426e-8b72-504ef7abcce0",
+              "8c760b7d-7e72-4cd7-a92a-d5491c021a5b": {
+                "id": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b",
                 "name": "OtherQuestions",
                 "type": "AgentState",
                 "owner": null,
                 "bounds": {
-                  "x": -280,
-                  "y": 360,
+                  "x": 350,
+                  "y": -90,
                   "width": 180,
                   "height": 70
                 },
                 "bodies": [
-                  "3721c5e6-19b1-4811-8b00-17415913c3aa"
+                  "6a3aeb02-bb44-4472-8489-595e8dc8ceb1"
                 ],
                 "fallbackBodies": []
               },
-              "3721c5e6-19b1-4811-8b00-17415913c3aa": {
-                "id": "3721c5e6-19b1-4811-8b00-17415913c3aa",
-                "name": "AI response \ud83e\ude84",
+              "6a3aeb02-bb44-4472-8489-595e8dc8ceb1": {
+                "id": "6a3aeb02-bb44-4472-8489-595e8dc8ceb1",
+                "name": "AI response 🪄",
                 "type": "AgentStateBody",
-                "owner": "a22b9877-2809-426e-8b72-504ef7abcce0",
+                "owner": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b",
                 "bounds": {
-                  "x": -279.5,
-                  "y": 400.5,
+                  "x": 350.5,
+                  "y": -49.5,
                   "width": 179,
                   "height": 30
                 },
-                "replyType": "llm"
+                "replyType": "llm",
+                "ragDatabaseName": ""
+              },
+              "659e810a-f686-47fb-aea8-d23ad06e482c": {
+                "id": "659e810a-f686-47fb-aea8-d23ad06e482c",
+                "name": "Nutrition_intent",
+                "type": "AgentIntent",
+                "owner": null,
+                "bounds": {
+                  "x": -900,
+                  "y": -290,
+                  "width": 630,
+                  "height": 100
+                },
+                "bodies": [
+                  "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0"
+                ],
+                "intent_description": "Question about nutrition in gym."
+              },
+              "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0": {
+                "id": "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0",
+                "name": "Which food to eat?",
+                "type": "AgentIntentBody",
+                "owner": "659e810a-f686-47fb-aea8-d23ad06e482c",
+                "bounds": {
+                  "x": -899.5,
+                  "y": -219.5,
+                  "width": 629,
+                  "height": 30
+                }
+              },
+              "37dff3e2-013c-42f0-ad6e-bbc197247d14": {
+                "id": "37dff3e2-013c-42f0-ad6e-bbc197247d14",
+                "name": "Other",
+                "type": "AgentIntent",
+                "owner": null,
+                "bounds": {
+                  "x": -860,
+                  "y": 150,
+                  "width": 630,
+                  "height": 70
+                },
+                "bodies": [],
+                "intent_description": "Any question that does not fit in \"Muscles\" or \"Nutrition\""
               }
             },
             "relationships": {
-              "7ac61ff1-1e47-4e69-8d38-8fd9be6ab17d": {
-                "id": "7ac61ff1-1e47-4e69-8d38-8fd9be6ab17d",
+              "bbd03bdd-b76e-47df-9e13-5a305885f94c": {
+                "id": "bbd03bdd-b76e-47df-9e13-5a305885f94c",
                 "name": "",
                 "type": "AgentStateTransitionInit",
                 "owner": null,
                 "bounds": {
-                  "x": -535,
-                  "y": -37.5,
-                  "width": 255,
+                  "x": -185,
+                  "y": -347.5,
+                  "width": 85,
                   "height": 1
                 },
                 "path": [
@@ -380,13 +392,13 @@
                     "y": 0
                   },
                   {
-                    "x": 255,
+                    "x": 85,
                     "y": 0
                   }
                 ],
                 "source": {
                   "direction": "Right",
-                  "element": "731e886c-9cef-4fa7-ba6d-72aa25c32d4f",
+                  "element": "699853eb-918b-4674-b08c-cf0af3cc61d7",
                   "bounds": {
                     "x": -535,
                     "y": -37.5,
@@ -396,7 +408,7 @@
                 },
                 "target": {
                   "direction": "Left",
-                  "element": "c10f03ca-2073-4002-8d1b-e42536008f4c",
+                  "element": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
                   "bounds": {
                     "x": -280,
                     "y": -45,
@@ -406,195 +418,22 @@
                 },
                 "isManuallyLayouted": false
               },
-              "b3c5c9c2-81fc-4a12-985e-9e885ef6e9d0": {
-                "id": "b3c5c9c2-81fc-4a12-985e-9e885ef6e9d0",
+              "0d7d8895-3eb0-44b0-bb41-e902684d0d2c": {
+                "id": "0d7d8895-3eb0-44b0-bb41-e902684d0d2c",
                 "name": "",
                 "type": "AgentStateTransition",
                 "owner": null,
                 "bounds": {
-                  "x": 50,
-                  "y": -45,
-                  "width": 160,
-                  "height": 1
-                },
-                "path": [
-                  {
-                    "x": 0,
-                    "y": 0
-                  },
-                  {
-                    "x": 160,
-                    "y": 0
-                  }
-                ],
-                "source": {
-                  "direction": "Right",
-                  "element": "c10f03ca-2073-4002-8d1b-e42536008f4c",
-                  "bounds": {
-                    "x": -120,
-                    "y": -30,
-                    "width": 0,
-                    "height": 0
-                  }
-                },
-                "target": {
-                  "direction": "Left",
-                  "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
-                  "bounds": {
-                    "x": 210,
-                    "y": -30,
-                    "width": 0,
-                    "height": 0
-                  }
-                },
-                "isManuallyLayouted": false,
-                "transitionType": "predefined",
-                "predefined": {
-                  "predefinedType": "auto",
-                  "conditionValue": ""
-                },
-                "custom": {
-                  "condition": []
-                }
-              },
-              "48858dc4-d788-4f13-858b-3010ae2f4ead": {
-                "id": "48858dc4-d788-4f13-858b-3010ae2f4ead",
-                "name": "",
-                "type": "AgentStateTransition",
-                "owner": null,
-                "bounds": {
-                  "x": 140,
-                  "y": -30,
-                  "width": 70,
-                  "height": 235
-                },
-                "path": [
-                  {
-                    "x": 70,
-                    "y": 0
-                  },
-                  {
-                    "x": 30,
-                    "y": 0
-                  },
-                  {
-                    "x": 30,
-                    "y": 110
-                  },
-                  {
-                    "x": 40,
-                    "y": 110
-                  },
-                  {
-                    "x": 40,
-                    "y": 235
-                  },
-                  {
-                    "x": 0,
-                    "y": 235
-                  }
-                ],
-                "source": {
-                  "direction": "Left",
-                  "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
-                  "bounds": {
-                    "x": 210,
-                    "y": -30,
-                    "width": 0,
-                    "height": 0
-                  }
-                },
-                "target": {
-                  "direction": "Right",
-                  "element": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
-                  "bounds": {
-                    "x": -120,
-                    "y": 190,
-                    "width": 0,
-                    "height": 0
-                  }
-                },
-                "isManuallyLayouted": false,
-                "transitionType": "predefined",
-                "predefined": {
-                  "predefinedType": "when_intent_matched",
-                  "intentName": "Muscles_intent"
-                },
-                "custom": {
-                  "condition": []
-                }
-              },
-              "425913e8-31ab-4ac5-908a-4f35fb7d732d": {
-                "id": "425913e8-31ab-4ac5-908a-4f35fb7d732d",
-                "name": "",
-                "type": "AgentStateTransition",
-                "owner": null,
-                "bounds": {
-                  "x": -100,
-                  "y": -30,
-                  "width": 310,
-                  "height": 425
-                },
-                "path": [
-                  {
-                    "x": 310,
-                    "y": 0
-                  },
-                  {
-                    "x": 155,
-                    "y": 0
-                  },
-                  {
-                    "x": 155,
-                    "y": 425
-                  },
-                  {
-                    "x": 0,
-                    "y": 425
-                  }
-                ],
-                "source": {
-                  "direction": "Left",
-                  "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
-                  "bounds": {
-                    "x": 210,
-                    "y": -30,
-                    "width": 0,
-                    "height": 0
-                  }
-                },
-                "target": {
-                  "direction": "Right",
-                  "element": "a22b9877-2809-426e-8b72-504ef7abcce0",
-                  "bounds": {
-                    "x": -120,
-                    "y": 410,
-                    "width": 0,
-                    "height": 0
-                  }
-                },
-                "isManuallyLayouted": false,
-                "transitionType": "predefined",
-                "predefined": {
-                  "predefinedType": "when_intent_matched",
-                  "intentName": "Other"
-                },
-                "custom": {
-                  "condition": []
-                }
-              },
-              "9f2ff8c7-b6dc-4246-b6ff-f1b1d1293a60": {
-                "id": "9f2ff8c7-b6dc-4246-b6ff-f1b1d1293a60",
-                "name": "",
-                "type": "AgentStateTransition",
-                "owner": null,
-                "bounds": {
-                  "x": 420,
-                  "y": 20,
-                  "width": 1,
+                  "x": -590,
+                  "y": -150,
+                  "width": 410,
                   "height": 120
                 },
                 "path": [
+                  {
+                    "x": 410,
+                    "y": 0
+                  },
                   {
                     "x": 0,
                     "y": 0
@@ -605,222 +444,236 @@
                   }
                 ],
                 "source": {
-                  "direction": "Down",
-                  "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
-                  "bounds": {
-                    "x": 290,
-                    "y": 20,
-                    "width": 0,
-                    "height": 0
-                  }
+                  "direction": "Left",
+                  "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
                 },
                 "target": {
                   "direction": "Up",
-                  "element": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
-                  "bounds": {
-                    "x": 290,
-                    "y": 140,
-                    "width": 0,
-                    "height": 0
-                  }
+                  "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
                 },
                 "isManuallyLayouted": false,
-                "transitionType": "predefined",
-                "predefined": {
-                  "predefinedType": "when_intent_matched",
-                  "intentName": "Nutrition_intent"
-                },
-                "custom": {
-                  "condition": []
-                }
+                "condition": "when_intent_matched",
+                "conditionValue": "Muscles_intent"
               },
-              "a5bf1da3-2426-43fb-827c-cc13ee896460": {
-                "id": "a5bf1da3-2426-43fb-827c-cc13ee896460",
+              "7d65df96-e669-4fc6-a882-dbfe92a57073": {
+                "id": "7d65df96-e669-4fc6-a882-dbfe92a57073",
                 "name": "",
                 "type": "AgentStateTransition",
                 "owner": null,
                 "bounds": {
-                  "x": 140,
-                  "y": -30,
-                  "width": 70,
-                  "height": 235
-                },
-                "path": [
-                  {
-                    "x": 0,
-                    "y": 235
-                  },
-                  {
-                    "x": 40,
-                    "y": 235
-                  },
-                  {
-                    "x": 40,
-                    "y": 110
-                  },
-                  {
-                    "x": 30,
-                    "y": 110
-                  },
-                  {
-                    "x": 30,
-                    "y": 0
-                  },
-                  {
-                    "x": 70,
-                    "y": 0
-                  }
-                ],
-                "source": {
-                  "direction": "Right",
-                  "element": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
-                  "bounds": {
-                    "x": -120,
-                    "y": 190,
-                    "width": 0,
-                    "height": 0
-                  }
-                },
-                "target": {
-                  "direction": "Left",
-                  "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
-                  "bounds": {
-                    "x": 210,
-                    "y": -30,
-                    "width": 0,
-                    "height": 0
-                  }
-                },
-                "isManuallyLayouted": false,
-                "transitionType": "predefined",
-                "predefined": {
-                  "predefinedType": "auto",
-                  "conditionValue": ""
-                },
-                "custom": {
-                  "condition": []
-                }
-              },
-              "25914e9b-e4dd-461f-9b4a-10229b76b618": {
-                "id": "25914e9b-e4dd-461f-9b4a-10229b76b618",
-                "name": "",
-                "type": "AgentStateTransition",
-                "owner": null,
-                "bounds": {
-                  "x": 420,
-                  "y": 20,
+                  "x": 70,
+                  "y": -300,
                   "width": 1,
-                  "height": 120
+                  "height": 100
                 },
                 "path": [
                   {
                     "x": 0,
-                    "y": 120
+                    "y": 0
                   },
                   {
                     "x": 0,
-                    "y": 0
+                    "y": 100
                   }
                 ],
                 "source": {
-                  "direction": "Up",
-                  "element": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
-                  "bounds": {
-                    "x": 290,
-                    "y": 140,
-                    "width": 0,
-                    "height": 0
-                  }
+                  "direction": "Down",
+                  "element": "77976ef7-599d-4c49-9f4d-1ecb23239fe3"
                 },
                 "target": {
-                  "direction": "Down",
-                  "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
-                  "bounds": {
-                    "x": 290,
-                    "y": 20,
-                    "width": 0,
-                    "height": 0
-                  }
+                  "direction": "Up",
+                  "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
                 },
                 "isManuallyLayouted": false,
-                "transitionType": "predefined",
-                "predefined": {
-                  "predefinedType": "auto",
-                  "conditionValue": ""
-                },
-                "custom": {
-                  "condition": []
-                }
+                "condition": "auto",
+                "conditionValue": ""
               },
-              "0efab80b-2e8c-45a3-a998-78ccd579fbd9": {
-                "id": "0efab80b-2e8c-45a3-a998-78ccd579fbd9",
+              "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31": {
+                "id": "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31",
                 "name": "",
                 "type": "AgentStateTransition",
                 "owner": null,
                 "bounds": {
-                  "x": -100,
-                  "y": -30,
-                  "width": 310,
-                  "height": 425
+                  "x": 240,
+                  "y": -130,
+                  "width": 200,
+                  "height": 40
                 },
                 "path": [
                   {
                     "x": 0,
-                    "y": 425
+                    "y": 5
                   },
                   {
-                    "x": 155,
-                    "y": 425
+                    "x": 40,
+                    "y": 5
                   },
                   {
-                    "x": 155,
+                    "x": 40,
                     "y": 0
                   },
                   {
-                    "x": 310,
+                    "x": 200,
                     "y": 0
+                  },
+                  {
+                    "x": 200,
+                    "y": 40
                   }
                 ],
                 "source": {
-                  "direction": "Right",
-                  "element": "a22b9877-2809-426e-8b72-504ef7abcce0",
-                  "bounds": {
-                    "x": -120,
-                    "y": 410,
-                    "width": 0,
-                    "height": 0
-                  }
+                  "direction": "Downright",
+                  "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
                 },
                 "target": {
-                  "direction": "Left",
-                  "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
-                  "bounds": {
-                    "x": 210,
-                    "y": -30,
-                    "width": 0,
-                    "height": 0
-                  }
+                  "direction": "Up",
+                  "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
                 },
-                "isManuallyLayouted": false,
-                "transitionType": "predefined",
-                "predefined": {
-                  "predefinedType": "auto",
-                  "conditionValue": ""
-                },
-                "custom": {
-                  "condition": []
-                }
+                "isManuallyLayouted": true,
+                "condition": "when_intent_matched",
+                "conditionValue": "Other"
               },
-              "0b385217-ea53-481d-8222-52dda332e351": {
-                "id": "0b385217-ea53-481d-8222-52dda332e351",
+              "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e": {
+                "id": "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e",
                 "name": "",
-                "type": "AgentStateTransitionInit",
+                "type": "AgentStateTransition",
                 "owner": null,
                 "bounds": {
-                  "x": -535,
-                  "y": -37.5,
-                  "width": 255,
-                  "height": 1
+                  "x": -380,
+                  "y": -125,
+                  "width": 200,
+                  "height": 127.5
+                },
+                "path": [
+                  {
+                    "x": 0,
+                    "y": 127.5
+                  },
+                  {
+                    "x": 100,
+                    "y": 127.5
+                  },
+                  {
+                    "x": 100,
+                    "y": 0
+                  },
+                  {
+                    "x": 200,
+                    "y": 0
+                  }
+                ],
+                "source": {
+                  "direction": "Upright",
+                  "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
+                },
+                "target": {
+                  "direction": "Downleft",
+                  "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+                },
+                "isManuallyLayouted": false,
+                "condition": "auto",
+                "conditionValue": ""
+              },
+              "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32": {
+                "id": "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32",
+                "name": "",
+                "type": "AgentStateTransition",
+                "owner": null,
+                "bounds": {
+                  "x": 135,
+                  "y": -100,
+                  "width": 215,
+                  "height": 40
+                },
+                "path": [
+                  {
+                    "x": 215,
+                    "y": 27.5
+                  },
+                  {
+                    "x": 175,
+                    "y": 27.5
+                  },
+                  {
+                    "x": 175,
+                    "y": 40
+                  },
+                  {
+                    "x": 0,
+                    "y": 40
+                  },
+                  {
+                    "x": 0,
+                    "y": 0
+                  }
+                ],
+                "source": {
+                  "direction": "Upleft",
+                  "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
+                },
+                "target": {
+                  "direction": "Bottomright",
+                  "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+                },
+                "isManuallyLayouted": false,
+                "condition": "auto",
+                "conditionValue": ""
+              },
+              "3564da62-bea0-4489-81b2-fda2effddd02": {
+                "id": "3564da62-bea0-4489-81b2-fda2effddd02",
+                "name": "",
+                "type": "AgentStateTransition",
+                "owner": null,
+                "bounds": {
+                  "x": -190,
+                  "y": -100,
+                  "width": 115,
+                  "height": 277.5
+                },
+                "path": [
+                  {
+                    "x": 40,
+                    "y": 277.5
+                  },
+                  {
+                    "x": 0,
+                    "y": 277.5
+                  },
+                  {
+                    "x": 0,
+                    "y": 115
+                  },
+                  {
+                    "x": 115,
+                    "y": 115
+                  },
+                  {
+                    "x": 115,
+                    "y": 0
+                  }
+                ],
+                "source": {
+                  "direction": "Upleft",
+                  "element": "7610bbda-21ef-4637-a188-1da1352bea17"
+                },
+                "target": {
+                  "direction": "Bottomleft",
+                  "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+                },
+                "isManuallyLayouted": false,
+                "condition": "auto",
+                "conditionValue": ""
+              },
+              "b696a5f6-f328-42fb-bdbc-83569b2beb06": {
+                "id": "b696a5f6-f328-42fb-bdbc-83569b2beb06",
+                "name": "",
+                "type": "AgentStateTransition",
+                "owner": null,
+                "bounds": {
+                  "x": 45,
+                  "y": -100,
+                  "width": 1,
+                  "height": 230
                 },
                 "path": [
                   {
@@ -828,31 +681,21 @@
                     "y": 0
                   },
                   {
-                    "x": 255,
-                    "y": 0
+                    "x": 0,
+                    "y": 230
                   }
                 ],
                 "source": {
-                  "direction": "Right",
-                  "element": "731e886c-9cef-4fa7-ba6d-72aa25c32d4f",
-                  "bounds": {
-                    "x": -535,
-                    "y": -37.5,
-                    "width": 0,
-                    "height": 0
-                  }
+                  "direction": "Down",
+                  "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
                 },
                 "target": {
-                  "direction": "Left",
-                  "element": "c10f03ca-2073-4002-8d1b-e42536008f4c",
-                  "bounds": {
-                    "x": -280,
-                    "y": -45,
-                    "width": 0,
-                    "height": 0
-                  }
+                  "direction": "Up",
+                  "element": "7610bbda-21ef-4637-a188-1da1352bea17"
                 },
-                "isManuallyLayouted": false
+                "isManuallyLayouted": false,
+                "condition": "when_intent_matched",
+                "conditionValue": "Nutrition_intent"
               }
             },
             "assessments": {}
@@ -1084,7 +927,7 @@
                     },
                     "e082c986-9bb3-45be-8f43-2e6b8af7a9d7": {
                       "id": "e082c986-9bb3-45be-8f43-2e6b8af7a9d7",
-                      "name": "Hi! I\u2019m your fitness helper and guide.",
+                      "name": "Hi! I’m your fitness helper and guide.",
                       "type": "AgentStateBody",
                       "owner": "3effee26-ddc1-4180-8dfc-4f54d929c334",
                       "bounds": {
@@ -1136,7 +979,7 @@
                     },
                     "4403443a-176c-4c34-b4c1-59566a6cee15": {
                       "id": "4403443a-176c-4c34-b4c1-59566a6cee15",
-                      "name": "Train 3\u20135 days a week. Add a little weight over time. Eat enough protein and calories to grow.",
+                      "name": "Train 3–5 days a week. Add a little weight over time. Eat enough protein and calories to grow.",
                       "type": "AgentStateBody",
                       "owner": "8f57a878-84ca-409d-b89d-cc62fc815507",
                       "bounds": {
@@ -1227,7 +1070,7 @@
                     },
                     "4499b560-b246-4b3f-b703-d9709836b98e": {
                       "id": "4499b560-b246-4b3f-b703-d9709836b98e",
-                      "name": "AI response \ud83e\ude84",
+                      "name": "AI response 🪄",
                       "type": "AgentStateBody",
                       "owner": "b5895c6c-fdf9-4f1f-813f-ef8baaa7a008",
                       "bounds": {
@@ -1993,7 +1836,7 @@
                     },
                     "964f437d-ab33-4e0d-bd1c-e36387c879eb": {
                       "id": "964f437d-ab33-4e0d-bd1c-e36387c879eb",
-                      "name": "Train 3\u20135 times per week, progressively increasing resistance on upper-body and core-focused exercises while eating enough protein and calories to support growth; balance pushing and pulling to protect your shoulders and allow adequate recovery.",
+                      "name": "Train 3–5 times per week, progressively increasing resistance on upper-body and core-focused exercises while eating enough protein and calories to support growth; balance pushing and pulling to protect your shoulders and allow adequate recovery.",
                       "type": "AgentStateBody",
                       "owner": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
                       "bounds": {
@@ -2006,7 +1849,7 @@
                     },
                     "31249e62-6b58-48fb-af98-e55090d683e1": {
                       "id": "31249e62-6b58-48fb-af98-e55090d683e1",
-                      "name": "Get good sleep and stay consistent\u2014muscle comes from steady effort over time.",
+                      "name": "Get good sleep and stay consistent—muscle comes from steady effort over time.",
                       "type": "AgentStateBody",
                       "owner": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
                       "bounds": {
@@ -2019,7 +1862,7 @@
                     },
                     "3fa5c3b5-3e12-4968-b16c-1f80a98693c1": {
                       "id": "3fa5c3b5-3e12-4968-b16c-1f80a98693c1",
-                      "name": "Nutrition basics: Eat mostly whole foods (lean protein, vegetables, fruits, whole grains, healthy fats). Protein: ~1.6\u20132.2 g per kg of body weight daily..",
+                      "name": "Nutrition basics: Eat mostly whole foods (lean protein, vegetables, fruits, whole grains, healthy fats). Protein: ~1.6–2.2 g per kg of body weight daily..",
                       "type": "AgentStateBody",
                       "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
                       "bounds": {
@@ -2071,7 +1914,7 @@
                     },
                     "0bcfa6cb-74c0-43c8-867b-2fc966c53671": {
                       "id": "0bcfa6cb-74c0-43c8-867b-2fc966c53671",
-                      "name": "Be consistent \u2014 results come from habits, not perfection",
+                      "name": "Be consistent — results come from habits, not perfection",
                       "type": "AgentStateBody",
                       "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
                       "bounds": {
@@ -2084,7 +1927,7 @@
                     },
                     "3721c5e6-19b1-4811-8b00-17415913c3aa": {
                       "id": "3721c5e6-19b1-4811-8b00-17415913c3aa",
-                      "name": "AI response \ud83e\ude84",
+                      "name": "AI response 🪄",
                       "type": "AgentStateBody",
                       "owner": "a22b9877-2809-426e-8b72-504ef7abcce0",
                       "bounds": {
@@ -2608,7 +2451,7 @@
                 }
               }
             ],
-            "activePersonalizedVariantId": "8892dc19-bacc-4de4-8f27-9ae32842dbbf:ef384a51-8bd6-45bb-952c-03a0944827d8"
+            "activePersonalizedVariantId": null
           }
         }
       ],
@@ -3190,5 +3033,5751 @@
     }
   },
   "exportedAt": "2026-05-06T13:49:40.997Z",
-  "version": "2.0.0"
+  "version": "2.0.0",
+  "agentConfigurations": [
+    {
+      "id": "75032e14-e116-4f62-8526-0bd8473283d5",
+      "name": "CoolConfig",
+      "savedAt": "2026-05-06T13:45:22.587Z",
+      "config": {
+        "agentLanguage": "original",
+        "inputModalities": [
+          "text"
+        ],
+        "outputModalities": [
+          "text"
+        ],
+        "agentPlatform": "streamlit",
+        "responseTiming": "instant",
+        "agentStyle": "informal",
+        "llm": {
+          "provider": "openai",
+          "model": "gpt-5"
+        },
+        "languageComplexity": "original",
+        "sentenceLength": "original",
+        "interfaceStyle": {
+          "size": 16,
+          "font": "sans",
+          "lineSpacing": 1.5,
+          "alignment": "left",
+          "color": "var(--apollon-primary-contrast)",
+          "contrast": "medium"
+        },
+        "voiceStyle": {
+          "gender": "male",
+          "speed": 1
+        },
+        "avatar": null,
+        "useAbbreviations": false,
+        "adaptContentToUserProfile": false,
+        "userProfileName": "Teenager",
+        "intentRecognitionTechnology": "llm-based"
+      },
+      "baseAgentModel": {
+        "version": "3.0.0",
+        "type": "AgentDiagram",
+        "size": {
+          "width": 1080,
+          "height": 400
+        },
+        "interactive": {
+          "elements": {},
+          "relationships": {}
+        },
+        "elements": {
+          "699853eb-918b-4674-b08c-cf0af3cc61d7": {
+            "id": "699853eb-918b-4674-b08c-cf0af3cc61d7",
+            "name": "",
+            "type": "StateInitialNode",
+            "owner": null,
+            "bounds": {
+              "x": -230,
+              "y": -370,
+              "width": 45,
+              "height": 45
+            }
+          },
+          "0cba5357-2c30-414b-8d74-ac74ac4ab158": {
+            "id": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
+            "name": "Idle",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -180,
+              "y": -200,
+              "width": 420,
+              "height": 100
+            },
+            "bodies": [
+              "63a2c160-ebbb-457b-953a-93fd2e643224"
+            ],
+            "fallbackBodies": [
+              "1f369122-06c2-4050-ba54-4ea160f95a8c"
+            ]
+          },
+          "63a2c160-ebbb-457b-953a-93fd2e643224": {
+            "id": "63a2c160-ebbb-457b-953a-93fd2e643224",
+            "name": "I am here to answer any questions regarding exercises, nutrition and recovery.",
+            "type": "AgentStateBody",
+            "owner": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
+            "bounds": {
+              "x": -179.5,
+              "y": -159.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "1f369122-06c2-4050-ba54-4ea160f95a8c": {
+            "id": "1f369122-06c2-4050-ba54-4ea160f95a8c",
+            "name": "I focus on gym and fitness topics only dude.",
+            "type": "AgentStateFallbackBody",
+            "owner": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
+            "bounds": {
+              "x": -179.5,
+              "y": -129.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "8dba49ff-2fc1-4066-b124-19e2df7981e2": {
+            "id": "8dba49ff-2fc1-4066-b124-19e2df7981e2",
+            "name": "Muscles_intent",
+            "type": "AgentIntent",
+            "owner": null,
+            "bounds": {
+              "x": -900,
+              "y": -400,
+              "width": 630,
+              "height": 100
+            },
+            "bodies": [
+              "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b"
+            ],
+            "intent_description": "Question about how to become muscular and which exercises to perform."
+          },
+          "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b": {
+            "id": "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b",
+            "name": "I want muscles",
+            "type": "AgentIntentBody",
+            "owner": "8dba49ff-2fc1-4066-b124-19e2df7981e2",
+            "bounds": {
+              "x": -899.5,
+              "y": -329.5,
+              "width": 629,
+              "height": 30
+            }
+          },
+          "68ccb630-b264-41a0-b70e-1e369bd5706c": {
+            "id": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+            "name": "TrainingPlan",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -800,
+              "y": -30,
+              "width": 420,
+              "height": 130
+            },
+            "bodies": [
+              "aa261be5-9c53-4df1-a72f-5a107ce8f1b7",
+              "747b8558-325d-4a15-baba-0d18a6602a8d",
+              "900f7fd9-738a-4981-a7d9-6c7334621981"
+            ],
+            "fallbackBodies": []
+          },
+          "aa261be5-9c53-4df1-a72f-5a107ce8f1b7": {
+            "id": "aa261be5-9c53-4df1-a72f-5a107ce8f1b7",
+            "name": "Focus on heavy compound lifts like squats, deadlifts, bench press, overhead press, and rows to build overall muscle mass. ",
+            "type": "AgentStateBody",
+            "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+            "bounds": {
+              "x": -799.5,
+              "y": 10.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "747b8558-325d-4a15-baba-0d18a6602a8d": {
+            "id": "747b8558-325d-4a15-baba-0d18a6602a8d",
+            "name": "Train 3–5 times per week, progressively increasing the weight while eating enough protein and calories to support growth. ",
+            "type": "AgentStateBody",
+            "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+            "bounds": {
+              "x": -799.5,
+              "y": 40.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "900f7fd9-738a-4981-a7d9-6c7334621981": {
+            "id": "900f7fd9-738a-4981-a7d9-6c7334621981",
+            "name": "Get good sleep and stay consistent—muscle comes from steady effort over time.",
+            "type": "AgentStateBody",
+            "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+            "bounds": {
+              "x": -799.5,
+              "y": 70.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "77976ef7-599d-4c49-9f4d-1ecb23239fe3": {
+            "id": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
+            "name": "Initial",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -100,
+              "y": -370,
+              "width": 420,
+              "height": 70
+            },
+            "bodies": [
+              "ad226172-93d8-4644-80c5-62825565dd24"
+            ],
+            "fallbackBodies": []
+          },
+          "ad226172-93d8-4644-80c5-62825565dd24": {
+            "id": "ad226172-93d8-4644-80c5-62825565dd24",
+            "name": "Hi, I am your buddy, the fitness agent.",
+            "type": "AgentStateBody",
+            "owner": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
+            "bounds": {
+              "x": -99.5,
+              "y": -329.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "7610bbda-21ef-4637-a188-1da1352bea17": {
+            "id": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "name": "Nutrition",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -150,
+              "y": 130,
+              "width": 420,
+              "height": 190
+            },
+            "bodies": [
+              "bb7e67bd-ead9-4f14-93db-c18af0d806af",
+              "13072ea8-9b51-45fe-927e-a9323627701b",
+              "95241c3a-f8a2-4bf0-b169-5dcff5a926fb",
+              "44904a03-ac46-4f9f-983a-f6a740b81c0e",
+              "90dfba4f-6dec-4ca8-8c15-786ed36587a1"
+            ],
+            "fallbackBodies": []
+          },
+          "bb7e67bd-ead9-4f14-93db-c18af0d806af": {
+            "id": "bb7e67bd-ead9-4f14-93db-c18af0d806af",
+            "name": "Nutrition basics: Eat mostly whole foods (lean protein, vegetables, fruits, whole grains, healthy fats). Protein: ~1.6–2.2 g per kg of body weight daily..",
+            "type": "AgentStateBody",
+            "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "bounds": {
+              "x": -149.5,
+              "y": 170.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "13072ea8-9b51-45fe-927e-a9323627701b": {
+            "id": "13072ea8-9b51-45fe-927e-a9323627701b",
+            "name": "Match calories to your goal: slight surplus to gain muscle, deficit to lose fat, maintenance to stay the same. ",
+            "type": "AgentStateBody",
+            "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "bounds": {
+              "x": -149.5,
+              "y": 200.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "95241c3a-f8a2-4bf0-b169-5dcff5a926fb": {
+            "id": "95241c3a-f8a2-4bf0-b169-5dcff5a926fb",
+            "name": " Carbs fuel training; fats support hormones.",
+            "type": "AgentStateBody",
+            "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "bounds": {
+              "x": -149.5,
+              "y": 230.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "44904a03-ac46-4f9f-983a-f6a740b81c0e": {
+            "id": "44904a03-ac46-4f9f-983a-f6a740b81c0e",
+            "name": " Drink plenty of water and limit ultra-processed foods and alcohol. ",
+            "type": "AgentStateBody",
+            "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "bounds": {
+              "x": -149.5,
+              "y": 260.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "90dfba4f-6dec-4ca8-8c15-786ed36587a1": {
+            "id": "90dfba4f-6dec-4ca8-8c15-786ed36587a1",
+            "name": "Be consistent — results come from habits, not perfection",
+            "type": "AgentStateBody",
+            "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "bounds": {
+              "x": -149.5,
+              "y": 290.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "8c760b7d-7e72-4cd7-a92a-d5491c021a5b": {
+            "id": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b",
+            "name": "OtherQuestions",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": 350,
+              "y": -90,
+              "width": 180,
+              "height": 70
+            },
+            "bodies": [
+              "6a3aeb02-bb44-4472-8489-595e8dc8ceb1"
+            ],
+            "fallbackBodies": []
+          },
+          "6a3aeb02-bb44-4472-8489-595e8dc8ceb1": {
+            "id": "6a3aeb02-bb44-4472-8489-595e8dc8ceb1",
+            "name": "AI response 🪄",
+            "type": "AgentStateBody",
+            "owner": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b",
+            "bounds": {
+              "x": 350.5,
+              "y": -49.5,
+              "width": 179,
+              "height": 30
+            },
+            "replyType": "llm",
+            "ragDatabaseName": ""
+          },
+          "659e810a-f686-47fb-aea8-d23ad06e482c": {
+            "id": "659e810a-f686-47fb-aea8-d23ad06e482c",
+            "name": "Nutrition_intent",
+            "type": "AgentIntent",
+            "owner": null,
+            "bounds": {
+              "x": -900,
+              "y": -290,
+              "width": 630,
+              "height": 100
+            },
+            "bodies": [
+              "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0"
+            ],
+            "intent_description": "Question about nutrition in gym."
+          },
+          "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0": {
+            "id": "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0",
+            "name": "Which food to eat?",
+            "type": "AgentIntentBody",
+            "owner": "659e810a-f686-47fb-aea8-d23ad06e482c",
+            "bounds": {
+              "x": -899.5,
+              "y": -219.5,
+              "width": 629,
+              "height": 30
+            }
+          },
+          "37dff3e2-013c-42f0-ad6e-bbc197247d14": {
+            "id": "37dff3e2-013c-42f0-ad6e-bbc197247d14",
+            "name": "Other",
+            "type": "AgentIntent",
+            "owner": null,
+            "bounds": {
+              "x": -860,
+              "y": 150,
+              "width": 630,
+              "height": 70
+            },
+            "bodies": [],
+            "intent_description": "Any question that does not fit in \"Muscles\" or \"Nutrition\""
+          }
+        },
+        "relationships": {
+          "bbd03bdd-b76e-47df-9e13-5a305885f94c": {
+            "id": "bbd03bdd-b76e-47df-9e13-5a305885f94c",
+            "name": "",
+            "type": "AgentStateTransitionInit",
+            "owner": null,
+            "bounds": {
+              "x": -185,
+              "y": -347.5,
+              "width": 85,
+              "height": 1
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 0
+              },
+              {
+                "x": 85,
+                "y": 0
+              }
+            ],
+            "source": {
+              "direction": "Right",
+              "element": "699853eb-918b-4674-b08c-cf0af3cc61d7",
+              "bounds": {
+                "x": -535,
+                "y": -37.5,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Left",
+              "element": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
+              "bounds": {
+                "x": -280,
+                "y": -45,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "isManuallyLayouted": false
+          },
+          "0d7d8895-3eb0-44b0-bb41-e902684d0d2c": {
+            "id": "0d7d8895-3eb0-44b0-bb41-e902684d0d2c",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -590,
+              "y": -150,
+              "width": 410,
+              "height": 120
+            },
+            "path": [
+              {
+                "x": 410,
+                "y": 0
+              },
+              {
+                "x": 0,
+                "y": 0
+              },
+              {
+                "x": 0,
+                "y": 120
+              }
+            ],
+            "source": {
+              "direction": "Left",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "target": {
+              "direction": "Up",
+              "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
+            },
+            "isManuallyLayouted": false,
+            "condition": "when_intent_matched",
+            "conditionValue": "Muscles_intent"
+          },
+          "7d65df96-e669-4fc6-a882-dbfe92a57073": {
+            "id": "7d65df96-e669-4fc6-a882-dbfe92a57073",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": 70,
+              "y": -300,
+              "width": 1,
+              "height": 100
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 0
+              },
+              {
+                "x": 0,
+                "y": 100
+              }
+            ],
+            "source": {
+              "direction": "Down",
+              "element": "77976ef7-599d-4c49-9f4d-1ecb23239fe3"
+            },
+            "target": {
+              "direction": "Up",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "isManuallyLayouted": false,
+            "condition": "auto",
+            "conditionValue": ""
+          },
+          "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31": {
+            "id": "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": 240,
+              "y": -130,
+              "width": 200,
+              "height": 40
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 5
+              },
+              {
+                "x": 40,
+                "y": 5
+              },
+              {
+                "x": 40,
+                "y": 0
+              },
+              {
+                "x": 200,
+                "y": 0
+              },
+              {
+                "x": 200,
+                "y": 40
+              }
+            ],
+            "source": {
+              "direction": "Downright",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "target": {
+              "direction": "Up",
+              "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
+            },
+            "isManuallyLayouted": true,
+            "condition": "when_intent_matched",
+            "conditionValue": "Other"
+          },
+          "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e": {
+            "id": "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -380,
+              "y": -125,
+              "width": 200,
+              "height": 127.5
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 127.5
+              },
+              {
+                "x": 100,
+                "y": 127.5
+              },
+              {
+                "x": 100,
+                "y": 0
+              },
+              {
+                "x": 200,
+                "y": 0
+              }
+            ],
+            "source": {
+              "direction": "Upright",
+              "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
+            },
+            "target": {
+              "direction": "Downleft",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "isManuallyLayouted": false,
+            "condition": "auto",
+            "conditionValue": ""
+          },
+          "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32": {
+            "id": "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": 135,
+              "y": -100,
+              "width": 215,
+              "height": 40
+            },
+            "path": [
+              {
+                "x": 215,
+                "y": 27.5
+              },
+              {
+                "x": 175,
+                "y": 27.5
+              },
+              {
+                "x": 175,
+                "y": 40
+              },
+              {
+                "x": 0,
+                "y": 40
+              },
+              {
+                "x": 0,
+                "y": 0
+              }
+            ],
+            "source": {
+              "direction": "Upleft",
+              "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
+            },
+            "target": {
+              "direction": "Bottomright",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "isManuallyLayouted": false,
+            "condition": "auto",
+            "conditionValue": ""
+          },
+          "3564da62-bea0-4489-81b2-fda2effddd02": {
+            "id": "3564da62-bea0-4489-81b2-fda2effddd02",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -190,
+              "y": -100,
+              "width": 115,
+              "height": 277.5
+            },
+            "path": [
+              {
+                "x": 40,
+                "y": 277.5
+              },
+              {
+                "x": 0,
+                "y": 277.5
+              },
+              {
+                "x": 0,
+                "y": 115
+              },
+              {
+                "x": 115,
+                "y": 115
+              },
+              {
+                "x": 115,
+                "y": 0
+              }
+            ],
+            "source": {
+              "direction": "Upleft",
+              "element": "7610bbda-21ef-4637-a188-1da1352bea17"
+            },
+            "target": {
+              "direction": "Bottomleft",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "isManuallyLayouted": false,
+            "condition": "auto",
+            "conditionValue": ""
+          },
+          "b696a5f6-f328-42fb-bdbc-83569b2beb06": {
+            "id": "b696a5f6-f328-42fb-bdbc-83569b2beb06",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": 45,
+              "y": -100,
+              "width": 1,
+              "height": 230
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 0
+              },
+              {
+                "x": 0,
+                "y": 230
+              }
+            ],
+            "source": {
+              "direction": "Down",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "target": {
+              "direction": "Up",
+              "element": "7610bbda-21ef-4637-a188-1da1352bea17"
+            },
+            "isManuallyLayouted": false,
+            "condition": "when_intent_matched",
+            "conditionValue": "Nutrition_intent"
+          }
+        },
+        "assessments": {}
+      },
+      "originalAgentModel": {
+        "version": "3.0.0",
+        "type": "AgentDiagram",
+        "size": {
+          "width": 1080,
+          "height": 400
+        },
+        "interactive": {
+          "elements": {},
+          "relationships": {}
+        },
+        "elements": {
+          "699853eb-918b-4674-b08c-cf0af3cc61d7": {
+            "id": "699853eb-918b-4674-b08c-cf0af3cc61d7",
+            "name": "",
+            "type": "StateInitialNode",
+            "owner": null,
+            "bounds": {
+              "x": -230,
+              "y": -370,
+              "width": 45,
+              "height": 45
+            }
+          },
+          "0cba5357-2c30-414b-8d74-ac74ac4ab158": {
+            "id": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
+            "name": "Idle",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -180,
+              "y": -200,
+              "width": 420,
+              "height": 100
+            },
+            "bodies": [
+              "63a2c160-ebbb-457b-953a-93fd2e643224"
+            ],
+            "fallbackBodies": [
+              "1f369122-06c2-4050-ba54-4ea160f95a8c"
+            ]
+          },
+          "63a2c160-ebbb-457b-953a-93fd2e643224": {
+            "id": "63a2c160-ebbb-457b-953a-93fd2e643224",
+            "name": "I am here to answer any questions regarding exercises, nutrition and recovery.",
+            "type": "AgentStateBody",
+            "owner": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
+            "bounds": {
+              "x": -179.5,
+              "y": -159.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "1f369122-06c2-4050-ba54-4ea160f95a8c": {
+            "id": "1f369122-06c2-4050-ba54-4ea160f95a8c",
+            "name": "I focus on gym and fitness topics only dude.",
+            "type": "AgentStateFallbackBody",
+            "owner": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
+            "bounds": {
+              "x": -179.5,
+              "y": -129.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "8dba49ff-2fc1-4066-b124-19e2df7981e2": {
+            "id": "8dba49ff-2fc1-4066-b124-19e2df7981e2",
+            "name": "Muscles_intent",
+            "type": "AgentIntent",
+            "owner": null,
+            "bounds": {
+              "x": -900,
+              "y": -400,
+              "width": 630,
+              "height": 100
+            },
+            "bodies": [
+              "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b"
+            ],
+            "intent_description": "Question about how to become muscular and which exercises to perform."
+          },
+          "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b": {
+            "id": "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b",
+            "name": "I want muscles",
+            "type": "AgentIntentBody",
+            "owner": "8dba49ff-2fc1-4066-b124-19e2df7981e2",
+            "bounds": {
+              "x": -899.5,
+              "y": -329.5,
+              "width": 629,
+              "height": 30
+            }
+          },
+          "68ccb630-b264-41a0-b70e-1e369bd5706c": {
+            "id": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+            "name": "TrainingPlan",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -800,
+              "y": -30,
+              "width": 420,
+              "height": 130
+            },
+            "bodies": [
+              "aa261be5-9c53-4df1-a72f-5a107ce8f1b7",
+              "747b8558-325d-4a15-baba-0d18a6602a8d",
+              "900f7fd9-738a-4981-a7d9-6c7334621981"
+            ],
+            "fallbackBodies": []
+          },
+          "aa261be5-9c53-4df1-a72f-5a107ce8f1b7": {
+            "id": "aa261be5-9c53-4df1-a72f-5a107ce8f1b7",
+            "name": "Focus on heavy compound lifts like squats, deadlifts, bench press, overhead press, and rows to build overall muscle mass. ",
+            "type": "AgentStateBody",
+            "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+            "bounds": {
+              "x": -799.5,
+              "y": 10.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "747b8558-325d-4a15-baba-0d18a6602a8d": {
+            "id": "747b8558-325d-4a15-baba-0d18a6602a8d",
+            "name": "Train 3–5 times per week, progressively increasing the weight while eating enough protein and calories to support growth. ",
+            "type": "AgentStateBody",
+            "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+            "bounds": {
+              "x": -799.5,
+              "y": 40.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "900f7fd9-738a-4981-a7d9-6c7334621981": {
+            "id": "900f7fd9-738a-4981-a7d9-6c7334621981",
+            "name": "Get good sleep and stay consistent—muscle comes from steady effort over time.",
+            "type": "AgentStateBody",
+            "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+            "bounds": {
+              "x": -799.5,
+              "y": 70.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "77976ef7-599d-4c49-9f4d-1ecb23239fe3": {
+            "id": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
+            "name": "Initial",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -100,
+              "y": -370,
+              "width": 420,
+              "height": 70
+            },
+            "bodies": [
+              "ad226172-93d8-4644-80c5-62825565dd24"
+            ],
+            "fallbackBodies": []
+          },
+          "ad226172-93d8-4644-80c5-62825565dd24": {
+            "id": "ad226172-93d8-4644-80c5-62825565dd24",
+            "name": "Hi, I am your buddy, the fitness agent.",
+            "type": "AgentStateBody",
+            "owner": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
+            "bounds": {
+              "x": -99.5,
+              "y": -329.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "7610bbda-21ef-4637-a188-1da1352bea17": {
+            "id": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "name": "Nutrition",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -150,
+              "y": 130,
+              "width": 420,
+              "height": 190
+            },
+            "bodies": [
+              "bb7e67bd-ead9-4f14-93db-c18af0d806af",
+              "13072ea8-9b51-45fe-927e-a9323627701b",
+              "95241c3a-f8a2-4bf0-b169-5dcff5a926fb",
+              "44904a03-ac46-4f9f-983a-f6a740b81c0e",
+              "90dfba4f-6dec-4ca8-8c15-786ed36587a1"
+            ],
+            "fallbackBodies": []
+          },
+          "bb7e67bd-ead9-4f14-93db-c18af0d806af": {
+            "id": "bb7e67bd-ead9-4f14-93db-c18af0d806af",
+            "name": "Nutrition basics: Eat mostly whole foods (lean protein, vegetables, fruits, whole grains, healthy fats). Protein: ~1.6–2.2 g per kg of body weight daily..",
+            "type": "AgentStateBody",
+            "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "bounds": {
+              "x": -149.5,
+              "y": 170.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "13072ea8-9b51-45fe-927e-a9323627701b": {
+            "id": "13072ea8-9b51-45fe-927e-a9323627701b",
+            "name": "Match calories to your goal: slight surplus to gain muscle, deficit to lose fat, maintenance to stay the same. ",
+            "type": "AgentStateBody",
+            "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "bounds": {
+              "x": -149.5,
+              "y": 200.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "95241c3a-f8a2-4bf0-b169-5dcff5a926fb": {
+            "id": "95241c3a-f8a2-4bf0-b169-5dcff5a926fb",
+            "name": " Carbs fuel training; fats support hormones.",
+            "type": "AgentStateBody",
+            "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "bounds": {
+              "x": -149.5,
+              "y": 230.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "44904a03-ac46-4f9f-983a-f6a740b81c0e": {
+            "id": "44904a03-ac46-4f9f-983a-f6a740b81c0e",
+            "name": " Drink plenty of water and limit ultra-processed foods and alcohol. ",
+            "type": "AgentStateBody",
+            "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "bounds": {
+              "x": -149.5,
+              "y": 260.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "90dfba4f-6dec-4ca8-8c15-786ed36587a1": {
+            "id": "90dfba4f-6dec-4ca8-8c15-786ed36587a1",
+            "name": "Be consistent — results come from habits, not perfection",
+            "type": "AgentStateBody",
+            "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "bounds": {
+              "x": -149.5,
+              "y": 290.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "8c760b7d-7e72-4cd7-a92a-d5491c021a5b": {
+            "id": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b",
+            "name": "OtherQuestions",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": 350,
+              "y": -90,
+              "width": 180,
+              "height": 70
+            },
+            "bodies": [
+              "6a3aeb02-bb44-4472-8489-595e8dc8ceb1"
+            ],
+            "fallbackBodies": []
+          },
+          "6a3aeb02-bb44-4472-8489-595e8dc8ceb1": {
+            "id": "6a3aeb02-bb44-4472-8489-595e8dc8ceb1",
+            "name": "AI response 🪄",
+            "type": "AgentStateBody",
+            "owner": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b",
+            "bounds": {
+              "x": 350.5,
+              "y": -49.5,
+              "width": 179,
+              "height": 30
+            },
+            "replyType": "llm",
+            "ragDatabaseName": ""
+          },
+          "659e810a-f686-47fb-aea8-d23ad06e482c": {
+            "id": "659e810a-f686-47fb-aea8-d23ad06e482c",
+            "name": "Nutrition_intent",
+            "type": "AgentIntent",
+            "owner": null,
+            "bounds": {
+              "x": -900,
+              "y": -290,
+              "width": 630,
+              "height": 100
+            },
+            "bodies": [
+              "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0"
+            ],
+            "intent_description": "Question about nutrition in gym."
+          },
+          "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0": {
+            "id": "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0",
+            "name": "Which food to eat?",
+            "type": "AgentIntentBody",
+            "owner": "659e810a-f686-47fb-aea8-d23ad06e482c",
+            "bounds": {
+              "x": -899.5,
+              "y": -219.5,
+              "width": 629,
+              "height": 30
+            }
+          },
+          "37dff3e2-013c-42f0-ad6e-bbc197247d14": {
+            "id": "37dff3e2-013c-42f0-ad6e-bbc197247d14",
+            "name": "Other",
+            "type": "AgentIntent",
+            "owner": null,
+            "bounds": {
+              "x": -860,
+              "y": 150,
+              "width": 630,
+              "height": 70
+            },
+            "bodies": [],
+            "intent_description": "Any question that does not fit in \"Muscles\" or \"Nutrition\""
+          }
+        },
+        "relationships": {
+          "bbd03bdd-b76e-47df-9e13-5a305885f94c": {
+            "id": "bbd03bdd-b76e-47df-9e13-5a305885f94c",
+            "name": "",
+            "type": "AgentStateTransitionInit",
+            "owner": null,
+            "bounds": {
+              "x": -185,
+              "y": -347.5,
+              "width": 85,
+              "height": 1
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 0
+              },
+              {
+                "x": 85,
+                "y": 0
+              }
+            ],
+            "source": {
+              "direction": "Right",
+              "element": "699853eb-918b-4674-b08c-cf0af3cc61d7",
+              "bounds": {
+                "x": -535,
+                "y": -37.5,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Left",
+              "element": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
+              "bounds": {
+                "x": -280,
+                "y": -45,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "isManuallyLayouted": false
+          },
+          "0d7d8895-3eb0-44b0-bb41-e902684d0d2c": {
+            "id": "0d7d8895-3eb0-44b0-bb41-e902684d0d2c",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -590,
+              "y": -150,
+              "width": 410,
+              "height": 120
+            },
+            "path": [
+              {
+                "x": 410,
+                "y": 0
+              },
+              {
+                "x": 0,
+                "y": 0
+              },
+              {
+                "x": 0,
+                "y": 120
+              }
+            ],
+            "source": {
+              "direction": "Left",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "target": {
+              "direction": "Up",
+              "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
+            },
+            "isManuallyLayouted": false,
+            "condition": "when_intent_matched",
+            "conditionValue": "Muscles_intent"
+          },
+          "7d65df96-e669-4fc6-a882-dbfe92a57073": {
+            "id": "7d65df96-e669-4fc6-a882-dbfe92a57073",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": 70,
+              "y": -300,
+              "width": 1,
+              "height": 100
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 0
+              },
+              {
+                "x": 0,
+                "y": 100
+              }
+            ],
+            "source": {
+              "direction": "Down",
+              "element": "77976ef7-599d-4c49-9f4d-1ecb23239fe3"
+            },
+            "target": {
+              "direction": "Up",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "isManuallyLayouted": false,
+            "condition": "auto",
+            "conditionValue": ""
+          },
+          "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31": {
+            "id": "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": 240,
+              "y": -130,
+              "width": 200,
+              "height": 40
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 5
+              },
+              {
+                "x": 40,
+                "y": 5
+              },
+              {
+                "x": 40,
+                "y": 0
+              },
+              {
+                "x": 200,
+                "y": 0
+              },
+              {
+                "x": 200,
+                "y": 40
+              }
+            ],
+            "source": {
+              "direction": "Downright",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "target": {
+              "direction": "Up",
+              "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
+            },
+            "isManuallyLayouted": true,
+            "condition": "when_intent_matched",
+            "conditionValue": "Other"
+          },
+          "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e": {
+            "id": "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -380,
+              "y": -125,
+              "width": 200,
+              "height": 127.5
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 127.5
+              },
+              {
+                "x": 100,
+                "y": 127.5
+              },
+              {
+                "x": 100,
+                "y": 0
+              },
+              {
+                "x": 200,
+                "y": 0
+              }
+            ],
+            "source": {
+              "direction": "Upright",
+              "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
+            },
+            "target": {
+              "direction": "Downleft",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "isManuallyLayouted": false,
+            "condition": "auto",
+            "conditionValue": ""
+          },
+          "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32": {
+            "id": "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": 135,
+              "y": -100,
+              "width": 215,
+              "height": 40
+            },
+            "path": [
+              {
+                "x": 215,
+                "y": 27.5
+              },
+              {
+                "x": 175,
+                "y": 27.5
+              },
+              {
+                "x": 175,
+                "y": 40
+              },
+              {
+                "x": 0,
+                "y": 40
+              },
+              {
+                "x": 0,
+                "y": 0
+              }
+            ],
+            "source": {
+              "direction": "Upleft",
+              "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
+            },
+            "target": {
+              "direction": "Bottomright",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "isManuallyLayouted": false,
+            "condition": "auto",
+            "conditionValue": ""
+          },
+          "3564da62-bea0-4489-81b2-fda2effddd02": {
+            "id": "3564da62-bea0-4489-81b2-fda2effddd02",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -190,
+              "y": -100,
+              "width": 115,
+              "height": 277.5
+            },
+            "path": [
+              {
+                "x": 40,
+                "y": 277.5
+              },
+              {
+                "x": 0,
+                "y": 277.5
+              },
+              {
+                "x": 0,
+                "y": 115
+              },
+              {
+                "x": 115,
+                "y": 115
+              },
+              {
+                "x": 115,
+                "y": 0
+              }
+            ],
+            "source": {
+              "direction": "Upleft",
+              "element": "7610bbda-21ef-4637-a188-1da1352bea17"
+            },
+            "target": {
+              "direction": "Bottomleft",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "isManuallyLayouted": false,
+            "condition": "auto",
+            "conditionValue": ""
+          },
+          "b696a5f6-f328-42fb-bdbc-83569b2beb06": {
+            "id": "b696a5f6-f328-42fb-bdbc-83569b2beb06",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": 45,
+              "y": -100,
+              "width": 1,
+              "height": 230
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 0
+              },
+              {
+                "x": 0,
+                "y": 230
+              }
+            ],
+            "source": {
+              "direction": "Down",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "target": {
+              "direction": "Up",
+              "element": "7610bbda-21ef-4637-a188-1da1352bea17"
+            },
+            "isManuallyLayouted": false,
+            "condition": "when_intent_matched",
+            "conditionValue": "Nutrition_intent"
+          }
+        },
+        "assessments": {}
+      },
+      "personalizedAgentModel": {
+        "version": "3.0.0",
+        "type": "AgentDiagram",
+        "size": {
+          "width": 1980,
+          "height": 640
+        },
+        "interactive": {
+          "elements": {},
+          "relationships": {}
+        },
+        "elements": {
+          "ccd1dced-243c-49c4-9a00-80e7f772327a": {
+            "id": "ccd1dced-243c-49c4-9a00-80e7f772327a",
+            "name": "I want muscles",
+            "type": "AgentIntentBody",
+            "owner": "566a781d-eb9d-4f80-bd98-8882ed800717",
+            "bounds": {
+              "x": -550,
+              "y": -300,
+              "width": 160,
+              "height": 30
+            }
+          },
+          "566a781d-eb9d-4f80-bd98-8882ed800717": {
+            "id": "566a781d-eb9d-4f80-bd98-8882ed800717",
+            "name": "Muscles_intent",
+            "type": "AgentIntent",
+            "owner": null,
+            "bounds": {
+              "x": -550,
+              "y": -300,
+              "width": 160,
+              "height": 100
+            },
+            "bodies": [
+              "ccd1dced-243c-49c4-9a00-80e7f772327a"
+            ],
+            "intent_description": "Question about how to become muscular and which exercises to perform."
+          },
+          "651f4205-d406-482c-8bb4-975fdf9e456f": {
+            "id": "651f4205-d406-482c-8bb4-975fdf9e456f",
+            "name": "Which food to eat?",
+            "type": "AgentIntentBody",
+            "owner": "1766afa2-4953-4cc8-9bb0-af48953503f3",
+            "bounds": {
+              "x": -250,
+              "y": -300,
+              "width": 160,
+              "height": 30
+            }
+          },
+          "1766afa2-4953-4cc8-9bb0-af48953503f3": {
+            "id": "1766afa2-4953-4cc8-9bb0-af48953503f3",
+            "name": "Nutrition_intent",
+            "type": "AgentIntent",
+            "owner": null,
+            "bounds": {
+              "x": -250,
+              "y": -300,
+              "width": 160,
+              "height": 100
+            },
+            "bodies": [
+              "651f4205-d406-482c-8bb4-975fdf9e456f"
+            ],
+            "intent_description": "Question about nutrition in gym."
+          },
+          "4037bf46-f138-4c9c-a891-c8f5639a19a0": {
+            "id": "4037bf46-f138-4c9c-a891-c8f5639a19a0",
+            "name": "Other",
+            "type": "AgentIntent",
+            "owner": null,
+            "bounds": {
+              "x": 50,
+              "y": -300,
+              "width": 160,
+              "height": 100
+            },
+            "bodies": [],
+            "intent_description": "Any question that does not fit in \"Muscles\" or \"Nutrition\""
+          },
+          "730ca64d-597c-4fd8-a756-5d98d475edb8": {
+            "id": "730ca64d-597c-4fd8-a756-5d98d475edb8",
+            "name": "",
+            "type": "StateInitialNode",
+            "owner": null,
+            "bounds": {
+              "x": -580,
+              "y": -60,
+              "width": 45,
+              "height": 45
+            }
+          },
+          "3effee26-ddc1-4180-8dfc-4f54d929c334": {
+            "id": "3effee26-ddc1-4180-8dfc-4f54d929c334",
+            "name": "Initial",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -280,
+              "y": -80,
+              "width": 160,
+              "height": 100
+            },
+            "bodies": [
+              "e082c986-9bb3-45be-8f43-2e6b8af7a9d7"
+            ],
+            "fallbackBodies": []
+          },
+          "07601353-ee34-4ca9-bbe4-bdd711e624c4": {
+            "id": "07601353-ee34-4ca9-bbe4-bdd711e624c4",
+            "name": "Idle",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": 210,
+              "y": -80,
+              "width": 160,
+              "height": 100
+            },
+            "bodies": [
+              "ac420544-4ccf-4a49-9b3f-0c1eb9278f7e"
+            ],
+            "fallbackBodies": [
+              "3e3e5cbe-d409-4601-9cb2-11b371cfb064"
+            ]
+          },
+          "8f57a878-84ca-409d-b89d-cc62fc815507": {
+            "id": "8f57a878-84ca-409d-b89d-cc62fc815507",
+            "name": "TrainingPlan",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -280,
+              "y": 140,
+              "width": 160,
+              "height": 100
+            },
+            "bodies": [
+              "bb125833-aa05-440d-922a-1684c5faea6f",
+              "4403443a-176c-4c34-b4c1-59566a6cee15",
+              "f7f7c51d-0768-4d06-ab4d-fe498e2665e7"
+            ],
+            "fallbackBodies": []
+          },
+          "c6bea043-ca61-463e-8c51-753602773b9a": {
+            "id": "c6bea043-ca61-463e-8c51-753602773b9a",
+            "name": "Nutrition",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": 210,
+              "y": 140,
+              "width": 160,
+              "height": 100
+            },
+            "bodies": [
+              "741a9bfa-d1ca-4ecf-b131-c0648fc0652a",
+              "7c1a4721-5f81-4330-b2a7-b0e395c52aa3",
+              "8c518247-6c3f-418a-9384-bb5272521b2b",
+              "8c96e0a0-670e-4c28-9ef0-b81fef0b1e8d",
+              "2c319d4a-9344-4a61-95d8-134fd903c053"
+            ],
+            "fallbackBodies": []
+          },
+          "b5895c6c-fdf9-4f1f-813f-ef8baaa7a008": {
+            "id": "b5895c6c-fdf9-4f1f-813f-ef8baaa7a008",
+            "name": "OtherQuestions",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -280,
+              "y": 360,
+              "width": 160,
+              "height": 100
+            },
+            "bodies": [
+              "4499b560-b246-4b3f-b703-d9709836b98e"
+            ],
+            "fallbackBodies": []
+          },
+          "e082c986-9bb3-45be-8f43-2e6b8af7a9d7": {
+            "id": "e082c986-9bb3-45be-8f43-2e6b8af7a9d7",
+            "name": "Hi! I’m your fitness helper and guide.",
+            "type": "AgentStateBody",
+            "owner": "3effee26-ddc1-4180-8dfc-4f54d929c334",
+            "bounds": {
+              "x": -280,
+              "y": -80,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "ac420544-4ccf-4a49-9b3f-0c1eb9278f7e": {
+            "id": "ac420544-4ccf-4a49-9b3f-0c1eb9278f7e",
+            "name": "I can answer questions about workouts, food, and recovery.",
+            "type": "AgentStateBody",
+            "owner": "07601353-ee34-4ca9-bbe4-bdd711e624c4",
+            "bounds": {
+              "x": 210,
+              "y": -80,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "3e3e5cbe-d409-4601-9cb2-11b371cfb064": {
+            "id": "3e3e5cbe-d409-4601-9cb2-11b371cfb064",
+            "name": "I only talk about gym and fitness.",
+            "type": "AgentStateFallbackBody",
+            "owner": "07601353-ee34-4ca9-bbe4-bdd711e624c4",
+            "bounds": {
+              "x": 210,
+              "y": -80,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "bb125833-aa05-440d-922a-1684c5faea6f": {
+            "id": "bb125833-aa05-440d-922a-1684c5faea6f",
+            "name": "Focus on big, heavy lifts to build muscle: squats, deadlifts, bench press, overhead press, and rows.",
+            "type": "AgentStateBody",
+            "owner": "8f57a878-84ca-409d-b89d-cc62fc815507",
+            "bounds": {
+              "x": -280,
+              "y": 140,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "4403443a-176c-4c34-b4c1-59566a6cee15": {
+            "id": "4403443a-176c-4c34-b4c1-59566a6cee15",
+            "name": "Train 3–5 days a week. Add a little weight over time. Eat enough protein and calories to grow.",
+            "type": "AgentStateBody",
+            "owner": "8f57a878-84ca-409d-b89d-cc62fc815507",
+            "bounds": {
+              "x": -280,
+              "y": 140,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "f7f7c51d-0768-4d06-ab4d-fe498e2665e7": {
+            "id": "f7f7c51d-0768-4d06-ab4d-fe498e2665e7",
+            "name": "Sleep well and be consistent. Muscle grows with steady effort over time.",
+            "type": "AgentStateBody",
+            "owner": "8f57a878-84ca-409d-b89d-cc62fc815507",
+            "bounds": {
+              "x": -280,
+              "y": 140,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "741a9bfa-d1ca-4ecf-b131-c0648fc0652a": {
+            "id": "741a9bfa-d1ca-4ecf-b131-c0648fc0652a",
+            "name": "Eat mostly whole foods: lean protein, vegetables, fruit, whole grains, and healthy fats. Aim for 1.6 to 2.2 grams of protein per kilogram of body weight each day.",
+            "type": "AgentStateBody",
+            "owner": "c6bea043-ca61-463e-8c51-753602773b9a",
+            "bounds": {
+              "x": 210,
+              "y": 140,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "7c1a4721-5f81-4330-b2a7-b0e395c52aa3": {
+            "id": "7c1a4721-5f81-4330-b2a7-b0e395c52aa3",
+            "name": "Match calories to your goal: eat a little more to gain muscle, eat less to lose fat, eat the same to stay the same.",
+            "type": "AgentStateBody",
+            "owner": "c6bea043-ca61-463e-8c51-753602773b9a",
+            "bounds": {
+              "x": 210,
+              "y": 140,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "8c518247-6c3f-418a-9384-bb5272521b2b": {
+            "id": "8c518247-6c3f-418a-9384-bb5272521b2b",
+            "name": "Carbs give you energy for training. Fats help your hormones.",
+            "type": "AgentStateBody",
+            "owner": "c6bea043-ca61-463e-8c51-753602773b9a",
+            "bounds": {
+              "x": 210,
+              "y": 140,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "8c96e0a0-670e-4c28-9ef0-b81fef0b1e8d": {
+            "id": "8c96e0a0-670e-4c28-9ef0-b81fef0b1e8d",
+            "name": "Drink plenty of water. Limit highly processed foods and alcohol.",
+            "type": "AgentStateBody",
+            "owner": "c6bea043-ca61-463e-8c51-753602773b9a",
+            "bounds": {
+              "x": 210,
+              "y": 140,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "2c319d4a-9344-4a61-95d8-134fd903c053": {
+            "id": "2c319d4a-9344-4a61-95d8-134fd903c053",
+            "name": "Be consistent. Results come from good habits, not perfection.",
+            "type": "AgentStateBody",
+            "owner": "c6bea043-ca61-463e-8c51-753602773b9a",
+            "bounds": {
+              "x": 210,
+              "y": 140,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "4499b560-b246-4b3f-b703-d9709836b98e": {
+            "id": "4499b560-b246-4b3f-b703-d9709836b98e",
+            "name": "AI response 🪄",
+            "type": "AgentStateBody",
+            "owner": "b5895c6c-fdf9-4f1f-813f-ef8baaa7a008",
+            "bounds": {
+              "x": -280,
+              "y": 360,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "llm"
+          }
+        },
+        "relationships": {
+          "4b6aa5dd-81c4-4ae8-a6bf-d6aa587831d1": {
+            "id": "4b6aa5dd-81c4-4ae8-a6bf-d6aa587831d1",
+            "name": "",
+            "type": "AgentStateTransitionInit",
+            "owner": null,
+            "source": {
+              "direction": "Right",
+              "element": "730ca64d-597c-4fd8-a756-5d98d475edb8",
+              "bounds": {
+                "x": -535,
+                "y": -37.5,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Left",
+              "element": "3effee26-ddc1-4180-8dfc-4f54d929c334",
+              "bounds": {
+                "x": -280,
+                "y": -45,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "bounds": {
+              "x": -535,
+              "y": -37.5,
+              "width": 255,
+              "height": 1
+            },
+            "path": [
+              {
+                "x": -535,
+                "y": -37.5
+              },
+              {
+                "x": -280,
+                "y": -37.5
+              }
+            ],
+            "isManuallyLayouted": false
+          },
+          "5f4c44a4-fdd5-4039-8896-30544b0780ba": {
+            "id": "5f4c44a4-fdd5-4039-8896-30544b0780ba",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -130,
+              "y": -40,
+              "width": 350,
+              "height": 20
+            },
+            "path": [
+              {
+                "x": -120,
+                "y": -30
+              },
+              {
+                "x": 45,
+                "y": -30
+              },
+              {
+                "x": 45,
+                "y": -30
+              },
+              {
+                "x": 210,
+                "y": -30
+              }
+            ],
+            "source": {
+              "direction": "Right",
+              "element": "3effee26-ddc1-4180-8dfc-4f54d929c334",
+              "bounds": {
+                "x": -120,
+                "y": -30,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Left",
+              "element": "07601353-ee34-4ca9-bbe4-bdd711e624c4",
+              "bounds": {
+                "x": 210,
+                "y": -30,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "isManuallyLayouted": false,
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "event": "None",
+              "condition": []
+            }
+          },
+          "b49bbd98-4465-4534-8bdc-e6861d4ff6b3": {
+            "id": "b49bbd98-4465-4534-8bdc-e6861d4ff6b3",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -130,
+              "y": -40,
+              "width": 350,
+              "height": 240
+            },
+            "path": [
+              {
+                "x": 210,
+                "y": -30
+              },
+              {
+                "x": 45,
+                "y": -30
+              },
+              {
+                "x": 45,
+                "y": 190
+              },
+              {
+                "x": -120,
+                "y": 190
+              }
+            ],
+            "source": {
+              "direction": "Left",
+              "element": "07601353-ee34-4ca9-bbe4-bdd711e624c4",
+              "bounds": {
+                "x": 210,
+                "y": -30,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Right",
+              "element": "8f57a878-84ca-409d-b89d-cc62fc815507",
+              "bounds": {
+                "x": -120,
+                "y": 190,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "isManuallyLayouted": false,
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "when_intent_matched",
+              "intentName": "Muscles_intent"
+            },
+            "custom": {
+              "event": "None",
+              "condition": []
+            }
+          },
+          "8b843917-2912-4965-a82b-0fbb16f9fefa": {
+            "id": "8b843917-2912-4965-a82b-0fbb16f9fefa",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -130,
+              "y": -40,
+              "width": 350,
+              "height": 460
+            },
+            "path": [
+              {
+                "x": 210,
+                "y": -30
+              },
+              {
+                "x": 45,
+                "y": -30
+              },
+              {
+                "x": 45,
+                "y": 410
+              },
+              {
+                "x": -120,
+                "y": 410
+              }
+            ],
+            "source": {
+              "direction": "Left",
+              "element": "07601353-ee34-4ca9-bbe4-bdd711e624c4",
+              "bounds": {
+                "x": 210,
+                "y": -30,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Right",
+              "element": "b5895c6c-fdf9-4f1f-813f-ef8baaa7a008",
+              "bounds": {
+                "x": -120,
+                "y": 410,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "isManuallyLayouted": false,
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "when_intent_matched",
+              "intentName": "Other"
+            },
+            "custom": {
+              "event": "None",
+              "condition": []
+            }
+          },
+          "43f309b8-9635-4b51-82ed-445d4b6b4d66": {
+            "id": "43f309b8-9635-4b51-82ed-445d4b6b4d66",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": 280,
+              "y": 10,
+              "width": 20,
+              "height": 140
+            },
+            "path": [
+              {
+                "x": 290,
+                "y": 20
+              },
+              {
+                "x": 290,
+                "y": 80
+              },
+              {
+                "x": 290,
+                "y": 80
+              },
+              {
+                "x": 290,
+                "y": 140
+              }
+            ],
+            "source": {
+              "direction": "Down",
+              "element": "07601353-ee34-4ca9-bbe4-bdd711e624c4",
+              "bounds": {
+                "x": 290,
+                "y": 20,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Up",
+              "element": "c6bea043-ca61-463e-8c51-753602773b9a",
+              "bounds": {
+                "x": 290,
+                "y": 140,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "isManuallyLayouted": false,
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "when_intent_matched",
+              "intentName": "Nutrition_intent"
+            },
+            "custom": {
+              "event": "None",
+              "condition": []
+            }
+          },
+          "6969907b-b7bb-4e23-bae9-daeaffa6a7c0": {
+            "id": "6969907b-b7bb-4e23-bae9-daeaffa6a7c0",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -130,
+              "y": -40,
+              "width": 350,
+              "height": 240
+            },
+            "path": [
+              {
+                "x": -120,
+                "y": 190
+              },
+              {
+                "x": 45,
+                "y": 190
+              },
+              {
+                "x": 45,
+                "y": -30
+              },
+              {
+                "x": 210,
+                "y": -30
+              }
+            ],
+            "source": {
+              "direction": "Right",
+              "element": "8f57a878-84ca-409d-b89d-cc62fc815507",
+              "bounds": {
+                "x": -120,
+                "y": 190,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Left",
+              "element": "07601353-ee34-4ca9-bbe4-bdd711e624c4",
+              "bounds": {
+                "x": 210,
+                "y": -30,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "isManuallyLayouted": false,
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "event": "None",
+              "condition": []
+            }
+          },
+          "4ba46b8a-28d1-48ee-b9e0-bc8c3aa82c61": {
+            "id": "4ba46b8a-28d1-48ee-b9e0-bc8c3aa82c61",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": 280,
+              "y": 10,
+              "width": 20,
+              "height": 140
+            },
+            "path": [
+              {
+                "x": 290,
+                "y": 140
+              },
+              {
+                "x": 290,
+                "y": 80
+              },
+              {
+                "x": 290,
+                "y": 80
+              },
+              {
+                "x": 290,
+                "y": 20
+              }
+            ],
+            "source": {
+              "direction": "Up",
+              "element": "c6bea043-ca61-463e-8c51-753602773b9a",
+              "bounds": {
+                "x": 290,
+                "y": 140,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Down",
+              "element": "07601353-ee34-4ca9-bbe4-bdd711e624c4",
+              "bounds": {
+                "x": 290,
+                "y": 20,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "isManuallyLayouted": false,
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "event": "None",
+              "condition": []
+            }
+          },
+          "2dead912-e083-4203-8a76-9d434ef3b39b": {
+            "id": "2dead912-e083-4203-8a76-9d434ef3b39b",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -130,
+              "y": -40,
+              "width": 350,
+              "height": 460
+            },
+            "path": [
+              {
+                "x": -120,
+                "y": 410
+              },
+              {
+                "x": 45,
+                "y": 410
+              },
+              {
+                "x": 45,
+                "y": -30
+              },
+              {
+                "x": 210,
+                "y": -30
+              }
+            ],
+            "source": {
+              "direction": "Right",
+              "element": "b5895c6c-fdf9-4f1f-813f-ef8baaa7a008",
+              "bounds": {
+                "x": -120,
+                "y": 410,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Left",
+              "element": "07601353-ee34-4ca9-bbe4-bdd711e624c4",
+              "bounds": {
+                "x": 210,
+                "y": -30,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "isManuallyLayouted": false,
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "event": "None",
+              "condition": []
+            }
+          },
+          "d1414fb9-bcf4-4e45-a74c-b7bb93d87d78": {
+            "id": "d1414fb9-bcf4-4e45-a74c-b7bb93d87d78",
+            "name": "",
+            "type": "AgentStateTransitionInit",
+            "owner": null,
+            "source": {
+              "direction": "Right",
+              "element": "730ca64d-597c-4fd8-a756-5d98d475edb8",
+              "bounds": {
+                "x": -535,
+                "y": -37.5,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Left",
+              "element": "3effee26-ddc1-4180-8dfc-4f54d929c334",
+              "bounds": {
+                "x": -280,
+                "y": -45,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "bounds": {
+              "x": -535,
+              "y": -37.5,
+              "width": 255,
+              "height": 1
+            },
+            "path": [
+              {
+                "x": -535,
+                "y": -37.5
+              },
+              {
+                "x": -280,
+                "y": -37.5
+              }
+            ],
+            "isManuallyLayouted": false
+          }
+        },
+        "assessments": {}
+      }
+    },
+    {
+      "id": "ef384a51-8bd6-45bb-952c-03a0944827d8",
+      "name": "paraplegicprofile",
+      "savedAt": "2026-05-06T13:49:25.848Z",
+      "config": {
+        "agentLanguage": "original",
+        "inputModalities": [
+          "text"
+        ],
+        "outputModalities": [
+          "text"
+        ],
+        "agentPlatform": "streamlit",
+        "responseTiming": "instant",
+        "agentStyle": "original",
+        "llm": {
+          "provider": "openai",
+          "model": "gpt-5"
+        },
+        "languageComplexity": "original",
+        "sentenceLength": "original",
+        "interfaceStyle": {
+          "size": 16,
+          "font": "sans",
+          "lineSpacing": 1.5,
+          "alignment": "left",
+          "color": "var(--apollon-primary-contrast)",
+          "contrast": "medium"
+        },
+        "voiceStyle": {
+          "gender": "male",
+          "speed": 1
+        },
+        "avatar": null,
+        "useAbbreviations": false,
+        "adaptContentToUserProfile": true,
+        "userProfileName": "ParaplegicUser",
+        "intentRecognitionTechnology": "llm-based"
+      },
+      "baseAgentModel": {
+        "version": "3.0.0",
+        "type": "AgentDiagram",
+        "size": {
+          "width": 1080,
+          "height": 400
+        },
+        "interactive": {
+          "elements": {},
+          "relationships": {}
+        },
+        "elements": {
+          "699853eb-918b-4674-b08c-cf0af3cc61d7": {
+            "id": "699853eb-918b-4674-b08c-cf0af3cc61d7",
+            "name": "",
+            "type": "StateInitialNode",
+            "owner": null,
+            "bounds": {
+              "x": -230,
+              "y": -370,
+              "width": 45,
+              "height": 45
+            }
+          },
+          "0cba5357-2c30-414b-8d74-ac74ac4ab158": {
+            "id": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
+            "name": "Idle",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -180,
+              "y": -200,
+              "width": 420,
+              "height": 100
+            },
+            "bodies": [
+              "63a2c160-ebbb-457b-953a-93fd2e643224"
+            ],
+            "fallbackBodies": [
+              "1f369122-06c2-4050-ba54-4ea160f95a8c"
+            ]
+          },
+          "63a2c160-ebbb-457b-953a-93fd2e643224": {
+            "id": "63a2c160-ebbb-457b-953a-93fd2e643224",
+            "name": "I am here to answer any questions regarding exercises, nutrition and recovery.",
+            "type": "AgentStateBody",
+            "owner": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
+            "bounds": {
+              "x": -179.5,
+              "y": -159.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "1f369122-06c2-4050-ba54-4ea160f95a8c": {
+            "id": "1f369122-06c2-4050-ba54-4ea160f95a8c",
+            "name": "I focus on gym and fitness topics only dude.",
+            "type": "AgentStateFallbackBody",
+            "owner": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
+            "bounds": {
+              "x": -179.5,
+              "y": -129.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "8dba49ff-2fc1-4066-b124-19e2df7981e2": {
+            "id": "8dba49ff-2fc1-4066-b124-19e2df7981e2",
+            "name": "Muscles_intent",
+            "type": "AgentIntent",
+            "owner": null,
+            "bounds": {
+              "x": -900,
+              "y": -400,
+              "width": 630,
+              "height": 100
+            },
+            "bodies": [
+              "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b"
+            ],
+            "intent_description": "Question about how to become muscular and which exercises to perform."
+          },
+          "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b": {
+            "id": "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b",
+            "name": "I want muscles",
+            "type": "AgentIntentBody",
+            "owner": "8dba49ff-2fc1-4066-b124-19e2df7981e2",
+            "bounds": {
+              "x": -899.5,
+              "y": -329.5,
+              "width": 629,
+              "height": 30
+            }
+          },
+          "68ccb630-b264-41a0-b70e-1e369bd5706c": {
+            "id": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+            "name": "TrainingPlan",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -800,
+              "y": -30,
+              "width": 420,
+              "height": 130
+            },
+            "bodies": [
+              "aa261be5-9c53-4df1-a72f-5a107ce8f1b7",
+              "747b8558-325d-4a15-baba-0d18a6602a8d",
+              "900f7fd9-738a-4981-a7d9-6c7334621981"
+            ],
+            "fallbackBodies": []
+          },
+          "aa261be5-9c53-4df1-a72f-5a107ce8f1b7": {
+            "id": "aa261be5-9c53-4df1-a72f-5a107ce8f1b7",
+            "name": "Focus on heavy compound lifts like squats, deadlifts, bench press, overhead press, and rows to build overall muscle mass. ",
+            "type": "AgentStateBody",
+            "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+            "bounds": {
+              "x": -799.5,
+              "y": 10.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "747b8558-325d-4a15-baba-0d18a6602a8d": {
+            "id": "747b8558-325d-4a15-baba-0d18a6602a8d",
+            "name": "Train 3–5 times per week, progressively increasing the weight while eating enough protein and calories to support growth. ",
+            "type": "AgentStateBody",
+            "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+            "bounds": {
+              "x": -799.5,
+              "y": 40.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "900f7fd9-738a-4981-a7d9-6c7334621981": {
+            "id": "900f7fd9-738a-4981-a7d9-6c7334621981",
+            "name": "Get good sleep and stay consistent—muscle comes from steady effort over time.",
+            "type": "AgentStateBody",
+            "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+            "bounds": {
+              "x": -799.5,
+              "y": 70.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "77976ef7-599d-4c49-9f4d-1ecb23239fe3": {
+            "id": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
+            "name": "Initial",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -100,
+              "y": -370,
+              "width": 420,
+              "height": 70
+            },
+            "bodies": [
+              "ad226172-93d8-4644-80c5-62825565dd24"
+            ],
+            "fallbackBodies": []
+          },
+          "ad226172-93d8-4644-80c5-62825565dd24": {
+            "id": "ad226172-93d8-4644-80c5-62825565dd24",
+            "name": "Hi, I am your buddy, the fitness agent.",
+            "type": "AgentStateBody",
+            "owner": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
+            "bounds": {
+              "x": -99.5,
+              "y": -329.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "7610bbda-21ef-4637-a188-1da1352bea17": {
+            "id": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "name": "Nutrition",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -150,
+              "y": 130,
+              "width": 420,
+              "height": 190
+            },
+            "bodies": [
+              "bb7e67bd-ead9-4f14-93db-c18af0d806af",
+              "13072ea8-9b51-45fe-927e-a9323627701b",
+              "95241c3a-f8a2-4bf0-b169-5dcff5a926fb",
+              "44904a03-ac46-4f9f-983a-f6a740b81c0e",
+              "90dfba4f-6dec-4ca8-8c15-786ed36587a1"
+            ],
+            "fallbackBodies": []
+          },
+          "bb7e67bd-ead9-4f14-93db-c18af0d806af": {
+            "id": "bb7e67bd-ead9-4f14-93db-c18af0d806af",
+            "name": "Nutrition basics: Eat mostly whole foods (lean protein, vegetables, fruits, whole grains, healthy fats). Protein: ~1.6–2.2 g per kg of body weight daily..",
+            "type": "AgentStateBody",
+            "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "bounds": {
+              "x": -149.5,
+              "y": 170.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "13072ea8-9b51-45fe-927e-a9323627701b": {
+            "id": "13072ea8-9b51-45fe-927e-a9323627701b",
+            "name": "Match calories to your goal: slight surplus to gain muscle, deficit to lose fat, maintenance to stay the same. ",
+            "type": "AgentStateBody",
+            "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "bounds": {
+              "x": -149.5,
+              "y": 200.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "95241c3a-f8a2-4bf0-b169-5dcff5a926fb": {
+            "id": "95241c3a-f8a2-4bf0-b169-5dcff5a926fb",
+            "name": " Carbs fuel training; fats support hormones.",
+            "type": "AgentStateBody",
+            "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "bounds": {
+              "x": -149.5,
+              "y": 230.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "44904a03-ac46-4f9f-983a-f6a740b81c0e": {
+            "id": "44904a03-ac46-4f9f-983a-f6a740b81c0e",
+            "name": " Drink plenty of water and limit ultra-processed foods and alcohol. ",
+            "type": "AgentStateBody",
+            "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "bounds": {
+              "x": -149.5,
+              "y": 260.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "90dfba4f-6dec-4ca8-8c15-786ed36587a1": {
+            "id": "90dfba4f-6dec-4ca8-8c15-786ed36587a1",
+            "name": "Be consistent — results come from habits, not perfection",
+            "type": "AgentStateBody",
+            "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "bounds": {
+              "x": -149.5,
+              "y": 290.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "8c760b7d-7e72-4cd7-a92a-d5491c021a5b": {
+            "id": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b",
+            "name": "OtherQuestions",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": 350,
+              "y": -90,
+              "width": 180,
+              "height": 70
+            },
+            "bodies": [
+              "6a3aeb02-bb44-4472-8489-595e8dc8ceb1"
+            ],
+            "fallbackBodies": []
+          },
+          "6a3aeb02-bb44-4472-8489-595e8dc8ceb1": {
+            "id": "6a3aeb02-bb44-4472-8489-595e8dc8ceb1",
+            "name": "AI response 🪄",
+            "type": "AgentStateBody",
+            "owner": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b",
+            "bounds": {
+              "x": 350.5,
+              "y": -49.5,
+              "width": 179,
+              "height": 30
+            },
+            "replyType": "llm",
+            "ragDatabaseName": ""
+          },
+          "659e810a-f686-47fb-aea8-d23ad06e482c": {
+            "id": "659e810a-f686-47fb-aea8-d23ad06e482c",
+            "name": "Nutrition_intent",
+            "type": "AgentIntent",
+            "owner": null,
+            "bounds": {
+              "x": -900,
+              "y": -290,
+              "width": 630,
+              "height": 100
+            },
+            "bodies": [
+              "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0"
+            ],
+            "intent_description": "Question about nutrition in gym."
+          },
+          "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0": {
+            "id": "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0",
+            "name": "Which food to eat?",
+            "type": "AgentIntentBody",
+            "owner": "659e810a-f686-47fb-aea8-d23ad06e482c",
+            "bounds": {
+              "x": -899.5,
+              "y": -219.5,
+              "width": 629,
+              "height": 30
+            }
+          },
+          "37dff3e2-013c-42f0-ad6e-bbc197247d14": {
+            "id": "37dff3e2-013c-42f0-ad6e-bbc197247d14",
+            "name": "Other",
+            "type": "AgentIntent",
+            "owner": null,
+            "bounds": {
+              "x": -860,
+              "y": 150,
+              "width": 630,
+              "height": 70
+            },
+            "bodies": [],
+            "intent_description": "Any question that does not fit in \"Muscles\" or \"Nutrition\""
+          }
+        },
+        "relationships": {
+          "bbd03bdd-b76e-47df-9e13-5a305885f94c": {
+            "id": "bbd03bdd-b76e-47df-9e13-5a305885f94c",
+            "name": "",
+            "type": "AgentStateTransitionInit",
+            "owner": null,
+            "bounds": {
+              "x": -185,
+              "y": -347.5,
+              "width": 85,
+              "height": 1
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 0
+              },
+              {
+                "x": 85,
+                "y": 0
+              }
+            ],
+            "source": {
+              "direction": "Right",
+              "element": "699853eb-918b-4674-b08c-cf0af3cc61d7",
+              "bounds": {
+                "x": -535,
+                "y": -37.5,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Left",
+              "element": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
+              "bounds": {
+                "x": -280,
+                "y": -45,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "isManuallyLayouted": false
+          },
+          "0d7d8895-3eb0-44b0-bb41-e902684d0d2c": {
+            "id": "0d7d8895-3eb0-44b0-bb41-e902684d0d2c",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -590,
+              "y": -150,
+              "width": 410,
+              "height": 120
+            },
+            "path": [
+              {
+                "x": 410,
+                "y": 0
+              },
+              {
+                "x": 0,
+                "y": 0
+              },
+              {
+                "x": 0,
+                "y": 120
+              }
+            ],
+            "source": {
+              "direction": "Left",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "target": {
+              "direction": "Up",
+              "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
+            },
+            "isManuallyLayouted": false,
+            "condition": "when_intent_matched",
+            "conditionValue": "Muscles_intent"
+          },
+          "7d65df96-e669-4fc6-a882-dbfe92a57073": {
+            "id": "7d65df96-e669-4fc6-a882-dbfe92a57073",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": 70,
+              "y": -300,
+              "width": 1,
+              "height": 100
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 0
+              },
+              {
+                "x": 0,
+                "y": 100
+              }
+            ],
+            "source": {
+              "direction": "Down",
+              "element": "77976ef7-599d-4c49-9f4d-1ecb23239fe3"
+            },
+            "target": {
+              "direction": "Up",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "isManuallyLayouted": false,
+            "condition": "auto",
+            "conditionValue": ""
+          },
+          "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31": {
+            "id": "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": 240,
+              "y": -130,
+              "width": 200,
+              "height": 40
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 5
+              },
+              {
+                "x": 40,
+                "y": 5
+              },
+              {
+                "x": 40,
+                "y": 0
+              },
+              {
+                "x": 200,
+                "y": 0
+              },
+              {
+                "x": 200,
+                "y": 40
+              }
+            ],
+            "source": {
+              "direction": "Downright",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "target": {
+              "direction": "Up",
+              "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
+            },
+            "isManuallyLayouted": true,
+            "condition": "when_intent_matched",
+            "conditionValue": "Other"
+          },
+          "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e": {
+            "id": "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -380,
+              "y": -125,
+              "width": 200,
+              "height": 127.5
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 127.5
+              },
+              {
+                "x": 100,
+                "y": 127.5
+              },
+              {
+                "x": 100,
+                "y": 0
+              },
+              {
+                "x": 200,
+                "y": 0
+              }
+            ],
+            "source": {
+              "direction": "Upright",
+              "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
+            },
+            "target": {
+              "direction": "Downleft",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "isManuallyLayouted": false,
+            "condition": "auto",
+            "conditionValue": ""
+          },
+          "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32": {
+            "id": "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": 135,
+              "y": -100,
+              "width": 215,
+              "height": 40
+            },
+            "path": [
+              {
+                "x": 215,
+                "y": 27.5
+              },
+              {
+                "x": 175,
+                "y": 27.5
+              },
+              {
+                "x": 175,
+                "y": 40
+              },
+              {
+                "x": 0,
+                "y": 40
+              },
+              {
+                "x": 0,
+                "y": 0
+              }
+            ],
+            "source": {
+              "direction": "Upleft",
+              "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
+            },
+            "target": {
+              "direction": "Bottomright",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "isManuallyLayouted": false,
+            "condition": "auto",
+            "conditionValue": ""
+          },
+          "3564da62-bea0-4489-81b2-fda2effddd02": {
+            "id": "3564da62-bea0-4489-81b2-fda2effddd02",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -190,
+              "y": -100,
+              "width": 115,
+              "height": 277.5
+            },
+            "path": [
+              {
+                "x": 40,
+                "y": 277.5
+              },
+              {
+                "x": 0,
+                "y": 277.5
+              },
+              {
+                "x": 0,
+                "y": 115
+              },
+              {
+                "x": 115,
+                "y": 115
+              },
+              {
+                "x": 115,
+                "y": 0
+              }
+            ],
+            "source": {
+              "direction": "Upleft",
+              "element": "7610bbda-21ef-4637-a188-1da1352bea17"
+            },
+            "target": {
+              "direction": "Bottomleft",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "isManuallyLayouted": false,
+            "condition": "auto",
+            "conditionValue": ""
+          },
+          "b696a5f6-f328-42fb-bdbc-83569b2beb06": {
+            "id": "b696a5f6-f328-42fb-bdbc-83569b2beb06",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": 45,
+              "y": -100,
+              "width": 1,
+              "height": 230
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 0
+              },
+              {
+                "x": 0,
+                "y": 230
+              }
+            ],
+            "source": {
+              "direction": "Down",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "target": {
+              "direction": "Up",
+              "element": "7610bbda-21ef-4637-a188-1da1352bea17"
+            },
+            "isManuallyLayouted": false,
+            "condition": "when_intent_matched",
+            "conditionValue": "Nutrition_intent"
+          }
+        },
+        "assessments": {}
+      },
+      "originalAgentModel": {
+        "version": "3.0.0",
+        "type": "AgentDiagram",
+        "size": {
+          "width": 1080,
+          "height": 400
+        },
+        "interactive": {
+          "elements": {},
+          "relationships": {}
+        },
+        "elements": {
+          "699853eb-918b-4674-b08c-cf0af3cc61d7": {
+            "id": "699853eb-918b-4674-b08c-cf0af3cc61d7",
+            "name": "",
+            "type": "StateInitialNode",
+            "owner": null,
+            "bounds": {
+              "x": -230,
+              "y": -370,
+              "width": 45,
+              "height": 45
+            }
+          },
+          "0cba5357-2c30-414b-8d74-ac74ac4ab158": {
+            "id": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
+            "name": "Idle",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -180,
+              "y": -200,
+              "width": 420,
+              "height": 100
+            },
+            "bodies": [
+              "63a2c160-ebbb-457b-953a-93fd2e643224"
+            ],
+            "fallbackBodies": [
+              "1f369122-06c2-4050-ba54-4ea160f95a8c"
+            ]
+          },
+          "63a2c160-ebbb-457b-953a-93fd2e643224": {
+            "id": "63a2c160-ebbb-457b-953a-93fd2e643224",
+            "name": "I am here to answer any questions regarding exercises, nutrition and recovery.",
+            "type": "AgentStateBody",
+            "owner": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
+            "bounds": {
+              "x": -179.5,
+              "y": -159.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "1f369122-06c2-4050-ba54-4ea160f95a8c": {
+            "id": "1f369122-06c2-4050-ba54-4ea160f95a8c",
+            "name": "I focus on gym and fitness topics only dude.",
+            "type": "AgentStateFallbackBody",
+            "owner": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
+            "bounds": {
+              "x": -179.5,
+              "y": -129.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "8dba49ff-2fc1-4066-b124-19e2df7981e2": {
+            "id": "8dba49ff-2fc1-4066-b124-19e2df7981e2",
+            "name": "Muscles_intent",
+            "type": "AgentIntent",
+            "owner": null,
+            "bounds": {
+              "x": -900,
+              "y": -400,
+              "width": 630,
+              "height": 100
+            },
+            "bodies": [
+              "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b"
+            ],
+            "intent_description": "Question about how to become muscular and which exercises to perform."
+          },
+          "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b": {
+            "id": "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b",
+            "name": "I want muscles",
+            "type": "AgentIntentBody",
+            "owner": "8dba49ff-2fc1-4066-b124-19e2df7981e2",
+            "bounds": {
+              "x": -899.5,
+              "y": -329.5,
+              "width": 629,
+              "height": 30
+            }
+          },
+          "68ccb630-b264-41a0-b70e-1e369bd5706c": {
+            "id": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+            "name": "TrainingPlan",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -800,
+              "y": -30,
+              "width": 420,
+              "height": 130
+            },
+            "bodies": [
+              "aa261be5-9c53-4df1-a72f-5a107ce8f1b7",
+              "747b8558-325d-4a15-baba-0d18a6602a8d",
+              "900f7fd9-738a-4981-a7d9-6c7334621981"
+            ],
+            "fallbackBodies": []
+          },
+          "aa261be5-9c53-4df1-a72f-5a107ce8f1b7": {
+            "id": "aa261be5-9c53-4df1-a72f-5a107ce8f1b7",
+            "name": "Focus on heavy compound lifts like squats, deadlifts, bench press, overhead press, and rows to build overall muscle mass. ",
+            "type": "AgentStateBody",
+            "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+            "bounds": {
+              "x": -799.5,
+              "y": 10.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "747b8558-325d-4a15-baba-0d18a6602a8d": {
+            "id": "747b8558-325d-4a15-baba-0d18a6602a8d",
+            "name": "Train 3–5 times per week, progressively increasing the weight while eating enough protein and calories to support growth. ",
+            "type": "AgentStateBody",
+            "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+            "bounds": {
+              "x": -799.5,
+              "y": 40.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "900f7fd9-738a-4981-a7d9-6c7334621981": {
+            "id": "900f7fd9-738a-4981-a7d9-6c7334621981",
+            "name": "Get good sleep and stay consistent—muscle comes from steady effort over time.",
+            "type": "AgentStateBody",
+            "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+            "bounds": {
+              "x": -799.5,
+              "y": 70.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "77976ef7-599d-4c49-9f4d-1ecb23239fe3": {
+            "id": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
+            "name": "Initial",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -100,
+              "y": -370,
+              "width": 420,
+              "height": 70
+            },
+            "bodies": [
+              "ad226172-93d8-4644-80c5-62825565dd24"
+            ],
+            "fallbackBodies": []
+          },
+          "ad226172-93d8-4644-80c5-62825565dd24": {
+            "id": "ad226172-93d8-4644-80c5-62825565dd24",
+            "name": "Hi, I am your buddy, the fitness agent.",
+            "type": "AgentStateBody",
+            "owner": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
+            "bounds": {
+              "x": -99.5,
+              "y": -329.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "7610bbda-21ef-4637-a188-1da1352bea17": {
+            "id": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "name": "Nutrition",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -150,
+              "y": 130,
+              "width": 420,
+              "height": 190
+            },
+            "bodies": [
+              "bb7e67bd-ead9-4f14-93db-c18af0d806af",
+              "13072ea8-9b51-45fe-927e-a9323627701b",
+              "95241c3a-f8a2-4bf0-b169-5dcff5a926fb",
+              "44904a03-ac46-4f9f-983a-f6a740b81c0e",
+              "90dfba4f-6dec-4ca8-8c15-786ed36587a1"
+            ],
+            "fallbackBodies": []
+          },
+          "bb7e67bd-ead9-4f14-93db-c18af0d806af": {
+            "id": "bb7e67bd-ead9-4f14-93db-c18af0d806af",
+            "name": "Nutrition basics: Eat mostly whole foods (lean protein, vegetables, fruits, whole grains, healthy fats). Protein: ~1.6–2.2 g per kg of body weight daily..",
+            "type": "AgentStateBody",
+            "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "bounds": {
+              "x": -149.5,
+              "y": 170.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "13072ea8-9b51-45fe-927e-a9323627701b": {
+            "id": "13072ea8-9b51-45fe-927e-a9323627701b",
+            "name": "Match calories to your goal: slight surplus to gain muscle, deficit to lose fat, maintenance to stay the same. ",
+            "type": "AgentStateBody",
+            "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "bounds": {
+              "x": -149.5,
+              "y": 200.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "95241c3a-f8a2-4bf0-b169-5dcff5a926fb": {
+            "id": "95241c3a-f8a2-4bf0-b169-5dcff5a926fb",
+            "name": " Carbs fuel training; fats support hormones.",
+            "type": "AgentStateBody",
+            "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "bounds": {
+              "x": -149.5,
+              "y": 230.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "44904a03-ac46-4f9f-983a-f6a740b81c0e": {
+            "id": "44904a03-ac46-4f9f-983a-f6a740b81c0e",
+            "name": " Drink plenty of water and limit ultra-processed foods and alcohol. ",
+            "type": "AgentStateBody",
+            "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "bounds": {
+              "x": -149.5,
+              "y": 260.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "90dfba4f-6dec-4ca8-8c15-786ed36587a1": {
+            "id": "90dfba4f-6dec-4ca8-8c15-786ed36587a1",
+            "name": "Be consistent — results come from habits, not perfection",
+            "type": "AgentStateBody",
+            "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+            "bounds": {
+              "x": -149.5,
+              "y": 290.5,
+              "width": 419,
+              "height": 30
+            },
+            "replyType": "text",
+            "ragDatabaseName": ""
+          },
+          "8c760b7d-7e72-4cd7-a92a-d5491c021a5b": {
+            "id": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b",
+            "name": "OtherQuestions",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": 350,
+              "y": -90,
+              "width": 180,
+              "height": 70
+            },
+            "bodies": [
+              "6a3aeb02-bb44-4472-8489-595e8dc8ceb1"
+            ],
+            "fallbackBodies": []
+          },
+          "6a3aeb02-bb44-4472-8489-595e8dc8ceb1": {
+            "id": "6a3aeb02-bb44-4472-8489-595e8dc8ceb1",
+            "name": "AI response 🪄",
+            "type": "AgentStateBody",
+            "owner": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b",
+            "bounds": {
+              "x": 350.5,
+              "y": -49.5,
+              "width": 179,
+              "height": 30
+            },
+            "replyType": "llm",
+            "ragDatabaseName": ""
+          },
+          "659e810a-f686-47fb-aea8-d23ad06e482c": {
+            "id": "659e810a-f686-47fb-aea8-d23ad06e482c",
+            "name": "Nutrition_intent",
+            "type": "AgentIntent",
+            "owner": null,
+            "bounds": {
+              "x": -900,
+              "y": -290,
+              "width": 630,
+              "height": 100
+            },
+            "bodies": [
+              "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0"
+            ],
+            "intent_description": "Question about nutrition in gym."
+          },
+          "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0": {
+            "id": "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0",
+            "name": "Which food to eat?",
+            "type": "AgentIntentBody",
+            "owner": "659e810a-f686-47fb-aea8-d23ad06e482c",
+            "bounds": {
+              "x": -899.5,
+              "y": -219.5,
+              "width": 629,
+              "height": 30
+            }
+          },
+          "37dff3e2-013c-42f0-ad6e-bbc197247d14": {
+            "id": "37dff3e2-013c-42f0-ad6e-bbc197247d14",
+            "name": "Other",
+            "type": "AgentIntent",
+            "owner": null,
+            "bounds": {
+              "x": -860,
+              "y": 150,
+              "width": 630,
+              "height": 70
+            },
+            "bodies": [],
+            "intent_description": "Any question that does not fit in \"Muscles\" or \"Nutrition\""
+          }
+        },
+        "relationships": {
+          "bbd03bdd-b76e-47df-9e13-5a305885f94c": {
+            "id": "bbd03bdd-b76e-47df-9e13-5a305885f94c",
+            "name": "",
+            "type": "AgentStateTransitionInit",
+            "owner": null,
+            "bounds": {
+              "x": -185,
+              "y": -347.5,
+              "width": 85,
+              "height": 1
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 0
+              },
+              {
+                "x": 85,
+                "y": 0
+              }
+            ],
+            "source": {
+              "direction": "Right",
+              "element": "699853eb-918b-4674-b08c-cf0af3cc61d7",
+              "bounds": {
+                "x": -535,
+                "y": -37.5,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Left",
+              "element": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
+              "bounds": {
+                "x": -280,
+                "y": -45,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "isManuallyLayouted": false
+          },
+          "0d7d8895-3eb0-44b0-bb41-e902684d0d2c": {
+            "id": "0d7d8895-3eb0-44b0-bb41-e902684d0d2c",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -590,
+              "y": -150,
+              "width": 410,
+              "height": 120
+            },
+            "path": [
+              {
+                "x": 410,
+                "y": 0
+              },
+              {
+                "x": 0,
+                "y": 0
+              },
+              {
+                "x": 0,
+                "y": 120
+              }
+            ],
+            "source": {
+              "direction": "Left",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "target": {
+              "direction": "Up",
+              "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
+            },
+            "isManuallyLayouted": false,
+            "condition": "when_intent_matched",
+            "conditionValue": "Muscles_intent"
+          },
+          "7d65df96-e669-4fc6-a882-dbfe92a57073": {
+            "id": "7d65df96-e669-4fc6-a882-dbfe92a57073",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": 70,
+              "y": -300,
+              "width": 1,
+              "height": 100
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 0
+              },
+              {
+                "x": 0,
+                "y": 100
+              }
+            ],
+            "source": {
+              "direction": "Down",
+              "element": "77976ef7-599d-4c49-9f4d-1ecb23239fe3"
+            },
+            "target": {
+              "direction": "Up",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "isManuallyLayouted": false,
+            "condition": "auto",
+            "conditionValue": ""
+          },
+          "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31": {
+            "id": "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": 240,
+              "y": -130,
+              "width": 200,
+              "height": 40
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 5
+              },
+              {
+                "x": 40,
+                "y": 5
+              },
+              {
+                "x": 40,
+                "y": 0
+              },
+              {
+                "x": 200,
+                "y": 0
+              },
+              {
+                "x": 200,
+                "y": 40
+              }
+            ],
+            "source": {
+              "direction": "Downright",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "target": {
+              "direction": "Up",
+              "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
+            },
+            "isManuallyLayouted": true,
+            "condition": "when_intent_matched",
+            "conditionValue": "Other"
+          },
+          "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e": {
+            "id": "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -380,
+              "y": -125,
+              "width": 200,
+              "height": 127.5
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 127.5
+              },
+              {
+                "x": 100,
+                "y": 127.5
+              },
+              {
+                "x": 100,
+                "y": 0
+              },
+              {
+                "x": 200,
+                "y": 0
+              }
+            ],
+            "source": {
+              "direction": "Upright",
+              "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
+            },
+            "target": {
+              "direction": "Downleft",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "isManuallyLayouted": false,
+            "condition": "auto",
+            "conditionValue": ""
+          },
+          "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32": {
+            "id": "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": 135,
+              "y": -100,
+              "width": 215,
+              "height": 40
+            },
+            "path": [
+              {
+                "x": 215,
+                "y": 27.5
+              },
+              {
+                "x": 175,
+                "y": 27.5
+              },
+              {
+                "x": 175,
+                "y": 40
+              },
+              {
+                "x": 0,
+                "y": 40
+              },
+              {
+                "x": 0,
+                "y": 0
+              }
+            ],
+            "source": {
+              "direction": "Upleft",
+              "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
+            },
+            "target": {
+              "direction": "Bottomright",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "isManuallyLayouted": false,
+            "condition": "auto",
+            "conditionValue": ""
+          },
+          "3564da62-bea0-4489-81b2-fda2effddd02": {
+            "id": "3564da62-bea0-4489-81b2-fda2effddd02",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -190,
+              "y": -100,
+              "width": 115,
+              "height": 277.5
+            },
+            "path": [
+              {
+                "x": 40,
+                "y": 277.5
+              },
+              {
+                "x": 0,
+                "y": 277.5
+              },
+              {
+                "x": 0,
+                "y": 115
+              },
+              {
+                "x": 115,
+                "y": 115
+              },
+              {
+                "x": 115,
+                "y": 0
+              }
+            ],
+            "source": {
+              "direction": "Upleft",
+              "element": "7610bbda-21ef-4637-a188-1da1352bea17"
+            },
+            "target": {
+              "direction": "Bottomleft",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "isManuallyLayouted": false,
+            "condition": "auto",
+            "conditionValue": ""
+          },
+          "b696a5f6-f328-42fb-bdbc-83569b2beb06": {
+            "id": "b696a5f6-f328-42fb-bdbc-83569b2beb06",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": 45,
+              "y": -100,
+              "width": 1,
+              "height": 230
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 0
+              },
+              {
+                "x": 0,
+                "y": 230
+              }
+            ],
+            "source": {
+              "direction": "Down",
+              "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+            },
+            "target": {
+              "direction": "Up",
+              "element": "7610bbda-21ef-4637-a188-1da1352bea17"
+            },
+            "isManuallyLayouted": false,
+            "condition": "when_intent_matched",
+            "conditionValue": "Nutrition_intent"
+          }
+        },
+        "assessments": {}
+      },
+      "personalizedAgentModel": {
+        "version": "3.0.0",
+        "type": "AgentDiagram",
+        "size": {
+          "width": 1980,
+          "height": 640
+        },
+        "interactive": {
+          "elements": {},
+          "relationships": {}
+        },
+        "elements": {
+          "6b718df7-70ef-4e1c-8c6b-c82133964f86": {
+            "id": "6b718df7-70ef-4e1c-8c6b-c82133964f86",
+            "name": "I want muscles",
+            "type": "AgentIntentBody",
+            "owner": "c383f8b0-d915-439b-8bde-18a30da80fa3",
+            "bounds": {
+              "x": -550,
+              "y": -300,
+              "width": 160,
+              "height": 30
+            }
+          },
+          "c383f8b0-d915-439b-8bde-18a30da80fa3": {
+            "id": "c383f8b0-d915-439b-8bde-18a30da80fa3",
+            "name": "Muscles_intent",
+            "type": "AgentIntent",
+            "owner": null,
+            "bounds": {
+              "x": -550,
+              "y": -300,
+              "width": 160,
+              "height": 100
+            },
+            "bodies": [
+              "6b718df7-70ef-4e1c-8c6b-c82133964f86"
+            ],
+            "intent_description": "Question about how to become muscular and which exercises to perform."
+          },
+          "192db72d-4d0e-49b0-b49c-5050fb0dbb68": {
+            "id": "192db72d-4d0e-49b0-b49c-5050fb0dbb68",
+            "name": "Which food to eat?",
+            "type": "AgentIntentBody",
+            "owner": "a009a9ba-7a03-4f79-9122-416d8b74a0bb",
+            "bounds": {
+              "x": -250,
+              "y": -300,
+              "width": 160,
+              "height": 30
+            }
+          },
+          "a009a9ba-7a03-4f79-9122-416d8b74a0bb": {
+            "id": "a009a9ba-7a03-4f79-9122-416d8b74a0bb",
+            "name": "Nutrition_intent",
+            "type": "AgentIntent",
+            "owner": null,
+            "bounds": {
+              "x": -250,
+              "y": -300,
+              "width": 160,
+              "height": 100
+            },
+            "bodies": [
+              "192db72d-4d0e-49b0-b49c-5050fb0dbb68"
+            ],
+            "intent_description": "Question about nutrition in gym."
+          },
+          "90d28305-378e-4bad-b3ea-61c3ddaa5921": {
+            "id": "90d28305-378e-4bad-b3ea-61c3ddaa5921",
+            "name": "Other",
+            "type": "AgentIntent",
+            "owner": null,
+            "bounds": {
+              "x": 50,
+              "y": -300,
+              "width": 160,
+              "height": 100
+            },
+            "bodies": [],
+            "intent_description": "Any question that does not fit in \"Muscles\" or \"Nutrition\""
+          },
+          "731e886c-9cef-4fa7-ba6d-72aa25c32d4f": {
+            "id": "731e886c-9cef-4fa7-ba6d-72aa25c32d4f",
+            "name": "",
+            "type": "StateInitialNode",
+            "owner": null,
+            "bounds": {
+              "x": -580,
+              "y": -60,
+              "width": 45,
+              "height": 45
+            }
+          },
+          "c10f03ca-2073-4002-8d1b-e42536008f4c": {
+            "id": "c10f03ca-2073-4002-8d1b-e42536008f4c",
+            "name": "Initial",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -280,
+              "y": -80,
+              "width": 160,
+              "height": 100
+            },
+            "bodies": [
+              "82783f5d-8ef3-47f7-8feb-9651bdf73d63"
+            ],
+            "fallbackBodies": []
+          },
+          "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8": {
+            "id": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+            "name": "Idle",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": 210,
+              "y": -80,
+              "width": 160,
+              "height": 100
+            },
+            "bodies": [
+              "d91b1fe8-cd6c-4b20-928c-70021c0f044d"
+            ],
+            "fallbackBodies": [
+              "10a044fe-f0bd-41e8-ae27-0f2c2afc2cac"
+            ]
+          },
+          "aa0bf687-2e08-4cba-aa98-335bcce5ecc7": {
+            "id": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+            "name": "TrainingPlan",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -280,
+              "y": 140,
+              "width": 160,
+              "height": 100
+            },
+            "bodies": [
+              "d55e541d-6530-44ad-8d86-0ae51039bd72",
+              "964f437d-ab33-4e0d-bd1c-e36387c879eb",
+              "31249e62-6b58-48fb-af98-e55090d683e1"
+            ],
+            "fallbackBodies": []
+          },
+          "110dac05-6c3a-4fd1-a747-6df88d09cf77": {
+            "id": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+            "name": "Nutrition",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": 210,
+              "y": 140,
+              "width": 160,
+              "height": 100
+            },
+            "bodies": [
+              "3fa5c3b5-3e12-4968-b16c-1f80a98693c1",
+              "5c6dad70-8209-4de6-ae7a-5a9747fada8a",
+              "ac38d464-9f06-48cf-b6c5-76e721298f92",
+              "49fc07e1-484c-4459-b5b9-b223c5d7b129",
+              "0bcfa6cb-74c0-43c8-867b-2fc966c53671"
+            ],
+            "fallbackBodies": []
+          },
+          "a22b9877-2809-426e-8b72-504ef7abcce0": {
+            "id": "a22b9877-2809-426e-8b72-504ef7abcce0",
+            "name": "OtherQuestions",
+            "type": "AgentState",
+            "owner": null,
+            "bounds": {
+              "x": -280,
+              "y": 360,
+              "width": 160,
+              "height": 100
+            },
+            "bodies": [
+              "3721c5e6-19b1-4811-8b00-17415913c3aa"
+            ],
+            "fallbackBodies": []
+          },
+          "82783f5d-8ef3-47f7-8feb-9651bdf73d63": {
+            "id": "82783f5d-8ef3-47f7-8feb-9651bdf73d63",
+            "name": "Hi, I am your buddy, the fitness agent.",
+            "type": "AgentStateBody",
+            "owner": "c10f03ca-2073-4002-8d1b-e42536008f4c",
+            "bounds": {
+              "x": -280,
+              "y": -80,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "d91b1fe8-cd6c-4b20-928c-70021c0f044d": {
+            "id": "d91b1fe8-cd6c-4b20-928c-70021c0f044d",
+            "name": "I am here to answer any questions regarding exercises, nutrition and recovery.",
+            "type": "AgentStateBody",
+            "owner": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+            "bounds": {
+              "x": 210,
+              "y": -80,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "10a044fe-f0bd-41e8-ae27-0f2c2afc2cac": {
+            "id": "10a044fe-f0bd-41e8-ae27-0f2c2afc2cac",
+            "name": "I focus on gym and fitness topics only dude.",
+            "type": "AgentStateFallbackBody",
+            "owner": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+            "bounds": {
+              "x": 210,
+              "y": -80,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "d55e541d-6530-44ad-8d86-0ae51039bd72": {
+            "id": "d55e541d-6530-44ad-8d86-0ae51039bd72",
+            "name": "Focus on accessible compound upper-body and core movements like bench press or machine chest press, overhead press, seated rows, lat pulldowns/assisted pull-ups, dips or triceps pushdowns, face pulls, and anti-rotation core work (e.g., Pallof press), using seated or strap-stabilized setups as needed.",
+            "type": "AgentStateBody",
+            "owner": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+            "bounds": {
+              "x": -280,
+              "y": 140,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "964f437d-ab33-4e0d-bd1c-e36387c879eb": {
+            "id": "964f437d-ab33-4e0d-bd1c-e36387c879eb",
+            "name": "Train 3–5 times per week, progressively increasing resistance on upper-body and core-focused exercises while eating enough protein and calories to support growth; balance pushing and pulling to protect your shoulders and allow adequate recovery.",
+            "type": "AgentStateBody",
+            "owner": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+            "bounds": {
+              "x": -280,
+              "y": 140,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "31249e62-6b58-48fb-af98-e55090d683e1": {
+            "id": "31249e62-6b58-48fb-af98-e55090d683e1",
+            "name": "Get good sleep and stay consistent—muscle comes from steady effort over time.",
+            "type": "AgentStateBody",
+            "owner": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+            "bounds": {
+              "x": -280,
+              "y": 140,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "3fa5c3b5-3e12-4968-b16c-1f80a98693c1": {
+            "id": "3fa5c3b5-3e12-4968-b16c-1f80a98693c1",
+            "name": "Nutrition basics: Eat mostly whole foods (lean protein, vegetables, fruits, whole grains, healthy fats). Protein: ~1.6–2.2 g per kg of body weight daily..",
+            "type": "AgentStateBody",
+            "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+            "bounds": {
+              "x": 210,
+              "y": 140,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "5c6dad70-8209-4de6-ae7a-5a9747fada8a": {
+            "id": "5c6dad70-8209-4de6-ae7a-5a9747fada8a",
+            "name": "Match calories to your goal: slight surplus to gain muscle, deficit to lose fat, maintenance to stay the same.",
+            "type": "AgentStateBody",
+            "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+            "bounds": {
+              "x": 210,
+              "y": 140,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "ac38d464-9f06-48cf-b6c5-76e721298f92": {
+            "id": "ac38d464-9f06-48cf-b6c5-76e721298f92",
+            "name": "Carbs fuel training; fats support hormones.",
+            "type": "AgentStateBody",
+            "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+            "bounds": {
+              "x": 210,
+              "y": 140,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "49fc07e1-484c-4459-b5b9-b223c5d7b129": {
+            "id": "49fc07e1-484c-4459-b5b9-b223c5d7b129",
+            "name": "Drink plenty of water and limit ultra-processed foods and alcohol.",
+            "type": "AgentStateBody",
+            "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+            "bounds": {
+              "x": 210,
+              "y": 140,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "0bcfa6cb-74c0-43c8-867b-2fc966c53671": {
+            "id": "0bcfa6cb-74c0-43c8-867b-2fc966c53671",
+            "name": "Be consistent — results come from habits, not perfection",
+            "type": "AgentStateBody",
+            "owner": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+            "bounds": {
+              "x": 210,
+              "y": 140,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "text"
+          },
+          "3721c5e6-19b1-4811-8b00-17415913c3aa": {
+            "id": "3721c5e6-19b1-4811-8b00-17415913c3aa",
+            "name": "AI response 🪄",
+            "type": "AgentStateBody",
+            "owner": "a22b9877-2809-426e-8b72-504ef7abcce0",
+            "bounds": {
+              "x": -280,
+              "y": 360,
+              "width": 159,
+              "height": 30
+            },
+            "replyType": "llm"
+          }
+        },
+        "relationships": {
+          "7ac61ff1-1e47-4e69-8d38-8fd9be6ab17d": {
+            "id": "7ac61ff1-1e47-4e69-8d38-8fd9be6ab17d",
+            "name": "",
+            "type": "AgentStateTransitionInit",
+            "owner": null,
+            "source": {
+              "direction": "Right",
+              "element": "731e886c-9cef-4fa7-ba6d-72aa25c32d4f",
+              "bounds": {
+                "x": -535,
+                "y": -37.5,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Left",
+              "element": "c10f03ca-2073-4002-8d1b-e42536008f4c",
+              "bounds": {
+                "x": -280,
+                "y": -45,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "bounds": {
+              "x": -535,
+              "y": -37.5,
+              "width": 255,
+              "height": 1
+            },
+            "path": [
+              {
+                "x": -535,
+                "y": -37.5
+              },
+              {
+                "x": -280,
+                "y": -37.5
+              }
+            ],
+            "isManuallyLayouted": false
+          },
+          "b3c5c9c2-81fc-4a12-985e-9e885ef6e9d0": {
+            "id": "b3c5c9c2-81fc-4a12-985e-9e885ef6e9d0",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -130,
+              "y": -40,
+              "width": 350,
+              "height": 20
+            },
+            "path": [
+              {
+                "x": -120,
+                "y": -30
+              },
+              {
+                "x": 45,
+                "y": -30
+              },
+              {
+                "x": 45,
+                "y": -30
+              },
+              {
+                "x": 210,
+                "y": -30
+              }
+            ],
+            "source": {
+              "direction": "Right",
+              "element": "c10f03ca-2073-4002-8d1b-e42536008f4c",
+              "bounds": {
+                "x": -120,
+                "y": -30,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Left",
+              "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+              "bounds": {
+                "x": 210,
+                "y": -30,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "isManuallyLayouted": false,
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "event": "None",
+              "condition": []
+            }
+          },
+          "48858dc4-d788-4f13-858b-3010ae2f4ead": {
+            "id": "48858dc4-d788-4f13-858b-3010ae2f4ead",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -130,
+              "y": -40,
+              "width": 350,
+              "height": 240
+            },
+            "path": [
+              {
+                "x": 210,
+                "y": -30
+              },
+              {
+                "x": 45,
+                "y": -30
+              },
+              {
+                "x": 45,
+                "y": 190
+              },
+              {
+                "x": -120,
+                "y": 190
+              }
+            ],
+            "source": {
+              "direction": "Left",
+              "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+              "bounds": {
+                "x": 210,
+                "y": -30,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Right",
+              "element": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+              "bounds": {
+                "x": -120,
+                "y": 190,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "isManuallyLayouted": false,
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "when_intent_matched",
+              "intentName": "Muscles_intent"
+            },
+            "custom": {
+              "event": "None",
+              "condition": []
+            }
+          },
+          "425913e8-31ab-4ac5-908a-4f35fb7d732d": {
+            "id": "425913e8-31ab-4ac5-908a-4f35fb7d732d",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -130,
+              "y": -40,
+              "width": 350,
+              "height": 460
+            },
+            "path": [
+              {
+                "x": 210,
+                "y": -30
+              },
+              {
+                "x": 45,
+                "y": -30
+              },
+              {
+                "x": 45,
+                "y": 410
+              },
+              {
+                "x": -120,
+                "y": 410
+              }
+            ],
+            "source": {
+              "direction": "Left",
+              "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+              "bounds": {
+                "x": 210,
+                "y": -30,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Right",
+              "element": "a22b9877-2809-426e-8b72-504ef7abcce0",
+              "bounds": {
+                "x": -120,
+                "y": 410,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "isManuallyLayouted": false,
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "when_intent_matched",
+              "intentName": "Other"
+            },
+            "custom": {
+              "event": "None",
+              "condition": []
+            }
+          },
+          "9f2ff8c7-b6dc-4246-b6ff-f1b1d1293a60": {
+            "id": "9f2ff8c7-b6dc-4246-b6ff-f1b1d1293a60",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": 280,
+              "y": 10,
+              "width": 20,
+              "height": 140
+            },
+            "path": [
+              {
+                "x": 290,
+                "y": 20
+              },
+              {
+                "x": 290,
+                "y": 80
+              },
+              {
+                "x": 290,
+                "y": 80
+              },
+              {
+                "x": 290,
+                "y": 140
+              }
+            ],
+            "source": {
+              "direction": "Down",
+              "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+              "bounds": {
+                "x": 290,
+                "y": 20,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Up",
+              "element": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+              "bounds": {
+                "x": 290,
+                "y": 140,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "isManuallyLayouted": false,
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "when_intent_matched",
+              "intentName": "Nutrition_intent"
+            },
+            "custom": {
+              "event": "None",
+              "condition": []
+            }
+          },
+          "a5bf1da3-2426-43fb-827c-cc13ee896460": {
+            "id": "a5bf1da3-2426-43fb-827c-cc13ee896460",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -130,
+              "y": -40,
+              "width": 350,
+              "height": 240
+            },
+            "path": [
+              {
+                "x": -120,
+                "y": 190
+              },
+              {
+                "x": 45,
+                "y": 190
+              },
+              {
+                "x": 45,
+                "y": -30
+              },
+              {
+                "x": 210,
+                "y": -30
+              }
+            ],
+            "source": {
+              "direction": "Right",
+              "element": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
+              "bounds": {
+                "x": -120,
+                "y": 190,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Left",
+              "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+              "bounds": {
+                "x": 210,
+                "y": -30,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "isManuallyLayouted": false,
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "event": "None",
+              "condition": []
+            }
+          },
+          "25914e9b-e4dd-461f-9b4a-10229b76b618": {
+            "id": "25914e9b-e4dd-461f-9b4a-10229b76b618",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": 280,
+              "y": 10,
+              "width": 20,
+              "height": 140
+            },
+            "path": [
+              {
+                "x": 290,
+                "y": 140
+              },
+              {
+                "x": 290,
+                "y": 80
+              },
+              {
+                "x": 290,
+                "y": 80
+              },
+              {
+                "x": 290,
+                "y": 20
+              }
+            ],
+            "source": {
+              "direction": "Up",
+              "element": "110dac05-6c3a-4fd1-a747-6df88d09cf77",
+              "bounds": {
+                "x": 290,
+                "y": 140,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Down",
+              "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+              "bounds": {
+                "x": 290,
+                "y": 20,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "isManuallyLayouted": false,
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "event": "None",
+              "condition": []
+            }
+          },
+          "0efab80b-2e8c-45a3-a998-78ccd579fbd9": {
+            "id": "0efab80b-2e8c-45a3-a998-78ccd579fbd9",
+            "name": "",
+            "type": "AgentStateTransition",
+            "owner": null,
+            "bounds": {
+              "x": -130,
+              "y": -40,
+              "width": 350,
+              "height": 460
+            },
+            "path": [
+              {
+                "x": -120,
+                "y": 410
+              },
+              {
+                "x": 45,
+                "y": 410
+              },
+              {
+                "x": 45,
+                "y": -30
+              },
+              {
+                "x": 210,
+                "y": -30
+              }
+            ],
+            "source": {
+              "direction": "Right",
+              "element": "a22b9877-2809-426e-8b72-504ef7abcce0",
+              "bounds": {
+                "x": -120,
+                "y": 410,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Left",
+              "element": "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8",
+              "bounds": {
+                "x": 210,
+                "y": -30,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "isManuallyLayouted": false,
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "event": "None",
+              "condition": []
+            }
+          },
+          "0b385217-ea53-481d-8222-52dda332e351": {
+            "id": "0b385217-ea53-481d-8222-52dda332e351",
+            "name": "",
+            "type": "AgentStateTransitionInit",
+            "owner": null,
+            "source": {
+              "direction": "Right",
+              "element": "731e886c-9cef-4fa7-ba6d-72aa25c32d4f",
+              "bounds": {
+                "x": -535,
+                "y": -37.5,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "target": {
+              "direction": "Left",
+              "element": "c10f03ca-2073-4002-8d1b-e42536008f4c",
+              "bounds": {
+                "x": -280,
+                "y": -45,
+                "width": 0,
+                "height": 0
+              }
+            },
+            "bounds": {
+              "x": -535,
+              "y": -37.5,
+              "width": 255,
+              "height": 1
+            },
+            "path": [
+              {
+                "x": -535,
+                "y": -37.5
+              },
+              {
+                "x": -280,
+                "y": -37.5
+              }
+            ],
+            "isManuallyLayouted": false
+          }
+        },
+        "assessments": {}
+      }
+    }
+  ],
+  "userProfiles": [
+    {
+      "id": "b8d65359-7826-4ce3-a8dc-da01ce8865d7",
+      "name": "Teenager",
+      "savedAt": "2026-05-06T13:45:22.587Z",
+      "model": {
+        "version": "3.0.0",
+        "type": "UserDiagram",
+        "size": {
+          "width": 880,
+          "height": 700
+        },
+        "interactive": {
+          "elements": {},
+          "relationships": {}
+        },
+        "elements": {
+          "8b66ecde-05bb-43f9-a5ac-b1e1279e8cb3": {
+            "id": "8b66ecde-05bb-43f9-a5ac-b1e1279e8cb3",
+            "name": "user_1",
+            "type": "UserModelName",
+            "owner": null,
+            "bounds": {
+              "x": -420,
+              "y": -330,
+              "width": 106,
+              "height": 146
+            },
+            "icon": "7a88f848-8622-4bea-a17a-ff49a0dfdb96",
+            "attributes": [],
+            "methods": [],
+            "classId": "ce1e2d59-3d7c-4753-adb7-09ca96797f5a",
+            "className": "User"
+          },
+          "7a88f848-8622-4bea-a17a-ff49a0dfdb96": {
+            "id": "7a88f848-8622-4bea-a17a-ff49a0dfdb96",
+            "name": "icon",
+            "type": "UserModelIcon",
+            "owner": "8b66ecde-05bb-43f9-a5ac-b1e1279e8cb3",
+            "bounds": {
+              "x": -419.5,
+              "y": -284.5,
+              "width": 106,
+              "height": 96
+            },
+            "icon": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"96\" height=\"96\" viewBox=\"0 0 20 20\"> \t<g fill=\"none\"> \t\t<path fill=\"url(#fluentColorPerson200)\" d=\"M5.009 11A2 2 0 0 0 3 13c0 1.691.833 2.966 2.135 3.797C6.417 17.614 8.145 18 10 18s3.583-.386 4.865-1.203C16.167 15.967 17 14.69 17 13a2 2 0 0 0-2-2z\" /> \t\t<path fill=\"url(#fluentColorPerson201)\" d=\"M5.009 11A2 2 0 0 0 3 13c0 1.691.833 2.966 2.135 3.797C6.417 17.614 8.145 18 10 18s3.583-.386 4.865-1.203C16.167 15.967 17 14.69 17 13a2 2 0 0 0-2-2z\" /> \t\t<path fill=\"url(#fluentColorPerson202)\" d=\"M10 2a4 4 0 1 0 0 8a4 4 0 0 0 0-8\" /> \t\t<defs> \t\t\t<linearGradient id=\"fluentColorPerson200\" x1=\"6.329\" x2=\"8.591\" y1=\"11.931\" y2=\"19.153\" gradientUnits=\"userSpaceOnUse\"> \t\t\t\t<stop offset=\".125\" stop-color=\"#5baad0\" /> \t\t\t\t<stop offset=\"1\" stop-color=\"#282233\" /> \t\t\t</linearGradient> \t\t\t<linearGradient id=\"fluentColorPerson201\" x1=\"10\" x2=\"13.167\" y1=\"10.167\" y2=\"22\" gradientUnits=\"userSpaceOnUse\"> \t\t\t\t<stop stop-color=\"#537fff\" stop-opacity=\"0\" /> \t\t\t\t<stop offset=\"1\" stop-color=\"#e362f8\" /> \t\t\t</linearGradient> \t\t\t<linearGradient id=\"fluentColorPerson202\" x1=\"7.902\" x2=\"11.979\" y1=\"3.063\" y2=\"9.574\" gradientUnits=\"userSpaceOnUse\"> \t\t\t\t<stop offset=\".125\" stop-color=\"#5baad0\" /> \t\t\t\t<stop offset=\"1\" stop-color=\"#282233\" /> \t\t\t</linearGradient> \t\t</defs> \t</g> </svg>"
+          },
+          "61f3399d-3642-4d70-8170-fa67b7184867": {
+            "id": "61f3399d-3642-4d70-8170-fa67b7184867",
+            "name": "personal_Information_1",
+            "type": "UserModelName",
+            "owner": null,
+            "bounds": {
+              "x": -320,
+              "y": -50,
+              "width": 192.11666870117188,
+              "height": 146
+            },
+            "icon": "07c9ec2d-1fad-4ce3-bcb2-00f4c4694543",
+            "attributes": [
+              "b4ecabb3-552e-47a3-9f12-5f34cd7737b2",
+              "4377e8bc-3ba6-4b32-bb33-085db4871029",
+              "9d85759c-def2-4e25-9a61-37d59c3aafc4",
+              "361bd580-2082-4248-9876-30ce806c0aa9",
+              "ee5c35bc-53df-4a4a-927b-0820161fb1cb",
+              "faf495f9-a9e3-40d3-8767-b205a6682e76"
+            ],
+            "methods": [],
+            "classId": "5b6e9989-bda3-4434-8fac-89f649dc05d3",
+            "className": "Personal_Information"
+          },
+          "b4ecabb3-552e-47a3-9f12-5f34cd7737b2": {
+            "id": "b4ecabb3-552e-47a3-9f12-5f34cd7737b2",
+            "name": "age < 18",
+            "type": "UserModelAttribute",
+            "owner": "61f3399d-3642-4d70-8170-fa67b7184867",
+            "bounds": {
+              "x": -320,
+              "y": -50,
+              "width": 120,
+              "height": 10
+            },
+            "code": "",
+            "visibility": "public",
+            "attributeType": "str",
+            "implementationType": "none",
+            "stateMachineId": "",
+            "quantumCircuitId": "",
+            "isOptional": false,
+            "isDerived": false,
+            "isId": false,
+            "isExternalId": false,
+            "attributeId": "8f52769c-e1f5-42c6-9f54-4072b2a4ff8a",
+            "attributeOperator": "<"
+          },
+          "4377e8bc-3ba6-4b32-bb33-085db4871029": {
+            "id": "4377e8bc-3ba6-4b32-bb33-085db4871029",
+            "name": "lastName = ",
+            "type": "UserModelAttribute",
+            "owner": "61f3399d-3642-4d70-8170-fa67b7184867",
+            "bounds": {
+              "x": -320,
+              "y": -50,
+              "width": 150,
+              "height": 10
+            },
+            "code": "",
+            "visibility": "public",
+            "attributeType": "str",
+            "implementationType": "none",
+            "stateMachineId": "",
+            "quantumCircuitId": "",
+            "isOptional": false,
+            "isDerived": false,
+            "isId": false,
+            "isExternalId": false,
+            "attributeId": "199a7c8e-f49f-4b6a-bd16-849ab546ae8b",
+            "attributeOperator": "=="
+          },
+          "9d85759c-def2-4e25-9a61-37d59c3aafc4": {
+            "id": "9d85759c-def2-4e25-9a61-37d59c3aafc4",
+            "name": "firstName = ",
+            "type": "UserModelAttribute",
+            "owner": "61f3399d-3642-4d70-8170-fa67b7184867",
+            "bounds": {
+              "x": -320,
+              "y": -50,
+              "width": 150,
+              "height": 10
+            },
+            "code": "",
+            "visibility": "public",
+            "attributeType": "str",
+            "implementationType": "none",
+            "stateMachineId": "",
+            "quantumCircuitId": "",
+            "isOptional": false,
+            "isDerived": false,
+            "isId": false,
+            "isExternalId": false,
+            "attributeId": "6e156ae9-ca13-42f2-a3c8-bfae46ab38c4",
+            "attributeOperator": "=="
+          },
+          "361bd580-2082-4248-9876-30ce806c0aa9": {
+            "id": "361bd580-2082-4248-9876-30ce806c0aa9",
+            "name": "nationality_iso3166 = ",
+            "type": "UserModelAttribute",
+            "owner": "61f3399d-3642-4d70-8170-fa67b7184867",
+            "bounds": {
+              "x": -320,
+              "y": -50,
+              "width": 220,
+              "height": 10
+            },
+            "code": "",
+            "visibility": "public",
+            "attributeType": "str",
+            "implementationType": "none",
+            "stateMachineId": "",
+            "quantumCircuitId": "",
+            "isOptional": false,
+            "isDerived": false,
+            "isId": false,
+            "isExternalId": false,
+            "attributeId": "e21d4af5-77da-46b6-8059-8f0fc152ee8e",
+            "attributeOperator": "=="
+          },
+          "ee5c35bc-53df-4a4a-927b-0820161fb1cb": {
+            "id": "ee5c35bc-53df-4a4a-927b-0820161fb1cb",
+            "name": "address = ",
+            "type": "UserModelAttribute",
+            "owner": "61f3399d-3642-4d70-8170-fa67b7184867",
+            "bounds": {
+              "x": -320,
+              "y": -50,
+              "width": 140,
+              "height": 10
+            },
+            "code": "",
+            "visibility": "public",
+            "attributeType": "str",
+            "implementationType": "none",
+            "stateMachineId": "",
+            "quantumCircuitId": "",
+            "isOptional": false,
+            "isDerived": false,
+            "isId": false,
+            "isExternalId": false,
+            "attributeId": "adffe2ad-db08-4804-9a9e-28f75812efdc",
+            "attributeOperator": "=="
+          },
+          "faf495f9-a9e3-40d3-8767-b205a6682e76": {
+            "id": "faf495f9-a9e3-40d3-8767-b205a6682e76",
+            "name": "gender = ",
+            "type": "UserModelAttribute",
+            "owner": "61f3399d-3642-4d70-8170-fa67b7184867",
+            "bounds": {
+              "x": -320,
+              "y": -50,
+              "width": 130,
+              "height": 10
+            },
+            "code": "",
+            "visibility": "public",
+            "attributeType": "str",
+            "implementationType": "none",
+            "stateMachineId": "",
+            "quantumCircuitId": "",
+            "isOptional": false,
+            "isDerived": false,
+            "isId": false,
+            "isExternalId": false,
+            "attributeId": "5acf56a9-041c-41c9-8841-01d1885ddb12",
+            "attributeOperator": "=="
+          },
+          "07c9ec2d-1fad-4ce3-bcb2-00f4c4694543": {
+            "id": "07c9ec2d-1fad-4ce3-bcb2-00f4c4694543",
+            "name": "icon",
+            "type": "UserModelIcon",
+            "owner": "61f3399d-3642-4d70-8170-fa67b7184867",
+            "bounds": {
+              "x": -319.5,
+              "y": -4.5,
+              "width": 192.11666870117188,
+              "height": 96
+            },
+            "icon": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"128\" height=\"96\" viewBox=\"0 0 2048 1536\"> \t<path fill=\"#6798bf\" d=\"M896 1084q0-54-7.5-100.5t-24.5-90t-51-68.5t-81-25q-64 64-156 64t-156-64q-47 0-81 25t-51 68.5t-24.5 90T256 1084q0 55 31.5 93.5T363 1216h426q44 0 75.5-38.5T896 1084M768 640q0-80-56-136t-136-56t-136 56t-56 136t56 136t136 56t136-56t56-136m1024 480v-64q0-14-9-23t-23-9h-704q-14 0-23 9t-9 23v64q0 14 9 23t23 9h704q14 0 23-9t9-23m-384-256v-64q0-14-9-23t-23-9h-320q-14 0-23 9t-9 23v64q0 14 9 23t23 9h320q14 0 23-9t9-23m384 0v-64q0-14-9-23t-23-9h-192q-14 0-23 9t-9 23v64q0 14 9 23t23 9h192q14 0 23-9t9-23m0-256v-64q0-14-9-23t-23-9h-704q-14 0-23 9t-9 23v64q0 14 9 23t23 9h704q14 0 23-9t9-23M128 256h1792v-96q0-14-9-23t-23-9H160q-14 0-23 9t-9 23zm1920-96v1216q0 66-47 113t-113 47H160q-66 0-113-47T0 1376V160Q0 94 47 47T160 0h1728q66 0 113 47t47 113\" /> </svg>"
+          }
+        },
+        "relationships": {
+          "7092694b-c0de-471d-97f2-a0b9b689dd8c": {
+            "id": "7092694b-c0de-471d-97f2-a0b9b689dd8c",
+            "name": "",
+            "type": "ObjectLink",
+            "owner": null,
+            "bounds": {
+              "x": -360,
+              "y": -184,
+              "width": 40,
+              "height": 170.5
+            },
+            "path": [
+              {
+                "x": 19.5,
+                "y": 0
+              },
+              {
+                "x": 19.5,
+                "y": 40
+              },
+              {
+                "x": 0,
+                "y": 40
+              },
+              {
+                "x": 0,
+                "y": 170.5
+              },
+              {
+                "x": 40,
+                "y": 170.5
+              }
+            ],
+            "source": {
+              "direction": "Bottomright",
+              "element": "8b66ecde-05bb-43f9-a5ac-b1e1279e8cb3"
+            },
+            "target": {
+              "direction": "Upleft",
+              "element": "61f3399d-3642-4d70-8170-fa67b7184867"
+            },
+            "isManuallyLayouted": false
+          }
+        },
+        "assessments": {}
+      }
+    },
+    {
+      "id": "8892dc19-bacc-4de4-8f27-9ae32842dbbf",
+      "name": "ParaplegicUser",
+      "savedAt": "2026-05-06T13:49:25.848Z",
+      "model": {
+        "version": "3.0.0",
+        "type": "UserDiagram",
+        "size": {
+          "width": 920,
+          "height": 363.5
+        },
+        "interactive": {
+          "elements": {},
+          "relationships": {}
+        },
+        "elements": {
+          "488449e0-5ad0-44db-a739-d505876ddfcb": {
+            "id": "488449e0-5ad0-44db-a739-d505876ddfcb",
+            "name": "user_1",
+            "type": "UserModelName",
+            "owner": null,
+            "bounds": {
+              "x": -440,
+              "y": -160,
+              "width": 106,
+              "height": 146
+            },
+            "icon": "c41ce2a8-2a01-4f1e-9f4d-25908a7f82ea",
+            "attributes": [],
+            "methods": [],
+            "classId": "ce1e2d59-3d7c-4753-adb7-09ca96797f5a",
+            "className": "User"
+          },
+          "c41ce2a8-2a01-4f1e-9f4d-25908a7f82ea": {
+            "id": "c41ce2a8-2a01-4f1e-9f4d-25908a7f82ea",
+            "name": "icon",
+            "type": "UserModelIcon",
+            "owner": "488449e0-5ad0-44db-a739-d505876ddfcb",
+            "bounds": {
+              "x": -439.5,
+              "y": -114.5,
+              "width": 106,
+              "height": 96
+            },
+            "icon": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"96\" height=\"96\" viewBox=\"0 0 20 20\"> \t<g fill=\"none\"> \t\t<path fill=\"url(#fluentColorPerson200)\" d=\"M5.009 11A2 2 0 0 0 3 13c0 1.691.833 2.966 2.135 3.797C6.417 17.614 8.145 18 10 18s3.583-.386 4.865-1.203C16.167 15.967 17 14.69 17 13a2 2 0 0 0-2-2z\" /> \t\t<path fill=\"url(#fluentColorPerson201)\" d=\"M5.009 11A2 2 0 0 0 3 13c0 1.691.833 2.966 2.135 3.797C6.417 17.614 8.145 18 10 18s3.583-.386 4.865-1.203C16.167 15.967 17 14.69 17 13a2 2 0 0 0-2-2z\" /> \t\t<path fill=\"url(#fluentColorPerson202)\" d=\"M10 2a4 4 0 1 0 0 8a4 4 0 0 0 0-8\" /> \t\t<defs> \t\t\t<linearGradient id=\"fluentColorPerson200\" x1=\"6.329\" x2=\"8.591\" y1=\"11.931\" y2=\"19.153\" gradientUnits=\"userSpaceOnUse\"> \t\t\t\t<stop offset=\".125\" stop-color=\"#5baad0\" /> \t\t\t\t<stop offset=\"1\" stop-color=\"#282233\" /> \t\t\t</linearGradient> \t\t\t<linearGradient id=\"fluentColorPerson201\" x1=\"10\" x2=\"13.167\" y1=\"10.167\" y2=\"22\" gradientUnits=\"userSpaceOnUse\"> \t\t\t\t<stop stop-color=\"#537fff\" stop-opacity=\"0\" /> \t\t\t\t<stop offset=\"1\" stop-color=\"#e362f8\" /> \t\t\t</linearGradient> \t\t\t<linearGradient id=\"fluentColorPerson202\" x1=\"7.902\" x2=\"11.979\" y1=\"3.063\" y2=\"9.574\" gradientUnits=\"userSpaceOnUse\"> \t\t\t\t<stop offset=\".125\" stop-color=\"#5baad0\" /> \t\t\t\t<stop offset=\"1\" stop-color=\"#282233\" /> \t\t\t</linearGradient> \t\t</defs> \t</g> </svg>"
+          },
+          "7b9e7742-9b5f-4ba6-8538-2204e16c29c8": {
+            "id": "7b9e7742-9b5f-4ba6-8538-2204e16c29c8",
+            "name": "accessibility_1",
+            "type": "UserModelName",
+            "owner": null,
+            "bounds": {
+              "x": -215.5,
+              "y": -83.5,
+              "width": 127.16666412353516,
+              "height": 146
+            },
+            "icon": "ae92fda6-2f7b-4d4e-98fe-093e27a57e04",
+            "attributes": [],
+            "methods": [],
+            "classId": "8ccd65ae-e26d-4d7a-bcd0-ff21a2e2e076",
+            "className": "Accessibility"
+          },
+          "ae92fda6-2f7b-4d4e-98fe-093e27a57e04": {
+            "id": "ae92fda6-2f7b-4d4e-98fe-093e27a57e04",
+            "name": "icon",
+            "type": "UserModelIcon",
+            "owner": "7b9e7742-9b5f-4ba6-8538-2204e16c29c8",
+            "bounds": {
+              "x": -215,
+              "y": -38,
+              "width": 127.16666412353516,
+              "height": 96
+            },
+            "icon": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"96\" height=\"96\" viewBox=\"0 0 16 16\"> \t<path fill=\"#41779a\" d=\"M8 4.5A1.75 1.75 0 1 0 8 1a1.75 1.75 0 0 0 0 3.5M4.198 3.115a1.6 1.6 0 0 0-2.076.873a1.58 1.58 0 0 0 .87 2.07l1.695.685A.5.5 0 0 1 5 7.206V9.13a.5.5 0 0 1-.058.234l-1.755 3.3a1.591 1.591 0 1 0 2.81 1.495l1.783-3.353a.25.25 0 0 1 .441 0l1.783 3.353a1.591 1.591 0 1 0 2.81-1.494L11.06 9.362a.5.5 0 0 1-.06-.235v-1.92a.5.5 0 0 1 .313-.464l1.695-.685a1.58 1.58 0 0 0 .87-2.07a1.6 1.6 0 0 0-2.076-.873l-.781.316c-.256.103-.44.3-.545.518a2.75 2.75 0 0 1-4.952 0a1.05 1.05 0 0 0-.545-.518z\" /> </svg>"
+          },
+          "5df48dc0-89d1-4b15-9444-a27668a89966": {
+            "id": "5df48dc0-89d1-4b15-9444-a27668a89966",
+            "name": "disability_1",
+            "type": "UserModelName",
+            "owner": null,
+            "bounds": {
+              "x": -61.5,
+              "y": -18.5,
+              "width": 106,
+              "height": 146
+            },
+            "icon": "a9e24c06-767a-4fb4-9cce-f3b22a8de045",
+            "attributes": [
+              "01d21950-b905-4a6e-a998-3b11e41f134c",
+              "de95a359-aa2c-4ddb-9bc9-21816c6bc510",
+              "4bde7832-5113-4458-9ab2-b4f7c8804dfb"
+            ],
+            "methods": [],
+            "classId": "b099bc5c-c80c-4143-bf86-b75a060d4d93",
+            "className": "Disability"
+          },
+          "01d21950-b905-4a6e-a998-3b11e41f134c": {
+            "id": "01d21950-b905-4a6e-a998-3b11e41f134c",
+            "name": "name == Paraplegia",
+            "type": "UserModelAttribute",
+            "owner": "5df48dc0-89d1-4b15-9444-a27668a89966",
+            "bounds": {
+              "x": -61.5,
+              "y": -18.5,
+              "width": 210,
+              "height": 10
+            },
+            "code": "",
+            "visibility": "public",
+            "attributeType": "str",
+            "implementationType": "none",
+            "stateMachineId": "",
+            "quantumCircuitId": "",
+            "isOptional": false,
+            "isDerived": false,
+            "isId": false,
+            "isExternalId": false,
+            "attributeId": "cb96a3aa-f446-4b1a-b5e9-c494668d5df1",
+            "attributeOperator": "=="
+          },
+          "de95a359-aa2c-4ddb-9bc9-21816c6bc510": {
+            "id": "de95a359-aa2c-4ddb-9bc9-21816c6bc510",
+            "name": "description == cannot use lower body",
+            "type": "UserModelAttribute",
+            "owner": "5df48dc0-89d1-4b15-9444-a27668a89966",
+            "bounds": {
+              "x": -61.5,
+              "y": -18.5,
+              "width": 330,
+              "height": 10
+            },
+            "code": "",
+            "visibility": "public",
+            "attributeType": "str",
+            "implementationType": "none",
+            "stateMachineId": "",
+            "quantumCircuitId": "",
+            "isOptional": false,
+            "isDerived": false,
+            "isId": false,
+            "isExternalId": false,
+            "attributeId": "9eb4de82-d6a9-46f6-94bc-1532d8774103",
+            "attributeOperator": "=="
+          },
+          "4bde7832-5113-4458-9ab2-b4f7c8804dfb": {
+            "id": "4bde7832-5113-4458-9ab2-b4f7c8804dfb",
+            "name": "affects == Mobility",
+            "type": "UserModelAttribute",
+            "owner": "5df48dc0-89d1-4b15-9444-a27668a89966",
+            "bounds": {
+              "x": -61.5,
+              "y": -18.5,
+              "width": 190,
+              "height": 10
+            },
+            "code": "",
+            "visibility": "public",
+            "attributeType": "str",
+            "implementationType": "none",
+            "stateMachineId": "",
+            "quantumCircuitId": "",
+            "isOptional": false,
+            "isDerived": false,
+            "isId": false,
+            "isExternalId": false,
+            "attributeId": "82c62904-19ae-45a0-b62a-60791bd696ee",
+            "attributeOperator": "=="
+          },
+          "a9e24c06-767a-4fb4-9cce-f3b22a8de045": {
+            "id": "a9e24c06-767a-4fb4-9cce-f3b22a8de045",
+            "name": "icon",
+            "type": "UserModelIcon",
+            "owner": "5df48dc0-89d1-4b15-9444-a27668a89966",
+            "bounds": {
+              "x": -61,
+              "y": 27,
+              "width": 106,
+              "height": 96
+            },
+            "icon": "<svg xmlns='http://www.w3.org/2000/svg' width='96' height='96' viewBox='0 0 24 24'> <g fill='none' stroke='#1e4b72' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5'><path d='M19.5 18h-1.323c-.328 0-.492 0-.619-.086s-.188-.238-.31-.543l-.497-1.242c-.121-.305-.182-.457-.31-.543c-.126-.086-.29-.086-.618-.086H13.5c-.471 0-.707 0-.854-.146c-.146-.147-.146-.383-.146-.854v-4m0-2.5v2.5m0 0h3.889M12.5 6a2 2 0 1 1 0-4a2 2 0 0 1 0 4' /><path d='M9.558 10c-2.87.48-5.058 2.964-5.058 5.958C4.5 19.295 7.217 22 10.57 22a6.07 6.07 0 0 0 4.93-2.517' /></g></svg>"
+          }
+        },
+        "relationships": {
+          "f3a88064-249c-4f0b-9fb8-9d8dcec56094": {
+            "id": "f3a88064-249c-4f0b-9fb8-9d8dcec56094",
+            "name": "",
+            "type": "ObjectLink",
+            "owner": null,
+            "bounds": {
+              "x": -387,
+              "y": -161.75,
+              "width": 235.08333206176758,
+              "height": 187.75
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 147.75
+              },
+              {
+                "x": 0,
+                "y": 187.75
+              },
+              {
+                "x": 93,
+                "y": 187.75
+              },
+              {
+                "x": 93,
+                "y": 0
+              },
+              {
+                "x": 235.08333206176758,
+                "y": 0
+              },
+              {
+                "x": 235.08333206176758,
+                "y": 78.25
+              }
+            ],
+            "source": {
+              "direction": "Down",
+              "element": "488449e0-5ad0-44db-a739-d505876ddfcb"
+            },
+            "target": {
+              "direction": "Up",
+              "element": "7b9e7742-9b5f-4ba6-8538-2204e16c29c8"
+            },
+            "isManuallyLayouted": false
+          },
+          "6f2a9605-d378-4737-82b8-eab065e12395": {
+            "id": "6f2a9605-d378-4737-82b8-eab065e12395",
+            "name": "",
+            "type": "ObjectLink",
+            "owner": null,
+            "bounds": {
+              "x": -151.91666793823242,
+              "y": -91,
+              "width": 143.41666793823242,
+              "height": 193.5
+            },
+            "path": [
+              {
+                "x": 0,
+                "y": 153.5
+              },
+              {
+                "x": 0,
+                "y": 193.5
+              },
+              {
+                "x": 103.58333206176758,
+                "y": 193.5
+              },
+              {
+                "x": 103.58333206176758,
+                "y": 0
+              },
+              {
+                "x": 143.41666793823242,
+                "y": 0
+              },
+              {
+                "x": 143.41666793823242,
+                "y": 72.5
+              }
+            ],
+            "source": {
+              "direction": "Down",
+              "element": "7b9e7742-9b5f-4ba6-8538-2204e16c29c8"
+            },
+            "target": {
+              "direction": "Up",
+              "element": "5df48dc0-89d1-4b15-9444-a27668a89966"
+            },
+            "isManuallyLayouted": false
+          }
+        },
+        "assessments": {}
+      }
+    }
+  ],
+  "agentProfileMappings": [
+    {
+      "id": "mapping_b8d65359_75032e14",
+      "userProfileId": "b8d65359-7826-4ce3-a8dc-da01ce8865d7",
+      "userProfileName": "Teenager",
+      "agentConfigurationId": "75032e14-e116-4f62-8526-0bd8473283d5",
+      "agentConfigurationName": "CoolConfig",
+      "savedAt": "2026-05-06T13:45:22.587Z"
+    },
+    {
+      "id": "mapping_8892dc19_ef384a51",
+      "userProfileId": "8892dc19-bacc-4de4-8f27-9ae32842dbbf",
+      "userProfileName": "ParaplegicUser",
+      "agentConfigurationId": "ef384a51-8bd6-45bb-952c-03a0944827d8",
+      "agentConfigurationName": "paraplegicprofile",
+      "savedAt": "2026-05-06T13:49:25.848Z"
+    }
+  ],
+  "activeAgentConfigurationId": null,
+  "agentBaseModels": {
+    "7ac41ba3-7e2b-44bd-9e47-46c377a9d757": {
+      "version": "3.0.0",
+      "type": "AgentDiagram",
+      "size": {
+        "width": 1080,
+        "height": 400
+      },
+      "interactive": {
+        "elements": {},
+        "relationships": {}
+      },
+      "elements": {
+        "699853eb-918b-4674-b08c-cf0af3cc61d7": {
+          "id": "699853eb-918b-4674-b08c-cf0af3cc61d7",
+          "name": "",
+          "type": "StateInitialNode",
+          "owner": null,
+          "bounds": {
+            "x": -230,
+            "y": -370,
+            "width": 45,
+            "height": 45
+          }
+        },
+        "0cba5357-2c30-414b-8d74-ac74ac4ab158": {
+          "id": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
+          "name": "Idle",
+          "type": "AgentState",
+          "owner": null,
+          "bounds": {
+            "x": -180,
+            "y": -200,
+            "width": 420,
+            "height": 100
+          },
+          "bodies": [
+            "63a2c160-ebbb-457b-953a-93fd2e643224"
+          ],
+          "fallbackBodies": [
+            "1f369122-06c2-4050-ba54-4ea160f95a8c"
+          ]
+        },
+        "63a2c160-ebbb-457b-953a-93fd2e643224": {
+          "id": "63a2c160-ebbb-457b-953a-93fd2e643224",
+          "name": "I am here to answer any questions regarding exercises, nutrition and recovery.",
+          "type": "AgentStateBody",
+          "owner": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
+          "bounds": {
+            "x": -179.5,
+            "y": -159.5,
+            "width": 419,
+            "height": 30
+          },
+          "replyType": "text",
+          "ragDatabaseName": ""
+        },
+        "1f369122-06c2-4050-ba54-4ea160f95a8c": {
+          "id": "1f369122-06c2-4050-ba54-4ea160f95a8c",
+          "name": "I focus on gym and fitness topics only dude.",
+          "type": "AgentStateFallbackBody",
+          "owner": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
+          "bounds": {
+            "x": -179.5,
+            "y": -129.5,
+            "width": 419,
+            "height": 30
+          },
+          "replyType": "text",
+          "ragDatabaseName": ""
+        },
+        "8dba49ff-2fc1-4066-b124-19e2df7981e2": {
+          "id": "8dba49ff-2fc1-4066-b124-19e2df7981e2",
+          "name": "Muscles_intent",
+          "type": "AgentIntent",
+          "owner": null,
+          "bounds": {
+            "x": -900,
+            "y": -400,
+            "width": 630,
+            "height": 100
+          },
+          "bodies": [
+            "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b"
+          ],
+          "intent_description": "Question about how to become muscular and which exercises to perform."
+        },
+        "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b": {
+          "id": "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b",
+          "name": "I want muscles",
+          "type": "AgentIntentBody",
+          "owner": "8dba49ff-2fc1-4066-b124-19e2df7981e2",
+          "bounds": {
+            "x": -899.5,
+            "y": -329.5,
+            "width": 629,
+            "height": 30
+          }
+        },
+        "68ccb630-b264-41a0-b70e-1e369bd5706c": {
+          "id": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+          "name": "TrainingPlan",
+          "type": "AgentState",
+          "owner": null,
+          "bounds": {
+            "x": -800,
+            "y": -30,
+            "width": 420,
+            "height": 130
+          },
+          "bodies": [
+            "aa261be5-9c53-4df1-a72f-5a107ce8f1b7",
+            "747b8558-325d-4a15-baba-0d18a6602a8d",
+            "900f7fd9-738a-4981-a7d9-6c7334621981"
+          ],
+          "fallbackBodies": []
+        },
+        "aa261be5-9c53-4df1-a72f-5a107ce8f1b7": {
+          "id": "aa261be5-9c53-4df1-a72f-5a107ce8f1b7",
+          "name": "Focus on heavy compound lifts like squats, deadlifts, bench press, overhead press, and rows to build overall muscle mass. ",
+          "type": "AgentStateBody",
+          "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+          "bounds": {
+            "x": -799.5,
+            "y": 10.5,
+            "width": 419,
+            "height": 30
+          },
+          "replyType": "text",
+          "ragDatabaseName": ""
+        },
+        "747b8558-325d-4a15-baba-0d18a6602a8d": {
+          "id": "747b8558-325d-4a15-baba-0d18a6602a8d",
+          "name": "Train 3–5 times per week, progressively increasing the weight while eating enough protein and calories to support growth. ",
+          "type": "AgentStateBody",
+          "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+          "bounds": {
+            "x": -799.5,
+            "y": 40.5,
+            "width": 419,
+            "height": 30
+          },
+          "replyType": "text",
+          "ragDatabaseName": ""
+        },
+        "900f7fd9-738a-4981-a7d9-6c7334621981": {
+          "id": "900f7fd9-738a-4981-a7d9-6c7334621981",
+          "name": "Get good sleep and stay consistent—muscle comes from steady effort over time.",
+          "type": "AgentStateBody",
+          "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+          "bounds": {
+            "x": -799.5,
+            "y": 70.5,
+            "width": 419,
+            "height": 30
+          },
+          "replyType": "text",
+          "ragDatabaseName": ""
+        },
+        "77976ef7-599d-4c49-9f4d-1ecb23239fe3": {
+          "id": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
+          "name": "Initial",
+          "type": "AgentState",
+          "owner": null,
+          "bounds": {
+            "x": -100,
+            "y": -370,
+            "width": 420,
+            "height": 70
+          },
+          "bodies": [
+            "ad226172-93d8-4644-80c5-62825565dd24"
+          ],
+          "fallbackBodies": []
+        },
+        "ad226172-93d8-4644-80c5-62825565dd24": {
+          "id": "ad226172-93d8-4644-80c5-62825565dd24",
+          "name": "Hi, I am your buddy, the fitness agent.",
+          "type": "AgentStateBody",
+          "owner": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
+          "bounds": {
+            "x": -99.5,
+            "y": -329.5,
+            "width": 419,
+            "height": 30
+          },
+          "replyType": "text",
+          "ragDatabaseName": ""
+        },
+        "7610bbda-21ef-4637-a188-1da1352bea17": {
+          "id": "7610bbda-21ef-4637-a188-1da1352bea17",
+          "name": "Nutrition",
+          "type": "AgentState",
+          "owner": null,
+          "bounds": {
+            "x": -150,
+            "y": 130,
+            "width": 420,
+            "height": 190
+          },
+          "bodies": [
+            "bb7e67bd-ead9-4f14-93db-c18af0d806af",
+            "13072ea8-9b51-45fe-927e-a9323627701b",
+            "95241c3a-f8a2-4bf0-b169-5dcff5a926fb",
+            "44904a03-ac46-4f9f-983a-f6a740b81c0e",
+            "90dfba4f-6dec-4ca8-8c15-786ed36587a1"
+          ],
+          "fallbackBodies": []
+        },
+        "bb7e67bd-ead9-4f14-93db-c18af0d806af": {
+          "id": "bb7e67bd-ead9-4f14-93db-c18af0d806af",
+          "name": "Nutrition basics: Eat mostly whole foods (lean protein, vegetables, fruits, whole grains, healthy fats). Protein: ~1.6–2.2 g per kg of body weight daily..",
+          "type": "AgentStateBody",
+          "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+          "bounds": {
+            "x": -149.5,
+            "y": 170.5,
+            "width": 419,
+            "height": 30
+          },
+          "replyType": "text",
+          "ragDatabaseName": ""
+        },
+        "13072ea8-9b51-45fe-927e-a9323627701b": {
+          "id": "13072ea8-9b51-45fe-927e-a9323627701b",
+          "name": "Match calories to your goal: slight surplus to gain muscle, deficit to lose fat, maintenance to stay the same. ",
+          "type": "AgentStateBody",
+          "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+          "bounds": {
+            "x": -149.5,
+            "y": 200.5,
+            "width": 419,
+            "height": 30
+          },
+          "replyType": "text",
+          "ragDatabaseName": ""
+        },
+        "95241c3a-f8a2-4bf0-b169-5dcff5a926fb": {
+          "id": "95241c3a-f8a2-4bf0-b169-5dcff5a926fb",
+          "name": " Carbs fuel training; fats support hormones.",
+          "type": "AgentStateBody",
+          "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+          "bounds": {
+            "x": -149.5,
+            "y": 230.5,
+            "width": 419,
+            "height": 30
+          },
+          "replyType": "text",
+          "ragDatabaseName": ""
+        },
+        "44904a03-ac46-4f9f-983a-f6a740b81c0e": {
+          "id": "44904a03-ac46-4f9f-983a-f6a740b81c0e",
+          "name": " Drink plenty of water and limit ultra-processed foods and alcohol. ",
+          "type": "AgentStateBody",
+          "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+          "bounds": {
+            "x": -149.5,
+            "y": 260.5,
+            "width": 419,
+            "height": 30
+          },
+          "replyType": "text",
+          "ragDatabaseName": ""
+        },
+        "90dfba4f-6dec-4ca8-8c15-786ed36587a1": {
+          "id": "90dfba4f-6dec-4ca8-8c15-786ed36587a1",
+          "name": "Be consistent — results come from habits, not perfection",
+          "type": "AgentStateBody",
+          "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+          "bounds": {
+            "x": -149.5,
+            "y": 290.5,
+            "width": 419,
+            "height": 30
+          },
+          "replyType": "text",
+          "ragDatabaseName": ""
+        },
+        "8c760b7d-7e72-4cd7-a92a-d5491c021a5b": {
+          "id": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b",
+          "name": "OtherQuestions",
+          "type": "AgentState",
+          "owner": null,
+          "bounds": {
+            "x": 350,
+            "y": -90,
+            "width": 180,
+            "height": 70
+          },
+          "bodies": [
+            "6a3aeb02-bb44-4472-8489-595e8dc8ceb1"
+          ],
+          "fallbackBodies": []
+        },
+        "6a3aeb02-bb44-4472-8489-595e8dc8ceb1": {
+          "id": "6a3aeb02-bb44-4472-8489-595e8dc8ceb1",
+          "name": "AI response 🪄",
+          "type": "AgentStateBody",
+          "owner": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b",
+          "bounds": {
+            "x": 350.5,
+            "y": -49.5,
+            "width": 179,
+            "height": 30
+          },
+          "replyType": "llm",
+          "ragDatabaseName": ""
+        },
+        "659e810a-f686-47fb-aea8-d23ad06e482c": {
+          "id": "659e810a-f686-47fb-aea8-d23ad06e482c",
+          "name": "Nutrition_intent",
+          "type": "AgentIntent",
+          "owner": null,
+          "bounds": {
+            "x": -900,
+            "y": -290,
+            "width": 630,
+            "height": 100
+          },
+          "bodies": [
+            "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0"
+          ],
+          "intent_description": "Question about nutrition in gym."
+        },
+        "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0": {
+          "id": "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0",
+          "name": "Which food to eat?",
+          "type": "AgentIntentBody",
+          "owner": "659e810a-f686-47fb-aea8-d23ad06e482c",
+          "bounds": {
+            "x": -899.5,
+            "y": -219.5,
+            "width": 629,
+            "height": 30
+          }
+        },
+        "37dff3e2-013c-42f0-ad6e-bbc197247d14": {
+          "id": "37dff3e2-013c-42f0-ad6e-bbc197247d14",
+          "name": "Other",
+          "type": "AgentIntent",
+          "owner": null,
+          "bounds": {
+            "x": -860,
+            "y": 150,
+            "width": 630,
+            "height": 70
+          },
+          "bodies": [],
+          "intent_description": "Any question that does not fit in \"Muscles\" or \"Nutrition\""
+        }
+      },
+      "relationships": {
+        "bbd03bdd-b76e-47df-9e13-5a305885f94c": {
+          "id": "bbd03bdd-b76e-47df-9e13-5a305885f94c",
+          "name": "",
+          "type": "AgentStateTransitionInit",
+          "owner": null,
+          "bounds": {
+            "x": -185,
+            "y": -347.5,
+            "width": 85,
+            "height": 1
+          },
+          "path": [
+            {
+              "x": 0,
+              "y": 0
+            },
+            {
+              "x": 85,
+              "y": 0
+            }
+          ],
+          "source": {
+            "direction": "Right",
+            "element": "699853eb-918b-4674-b08c-cf0af3cc61d7",
+            "bounds": {
+              "x": -535,
+              "y": -37.5,
+              "width": 0,
+              "height": 0
+            }
+          },
+          "target": {
+            "direction": "Left",
+            "element": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
+            "bounds": {
+              "x": -280,
+              "y": -45,
+              "width": 0,
+              "height": 0
+            }
+          },
+          "isManuallyLayouted": false
+        },
+        "0d7d8895-3eb0-44b0-bb41-e902684d0d2c": {
+          "id": "0d7d8895-3eb0-44b0-bb41-e902684d0d2c",
+          "name": "",
+          "type": "AgentStateTransition",
+          "owner": null,
+          "bounds": {
+            "x": -590,
+            "y": -150,
+            "width": 410,
+            "height": 120
+          },
+          "path": [
+            {
+              "x": 410,
+              "y": 0
+            },
+            {
+              "x": 0,
+              "y": 0
+            },
+            {
+              "x": 0,
+              "y": 120
+            }
+          ],
+          "source": {
+            "direction": "Left",
+            "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+          },
+          "target": {
+            "direction": "Up",
+            "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
+          },
+          "isManuallyLayouted": false,
+          "condition": "when_intent_matched",
+          "conditionValue": "Muscles_intent"
+        },
+        "7d65df96-e669-4fc6-a882-dbfe92a57073": {
+          "id": "7d65df96-e669-4fc6-a882-dbfe92a57073",
+          "name": "",
+          "type": "AgentStateTransition",
+          "owner": null,
+          "bounds": {
+            "x": 70,
+            "y": -300,
+            "width": 1,
+            "height": 100
+          },
+          "path": [
+            {
+              "x": 0,
+              "y": 0
+            },
+            {
+              "x": 0,
+              "y": 100
+            }
+          ],
+          "source": {
+            "direction": "Down",
+            "element": "77976ef7-599d-4c49-9f4d-1ecb23239fe3"
+          },
+          "target": {
+            "direction": "Up",
+            "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+          },
+          "isManuallyLayouted": false,
+          "condition": "auto",
+          "conditionValue": ""
+        },
+        "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31": {
+          "id": "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31",
+          "name": "",
+          "type": "AgentStateTransition",
+          "owner": null,
+          "bounds": {
+            "x": 240,
+            "y": -130,
+            "width": 200,
+            "height": 40
+          },
+          "path": [
+            {
+              "x": 0,
+              "y": 5
+            },
+            {
+              "x": 40,
+              "y": 5
+            },
+            {
+              "x": 40,
+              "y": 0
+            },
+            {
+              "x": 200,
+              "y": 0
+            },
+            {
+              "x": 200,
+              "y": 40
+            }
+          ],
+          "source": {
+            "direction": "Downright",
+            "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+          },
+          "target": {
+            "direction": "Up",
+            "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
+          },
+          "isManuallyLayouted": true,
+          "condition": "when_intent_matched",
+          "conditionValue": "Other"
+        },
+        "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e": {
+          "id": "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e",
+          "name": "",
+          "type": "AgentStateTransition",
+          "owner": null,
+          "bounds": {
+            "x": -380,
+            "y": -125,
+            "width": 200,
+            "height": 127.5
+          },
+          "path": [
+            {
+              "x": 0,
+              "y": 127.5
+            },
+            {
+              "x": 100,
+              "y": 127.5
+            },
+            {
+              "x": 100,
+              "y": 0
+            },
+            {
+              "x": 200,
+              "y": 0
+            }
+          ],
+          "source": {
+            "direction": "Upright",
+            "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
+          },
+          "target": {
+            "direction": "Downleft",
+            "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+          },
+          "isManuallyLayouted": false,
+          "condition": "auto",
+          "conditionValue": ""
+        },
+        "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32": {
+          "id": "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32",
+          "name": "",
+          "type": "AgentStateTransition",
+          "owner": null,
+          "bounds": {
+            "x": 135,
+            "y": -100,
+            "width": 215,
+            "height": 40
+          },
+          "path": [
+            {
+              "x": 215,
+              "y": 27.5
+            },
+            {
+              "x": 175,
+              "y": 27.5
+            },
+            {
+              "x": 175,
+              "y": 40
+            },
+            {
+              "x": 0,
+              "y": 40
+            },
+            {
+              "x": 0,
+              "y": 0
+            }
+          ],
+          "source": {
+            "direction": "Upleft",
+            "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
+          },
+          "target": {
+            "direction": "Bottomright",
+            "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+          },
+          "isManuallyLayouted": false,
+          "condition": "auto",
+          "conditionValue": ""
+        },
+        "3564da62-bea0-4489-81b2-fda2effddd02": {
+          "id": "3564da62-bea0-4489-81b2-fda2effddd02",
+          "name": "",
+          "type": "AgentStateTransition",
+          "owner": null,
+          "bounds": {
+            "x": -190,
+            "y": -100,
+            "width": 115,
+            "height": 277.5
+          },
+          "path": [
+            {
+              "x": 40,
+              "y": 277.5
+            },
+            {
+              "x": 0,
+              "y": 277.5
+            },
+            {
+              "x": 0,
+              "y": 115
+            },
+            {
+              "x": 115,
+              "y": 115
+            },
+            {
+              "x": 115,
+              "y": 0
+            }
+          ],
+          "source": {
+            "direction": "Upleft",
+            "element": "7610bbda-21ef-4637-a188-1da1352bea17"
+          },
+          "target": {
+            "direction": "Bottomleft",
+            "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+          },
+          "isManuallyLayouted": false,
+          "condition": "auto",
+          "conditionValue": ""
+        },
+        "b696a5f6-f328-42fb-bdbc-83569b2beb06": {
+          "id": "b696a5f6-f328-42fb-bdbc-83569b2beb06",
+          "name": "",
+          "type": "AgentStateTransition",
+          "owner": null,
+          "bounds": {
+            "x": 45,
+            "y": -100,
+            "width": 1,
+            "height": 230
+          },
+          "path": [
+            {
+              "x": 0,
+              "y": 0
+            },
+            {
+              "x": 0,
+              "y": 230
+            }
+          ],
+          "source": {
+            "direction": "Down",
+            "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+          },
+          "target": {
+            "direction": "Up",
+            "element": "7610bbda-21ef-4637-a188-1da1352bea17"
+          },
+          "isManuallyLayouted": false,
+          "condition": "when_intent_matched",
+          "conditionValue": "Nutrition_intent"
+        }
+      },
+      "assessments": {}
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Importing the **Personalized Gym Agent** template left the agent-config Personalization tab with an empty *Saved Configurations* list, which then broke agent generation. Two underlying gaps:

1. The V2 export envelope had no slot for saved configurations, user profiles, profile↔config mappings, or base agent models, and the import path only persisted project diagrams.
2. The bundled gym template carried only the personalized variants — the un-personalized base model wasn't anywhere reachable, so on import users only saw the adapted version.

## Changes

- **`projectExportUtils.ts`** — extend `ProjectExportEnvelope` with optional `agentConfigurations`, `userProfiles`, `agentProfileMappings`, `activeAgentConfigurationId`, `agentBaseModels`. `buildProjectExportEnvelope` bundles them by default; new `BuildProjectExportEnvelopeOptions.includePersonalization` lets callers opt out.
- **`useGitHubRepo.ts`** — opts out of bundling personalization so saved configs and user profiles aren't pushed to (potentially public) GitHub repos on every deploy.
- **`local-storage-repository.ts`** — adds `mergeImportedPersonalization()` that merges by id (existing entries win on collision; new ids appended). `activeAgentConfigurationId` is only applied when nothing is currently active so an in-progress session isn't disrupted. Adds `getAllAgentBaseModels()` getter for the export side.
- **`projectImport.ts`** — extends `V2ExportData` with the new optional fields; both V2 paths (JSON + BUML) extract and merge bundled personalization after `ProjectStorageRepository.saveProject`.
- **`personalized_gym_agent.json`** — regenerated:
  - Agent diagram main `model` reset to the base `gymagent.json` (un-personalized)
  - `activePersonalizedVariantId` cleared so import lands on the base
  - Bundled `agentBaseModels` keyed by agent diagram id
  - Bundled 2 user profiles (Teenager, ParaplegicUser), 2 saved configurations (CoolConfig, paraplegicprofile) with `baseAgentModel` / `originalAgentModel` / `personalizedAgentModel` populated, and 2 profile↔config mappings

## Behavior matrix (per requested spec)

- Importing a **new agent model alone** → existing local saved configs are not wiped; the user retriggers Save & Apply to bind to the new model.
- Importing a **whole project that bundles configs/profiles/mappings** → merge by id, keep existing on collision, append new.

## Test plan

- [ ] Fresh browser profile: import the **Personalized Gym Agent** template and confirm the agent-config Personalization tab now lists *CoolConfig* and *paraplegicprofile* under Saved Configurations.
- [ ] Confirm the imported agent diagram opens on the **base** gym model (not a personalized variant) and the variant list still has Teenager & ParaplegicUser available to apply.
- [ ] Run agent generation against an imported saved config end-to-end and confirm no longer errors due to missing config.
- [ ] With local saved configs already present, import the template again and verify existing entries are preserved (merge by id).
- [ ] Export → re-import a project with saved configs and confirm round-trip.
- [ ] GitHub deploy: verify the `diagrams.json` written into the deployed repo does NOT contain `agentConfigurations` / `userProfiles` / `agentProfileMappings` / `agentBaseModels`.
- [ ] `npx vitest run src/main/shared/utils/__tests__/projectExportUtils.test.ts` — 23/23 still passing locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)