### PR TITLE
release: v7.7.1 — wire Supabase config dialog in WME frontend

### DIFF
--- a/packages/webapp/src/main/app/application.tsx
+++ b/packages/webapp/src/main/app/application.tsx
@@ -173,6 +173,7 @@ function AppContentInner() {
         sqlDialect={configState.sqlDialect}
         sqlAlchemyDbms={configState.sqlAlchemyDbms}
         jsonSchemaMode={configState.jsonSchemaMode}
+        supabaseUserRoot={configState.supabaseUserRoot}
         // ── Agent config (languages + advanced/personalization) ──────
         sourceLanguage={configState.sourceLanguage}
         pendingAgentLanguage={configState.pendingAgentLanguage}
@@ -197,6 +198,7 @@ function AppContentInner() {
         onSqlDialectChange={configState.onSqlDialectChange}
         onSqlAlchemyDbmsChange={configState.onSqlAlchemyDbmsChange}
         onJsonSchemaModeChange={configState.onJsonSchemaModeChange}
+        onSupabaseUserRootChange={configState.onSupabaseUserRootChange}
         onSourceLanguageChange={configState.onSourceLanguageChange}
         onPendingAgentLanguageChange={configState.onPendingAgentLanguageChange}
         onSelectedAgentLanguagesChange={configState.onSelectedAgentLanguagesChange}
@@ -212,6 +214,7 @@ function AppContentInner() {
         onSqlGenerate={configState.onSqlGenerate}
         onSqlAlchemyGenerate={configState.onSqlAlchemyGenerate}
         onJsonSchemaGenerate={configState.onJsonSchemaGenerate}
+        onSupabaseGenerate={configState.onSupabaseGenerate}
         onAgentGenerate={configState.onAgentGenerate}
         onQiskitGenerate={configState.onQiskitGenerate}
         onWebAppGenerate={configState.onWebAppGenerate}


### PR DESCRIPTION
Sync `develop` → `main` for BESSER v7.7.1.

## Summary
- Forwards `supabaseUserRoot`, `onSupabaseUserRootChange` and `onSupabaseGenerate` from `useGeneratorExecution` through `application.tsx` into `GeneratorConfigDialogs`.
- Without it the Supabase config dialog crashed with `W is not a function` in the minified v7.7.0 bundle the moment the user typed in the **User-root class** field or clicked **Generate**, making the v7.7.0 Supabase generator unreachable from the editor.

## Test plan
- [ ] Lint + build pass.
- [ ] Visual smoke: open the editor, **File → Generate Code → Database → Supabase**, type a user-root class, click Generate — dialog accepts input and the SQL file downloads.
