### PR TITLE
feat(agent-editor): visual polish for reasoning primitives palette

### DIFF
--- a/packages/editor/src/main/packages/agent-state-diagram/agent-skill/agent-skill-component.tsx
+++ b/packages/editor/src/main/packages/agent-state-diagram/agent-skill/agent-skill-component.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { AgentSkill } from './agent-skill';
 import { Text } from '../../../components/controls/text/text';
-import { ThemedRect } from '../../../components/theme/themedComponents';
 import { AGENT_PRIMITIVE_COLORS } from '../agent-primitive-colors';
 
 interface Props {
@@ -19,24 +18,24 @@ const truncate = (value: string, max: number) => {
 export const AgentSkillComponent: FunctionComponent<Props> = ({ element, children, fillColor }) => {
   const width = element.bounds.width;
   const height = element.bounds.height;
-  const cornerRadius = 8;
   const subtitle = truncate(element.description || element.content || '', 48);
   const accent = element.strokeColor || AGENT_PRIMITIVE_COLORS.skill.accent;
+  const fill = fillColor || element.fillColor || AGENT_PRIMITIVE_COLORS.skill.tint;
   const textColor = element.textColor || 'currentColor';
+
+  // Card with a folded top-right corner (a "note" silhouette).
+  const fold = Math.min(16, width / 6);
+  const cardPath = `M 0 0 H ${width - fold} L ${width} ${fold} V ${height} H 0 Z`;
+  const foldPath = `M ${width - fold} 0 L ${width} ${fold} L ${width - fold} ${fold} Z`;
 
   return (
     <g>
-      <ThemedRect
-        width="100%"
-        height="100%"
-        rx={cornerRadius}
-        fillColor={fillColor || element.fillColor || AGENT_PRIMITIVE_COLORS.skill.tint}
-        strokeColor={accent}
-      />
-      <Text y={22} fill={accent} fontWeight="bold" fontSize="80%">
+      <path d={cardPath} fill={fill} stroke={accent} strokeWidth={1.5} />
+      <path d={foldPath} fill={accent} fillOpacity={0.45} stroke={accent} strokeWidth={1} />
+      <Text x={width / 2} y={24} fill={accent} fontWeight="bold" fontSize="80%" textAnchor="middle">
         {`${AGENT_PRIMITIVE_COLORS.skill.icon} «skill»`}
       </Text>
-      <Text y={42} fill={textColor} fontWeight="bold">
+      <Text x={width / 2} y={44} fill={textColor} fontWeight="bold" textAnchor="middle">
         {element.name}
       </Text>
       {subtitle ? (

--- a/packages/editor/src/main/packages/agent-state-diagram/agent-state-preview.ts
+++ b/packages/editor/src/main/packages/agent-state-diagram/agent-state-preview.ts
@@ -125,14 +125,14 @@ export const composeBotPreview: ComposePreview = (
     sectionTitle('Reasoning'),
     reasoningState,
     sectionSeparator(),
+    sectionTitle('Knowledge'),
+    emptyIntent,
+    ragElement,
+    sectionSeparator(),
     sectionTitle('Capabilities'),
     toolElement,
     skillElement,
     workspaceElement,
-    sectionSeparator(),
-    sectionTitle('Knowledge'),
-    emptyIntent,
-    ragElement,
   ];
 
   return elements;

--- a/packages/editor/src/main/packages/agent-state-diagram/agent-tool/agent-tool-component.tsx
+++ b/packages/editor/src/main/packages/agent-state-diagram/agent-tool/agent-tool-component.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { AgentTool } from './agent-tool';
 import { Text } from '../../../components/controls/text/text';
-import { ThemedRect } from '../../../components/theme/themedComponents';
 import { AGENT_PRIMITIVE_COLORS } from '../agent-primitive-colors';
 
 interface Props {
@@ -19,24 +18,24 @@ const truncate = (value: string, max: number) => {
 export const AgentToolComponent: FunctionComponent<Props> = ({ element, children, fillColor }) => {
   const width = element.bounds.width;
   const height = element.bounds.height;
-  const cornerRadius = 8;
   const subtitle = truncate(element.description || '', 48);
   const accent = element.strokeColor || AGENT_PRIMITIVE_COLORS.tool.accent;
+  const fill = fillColor || element.fillColor || AGENT_PRIMITIVE_COLORS.tool.tint;
   const textColor = element.textColor || 'currentColor';
+
+  // Hexagon: pointed left/right edges (a "module" silhouette).
+  const notch = Math.min(18, width / 6);
+  const hexPath =
+    `M ${notch} 0 H ${width - notch} L ${width} ${height / 2} ` +
+    `L ${width - notch} ${height} H ${notch} L 0 ${height / 2} Z`;
 
   return (
     <g>
-      <ThemedRect
-        width="100%"
-        height="100%"
-        rx={cornerRadius}
-        fillColor={fillColor || element.fillColor || AGENT_PRIMITIVE_COLORS.tool.tint}
-        strokeColor={accent}
-      />
-      <Text y={22} fill={accent} fontWeight="bold" fontSize="80%">
+      <path d={hexPath} fill={fill} stroke={accent} strokeWidth={1.5} />
+      <Text x={width / 2} y={24} fill={accent} fontWeight="bold" fontSize="80%" textAnchor="middle">
         {`${AGENT_PRIMITIVE_COLORS.tool.icon} «tool»`}
       </Text>
-      <Text y={42} fill={textColor} fontWeight="bold">
+      <Text x={width / 2} y={44} fill={textColor} fontWeight="bold" textAnchor="middle">
         {element.name}
       </Text>
       {subtitle ? (

--- a/packages/editor/src/main/packages/agent-state-diagram/agent-workspace/agent-workspace-component.tsx
+++ b/packages/editor/src/main/packages/agent-state-diagram/agent-workspace/agent-workspace-component.tsx
@@ -32,14 +32,14 @@ export const AgentWorkspaceComponent: FunctionComponent<Props> = ({ element, chi
   return (
     <g>
       <path d={folderPath} fill={fill} stroke={accent} strokeWidth={1.5} />
-      <Text x={width / 2} y={tabH + 22} fill={accent} fontWeight="bold" fontSize="80%" textAnchor="middle">
+      <Text x={width / 2} y={tabH + 16} fill={accent} fontWeight="bold" fontSize="80%" textAnchor="middle">
         {`${AGENT_PRIMITIVE_COLORS.workspace.icon} «workspace»`}
       </Text>
-      <Text x={width / 2} y={tabH + 42} fill={textColor} fontWeight="bold" textAnchor="middle">
+      <Text x={width / 2} y={tabH + 34} fill={textColor} fontWeight="bold" textAnchor="middle">
         {element.name}
       </Text>
       {subtitle ? (
-        <Text x={width / 2} y={height - 14} fill={textColor} fontWeight="normal" fontSize="80%" textAnchor="middle">
+        <Text x={width / 2} y={height - 12} fill={textColor} fontWeight="normal" fontSize="80%" textAnchor="middle">
           {subtitle}
         </Text>
       ) : null}

--- a/packages/editor/src/main/packages/agent-state-diagram/agent-workspace/agent-workspace-component.tsx
+++ b/packages/editor/src/main/packages/agent-state-diagram/agent-workspace/agent-workspace-component.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { AgentWorkspace } from './agent-workspace';
 import { Text } from '../../../components/controls/text/text';
-import { ThemedRect } from '../../../components/theme/themedComponents';
 import { AGENT_PRIMITIVE_COLORS } from '../agent-primitive-colors';
 
 interface Props {
@@ -19,28 +18,28 @@ const truncate = (value: string, max: number) => {
 export const AgentWorkspaceComponent: FunctionComponent<Props> = ({ element, children, fillColor }) => {
   const width = element.bounds.width;
   const height = element.bounds.height;
-  const cornerRadius = 8;
   const subtitle = truncate(element.path || element.description || '', 48);
   const accent = element.strokeColor || AGENT_PRIMITIVE_COLORS.workspace.accent;
+  const fill = fillColor || element.fillColor || AGENT_PRIMITIVE_COLORS.workspace.tint;
   const textColor = element.textColor || 'currentColor';
+
+  // Folder: a tab on the top-left rising above the body (a "folder" silhouette).
+  const tabW = Math.min(70, width * 0.45);
+  const tabH = Math.min(16, height * 0.22);
+  const slope = 10;
+  const folderPath = `M 0 0 H ${tabW} L ${tabW + slope} ${tabH} H ${width} V ${height} H 0 Z`;
 
   return (
     <g>
-      <ThemedRect
-        width="100%"
-        height="100%"
-        rx={cornerRadius}
-        fillColor={fillColor || element.fillColor || AGENT_PRIMITIVE_COLORS.workspace.tint}
-        strokeColor={accent}
-      />
-      <Text y={22} fill={accent} fontWeight="bold" fontSize="80%">
+      <path d={folderPath} fill={fill} stroke={accent} strokeWidth={1.5} />
+      <Text x={width / 2} y={tabH + 22} fill={accent} fontWeight="bold" fontSize="80%" textAnchor="middle">
         {`${AGENT_PRIMITIVE_COLORS.workspace.icon} «workspace»`}
       </Text>
-      <Text y={42} fill={textColor} fontWeight="bold">
+      <Text x={width / 2} y={tabH + 42} fill={textColor} fontWeight="bold" textAnchor="middle">
         {element.name}
       </Text>
       {subtitle ? (
-        <Text x={width / 2} y={height - 16} fill={textColor} fontWeight="normal" fontSize="80%" textAnchor="middle">
+        <Text x={width / 2} y={height - 14} fill={textColor} fontWeight="normal" fontSize="80%" textAnchor="middle">
           {subtitle}
         </Text>
       ) : null}


### PR DESCRIPTION
Follow-up polish on top of the merged #135, for the agent editor palette.

- **Distinct shapes** for the reasoning primitives instead of identical rounded rectangles: Tool = hexagon, Skill = folded-corner card, Workspace = folder with a tab (each keeps its accent color + icon).
- **Fix**: workspace name no longer overlaps the path-to-dir label.
- **Palette order**: Knowledge section now appears before Capabilities (Flow → Reasoning → Knowledge → Capabilities).

Built on the color-coding, per-type icons and NN-style titled sections already merged via #135.