### PR TITLE
release: v7.8.3 — agent transition normalization + variant edit persistence

### DIFF
--- a/packages/editor/src/main/index.ts
+++ b/packages/editor/src/main/index.ts
@@ -36,6 +36,11 @@ export * from './services/settings/settings-service';
 // from tests and from consumer webapps.
 export * from './packages/common/uml-association/multiplicity';
 
+// Export the agent-model normalizer (flat → canonical nested transition shape).
+// Pure function, used by the webapp to normalize models that bypass the editor
+// (e.g. agentBaseModels snapshots written straight to localStorage).
+export { normalizeAgentModel } from './packages/agent-state-diagram/normalize-agent-model';
+
 // Export only the Patch type (not the implementation) for type safety
 // Used when working with patching operations in TypeScript
 export type { Patch } from './services/patcher';

--- a/packages/editor/src/main/packages/agent-state-diagram/normalize-agent-model.ts
+++ b/packages/editor/src/main/packages/agent-state-diagram/normalize-agent-model.ts
@@ -1,0 +1,45 @@
+import * as Apollon from '../../typings';
+import { UMLModel, UMLRelationship } from '../../typings';
+import { AgentRelationshipType } from './index';
+import { AgentStateTransition } from './agent-state-transition/agent-state-transition';
+
+/**
+ * Normalize every agent transition in a model to the canonical nested shape.
+ *
+ * Agent transitions historically came in two JSON shapes: a legacy *flat* shape
+ * (top-level ``condition`` + ``conditionValue``) and the canonical *nested* shape
+ * (``transitionType`` + ``predefined`` / ``custom`` blocks). The Apollon editor
+ * upgrades flat → nested whenever a diagram is loaded, but models that bypass the
+ * editor — e.g. an ``agentBaseModels`` snapshot bundled in an imported project and
+ * written straight to localStorage — keep the flat shape. The backend agent
+ * processor only understands the nested shape and silently collapses flat
+ * transitions to ``when_no_intent_matched``, so any model persisted outside the
+ * editor must be normalized first.
+ *
+ * This reuses the single canonical normalizer — ``AgentStateTransition`` — by
+ * round-tripping each transition through its constructor and ``serialize()``, so
+ * there is no second flat→nested mapper to keep in sync. Geometry (source/target/
+ * path/bounds) and the relationship id are preserved. The function is pure
+ * (returns a clone) and idempotent on already-nested input.
+ */
+export function normalizeAgentModel(model: UMLModel): UMLModel {
+  if (!model || !model.relationships) {
+    return model;
+  }
+
+  const clone: UMLModel = JSON.parse(JSON.stringify(model));
+  for (const [id, relationship] of Object.entries(clone.relationships)) {
+    if (relationship?.type !== AgentRelationshipType.AgentStateTransition) {
+      continue;
+    }
+    // Mirror the editor's load path exactly: instantiate empty, then
+    // deserialize(). deserialize() seeds geometry (via super.deserialize) and
+    // performs the full flat→nested upgrade, including mapping the flat
+    // ``conditionValue`` onto intentName / fileType / variable-operation fields.
+    const transition = new AgentStateTransition();
+    transition.deserialize(relationship as Apollon.AgentStateTransition);
+    clone.relationships[id] = { ...(transition.serialize() as UMLRelationship), id };
+  }
+
+  return clone;
+}

--- a/packages/webapp/src/main/app/shell/WorkspaceShell.tsx
+++ b/packages/webapp/src/main/app/shell/WorkspaceShell.tsx
@@ -12,7 +12,7 @@ import { useGitHubAuth } from '../../features/github/hooks/useGitHubAuth';
 import { isDarkThemeEnabled, toggleTheme } from '../../shared/utils/theme-switcher';
 import { ProjectStorageRepository } from '../../shared/services/storage/ProjectStorageRepository';
 import { LocalStorageRepository } from '../../shared/services/storage/local-storage-repository';
-import { readAgentVariants } from '../../shared/services/agent-variants/agent-variants-service';
+import { readAgentVariants, getActiveAgentVariantId } from '../../shared/services/agent-variants/agent-variants-service';
 import { useImportDiagramToProjectWorkflow } from '../../features/import/useImportDiagram';
 import { buildProjectExportEnvelope, PROJECT_EXPORT_VERSION } from '../../shared/utils/projectExportUtils';
 import {
@@ -542,9 +542,33 @@ export const WorkspaceShell: React.FC<WorkspaceShellProps> = ({
     const latestProjectSnapshot = ProjectStorageRepository.loadProject(currentProject.id) || currentProject;
     const agentIndex = latestProjectSnapshot.currentDiagramIndices.AgentDiagram ?? 0;
     const activeAgentDiagram = latestProjectSnapshot.diagrams.AgentDiagram[agentIndex] || getActiveDiagram(latestProjectSnapshot, 'AgentDiagram') || diagram;
-    const currentConfigRecord = (activeAgentDiagram.config ?? {}) as Record<string, unknown>;
+    let currentConfigRecord = (activeAgentDiagram.config ?? {}) as Record<string, unknown>;
 
     try {
+      // Persist the current live model back into its source before switching,
+      // so in-canvas edits to the active base/variant aren't discarded. When a
+      // variant is active, fold the edits into its inline snapshot; on the base,
+      // update the stored base model.
+      const currentActiveVariantId = getActiveAgentVariantId(activeAgentDiagram);
+      const liveModel = activeAgentDiagram.model;
+      if (isUMLModel(liveModel) && liveModel.type === UMLDiagramType.AgentDiagram) {
+        if (currentActiveVariantId) {
+          const currentVariants = readAgentVariants(activeAgentDiagram);
+          if (currentVariants.some((variant) => variant.id === currentActiveVariantId)) {
+            currentConfigRecord = {
+              ...currentConfigRecord,
+              personalizedVariants: currentVariants.map((variant) =>
+                variant.id === currentActiveVariantId
+                  ? { ...variant, model: structuredClone(liveModel) }
+                  : variant,
+              ),
+            };
+          }
+        } else {
+          LocalStorageRepository.saveAgentBaseModel(activeAgentDiagram.id, liveModel);
+        }
+      }
+
       if (!variantId) {
         const baseModel = LocalStorageRepository.getAgentBaseModel(activeAgentDiagram.id);
         if (!baseModel) {

--- a/packages/webapp/src/main/features/agent-config/AgentConfigurationPanel.tsx
+++ b/packages/webapp/src/main/features/agent-config/AgentConfigurationPanel.tsx
@@ -1812,6 +1812,10 @@ export const AgentConfigurationPanel: React.FC = () => {
       ? LocalStorageRepository.getAgentBaseModel(currentAgentDiagram.id)
       : null;
 
+    // Re-personalize from the stored un-personalized base when one exists,
+    // otherwise the live diagram is itself the base. The stored snapshot is
+    // guaranteed to be in the canonical nested transition shape (normalized at
+    // the storage boundary), so it round-trips through the backend cleanly.
     const agentModel = storedBaseModel
       ? cloneModel(storedBaseModel)
       : currentAgentModel

--- a/packages/webapp/src/main/features/generation/hooks/useGenerateCode.ts
+++ b/packages/webapp/src/main/features/generation/hooks/useGenerateCode.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { ApollonEditor } from '@besser/wme';
+import { ApollonEditor, UMLModel } from '@besser/wme';
 import { useFileDownload } from '../../../shared/services/file-download/useFileDownload';
 import { toast } from 'react-toastify';
 import { validateDiagram } from '../../../shared/services/validation/validateDiagram';
@@ -196,6 +196,7 @@ export const useGenerateCode = () => {
       diagramTitle: string,
       config?: GeneratorConfig[keyof GeneratorConfig],
       referenceDiagramData?: Record<string, any>,
+      modelOverride?: UMLModel,
     ): Promise<GenerationResult> => {
       console.log('Starting code generation...');
 
@@ -228,10 +229,13 @@ export const useGenerateCode = () => {
         return { ok: false, error: validationResult.message || 'Validation failed' };
       }
 
-      // Prepare body for single diagram generation
+      // Prepare body for single diagram generation. modelOverride is used by
+      // agent personalization to ship the un-personalized base instead of
+      // whatever variant happens to be active in the editor — see
+      // handleAgentGenerate in useGeneratorExecution.
       const body: any = {
         title: diagramTitle,
-        model: editor.model,
+        model: modelOverride ?? editor.model,
         generator: generatorType,
         config: config,
         ...(referenceDiagramData ? { referenceDiagramData } : {}),

--- a/packages/webapp/src/main/features/generation/useGeneratorExecution.ts
+++ b/packages/webapp/src/main/features/generation/useGeneratorExecution.ts
@@ -15,7 +15,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { ApollonEditor, UMLDiagramType } from '@besser/wme';
+import { ApollonEditor, UMLDiagramType, UMLModel } from '@besser/wme';
 import { toast } from 'react-toastify';
 
 import { useAppDispatch } from '../../app/store/hooks';
@@ -616,7 +616,7 @@ export function useGeneratorExecution(editor: ApollonEditor | undefined): UseGen
     async (
       generatorType: GeneratorType,
       config?: unknown,
-      options?: { autoGenerateGuiIfEmpty?: boolean },
+      options?: { autoGenerateGuiIfEmpty?: boolean; agentModelOverride?: UMLModel },
     ): Promise<GenerationResult> => {
       if (!currentProject) {
         toast.error('Create or load a project before generating code.');
@@ -735,7 +735,14 @@ export function useGeneratorExecution(editor: ApollonEditor | undefined): UseGen
             result = await generateCode(editor, 'jsonschema', activeDiagramTitle, config as JSONSchemaConfig);
             break;
           case 'agent':
-            result = await generateCode(editor, 'agent', activeDiagramTitle, config as AgentConfig);
+            result = await generateCode(
+              editor,
+              'agent',
+              activeDiagramTitle,
+              config as AgentConfig,
+              undefined,
+              options?.agentModelOverride,
+            );
             break;
           case 'jsonobject': {
             if (!isObjectContext && !isUserContext) {
@@ -962,6 +969,7 @@ export function useGeneratorExecution(editor: ApollonEditor | undefined): UseGen
     }
 
     let finalConfig: AgentConfig = baseConfig;
+    let agentModelOverride: UMLModel | undefined;
 
     if (agentGenerationMode === 'personalization') {
       const localProfiles = LocalStorageRepository.getUserProfiles();
@@ -1019,10 +1027,36 @@ export function useGeneratorExecution(editor: ApollonEditor | undefined): UseGen
         ...baseConfig,
         personalizationMapping,
       };
+
+      // Personalization codegen rebuilds every variant on top of the model the
+      // backend receives. Send the un-personalized base from localStorage so
+      // generation is deterministic — without this, whichever variant is
+      // active in the editor would silently become the new "base" each variant
+      // is layered onto.
+      const baseAgentDiagramId = activeAgentDiagram?.id;
+      const storedBase = baseAgentDiagramId
+        ? LocalStorageRepository.getAgentBaseModel(baseAgentDiagramId)
+        : null;
+      if (storedBase && isUMLModel(storedBase) && storedBase.type === UMLDiagramType.AgentDiagram) {
+        agentModelOverride = storedBase;
+      } else {
+        // No stored base resolved — generation falls back to the active editor
+        // model, which may be a personalized variant rather than the
+        // un-personalized base. Surface it instead of silently shipping the
+        // wrong base.
+        console.warn(
+          '[generation] Personalization mode could not resolve a stored agent base model; ' +
+            'falling back to the active diagram. Save & Apply at least once to capture the base.',
+        );
+      }
     }
 
     const shouldSendConfig = Object.keys(finalConfig).length > 0;
-    await executeGenerator('agent', shouldSendConfig ? finalConfig : undefined);
+    await executeGenerator(
+      'agent',
+      shouldSendConfig ? finalConfig : undefined,
+      agentModelOverride ? { agentModelOverride } : undefined,
+    );
     setConfigDialog('none');
   }, [
     currentProject,

--- a/packages/webapp/src/main/shared/services/storage/__tests__/agent-base-model-normalization.test.ts
+++ b/packages/webapp/src/main/shared/services/storage/__tests__/agent-base-model-normalization.test.ts
@@ -1,0 +1,163 @@
+import { normalizeAgentModel } from '@besser/wme';
+import { LocalStorageRepository } from '../local-storage-repository';
+import { localStorageAgentBaseModels } from '../../../constants/constant';
+
+// Mock react-toastify (imported transitively by localStorageQuota).
+vi.mock('react-toastify', () => ({
+  toast: { warning: vi.fn(), error: vi.fn(), success: vi.fn() },
+}));
+
+type AnyModel = Record<string, any>;
+
+function flatTransition(id: string, condition: string, conditionValue: unknown): AnyModel {
+  return {
+    id,
+    name: '',
+    type: 'AgentStateTransition',
+    owner: null,
+    bounds: { x: 0, y: 0, width: 1, height: 1 },
+    source: { element: `${id}-src`, direction: 'Right' },
+    target: { element: `${id}-tgt`, direction: 'Left' },
+    path: [{ x: 0, y: 0 }],
+    isManuallyLayouted: false,
+    condition,
+    conditionValue,
+  };
+}
+
+function agentModel(relationships: Record<string, AnyModel>): AnyModel {
+  return {
+    version: '3.0.0',
+    type: 'AgentDiagram',
+    size: { width: 100, height: 100 },
+    elements: {},
+    interactive: { elements: {}, relationships: {} },
+    relationships,
+    assessments: {},
+  };
+}
+
+describe('normalizeAgentModel', () => {
+  it('upgrades a flat when_intent_matched transition to the nested shape', () => {
+    const out = normalizeAgentModel(
+      agentModel({ r1: flatTransition('r1', 'when_intent_matched', 'Greeting_intent') }) as any,
+    );
+    const rel = out.relationships.r1 as AnyModel;
+
+    expect(rel.transitionType).toBe('predefined');
+    expect(rel.predefined.predefinedType).toBe('when_intent_matched');
+    expect(rel.predefined.intentName).toBe('Greeting_intent');
+    // Flat keys are gone.
+    expect('condition' in rel).toBe(false);
+    expect('conditionValue' in rel).toBe(false);
+  });
+
+  it('upgrades when_no_intent_matched and auto transitions', () => {
+    const out = normalizeAgentModel(
+      agentModel({
+        a: flatTransition('a', 'when_no_intent_matched', ''),
+        b: flatTransition('b', 'auto', ''),
+      }) as any,
+    );
+
+    expect((out.relationships.a as AnyModel).predefined.predefinedType).toBe('when_no_intent_matched');
+    expect((out.relationships.b as AnyModel).predefined.predefinedType).toBe('auto');
+  });
+
+  it('maps an object conditionValue onto variable-operation fields', () => {
+    const out = normalizeAgentModel(
+      agentModel({
+        v: flatTransition('v', 'when_variable_operation_matched', {
+          variable: 'count',
+          operator: '>',
+          targetValue: '3',
+        }),
+      }) as any,
+    );
+    const predefined = (out.relationships.v as AnyModel).predefined;
+
+    expect(predefined.predefinedType).toBe('when_variable_operation_matched');
+    expect(predefined.conditionValue).toEqual({ variable: 'count', operator: '>', targetValue: '3' });
+  });
+
+  it('preserves the relationship id and endpoints', () => {
+    const out = normalizeAgentModel(
+      agentModel({ r1: flatTransition('r1', 'when_intent_matched', 'X') }) as any,
+    );
+    const rel = out.relationships.r1 as AnyModel;
+
+    expect(rel.id).toBe('r1');
+    expect(rel.source.element).toBe('r1-src');
+    expect(rel.target.element).toBe('r1-tgt');
+  });
+
+  it('is idempotent on already-nested input', () => {
+    const once = normalizeAgentModel(
+      agentModel({ r1: flatTransition('r1', 'when_intent_matched', 'X') }) as any,
+    );
+    const twice = normalizeAgentModel(once);
+
+    expect(twice.relationships.r1).toEqual(once.relationships.r1);
+  });
+
+  it('does not touch AgentStateTransitionInit relationships', () => {
+    const init = {
+      id: 'init',
+      name: '',
+      type: 'AgentStateTransitionInit',
+      owner: null,
+      bounds: { x: 0, y: 0, width: 1, height: 1 },
+      source: { element: 's' },
+      target: { element: 't' },
+      path: [],
+      isManuallyLayouted: false,
+    };
+    const out = normalizeAgentModel(agentModel({ init }) as any);
+
+    expect(out.relationships.init).toEqual(init);
+  });
+
+  it('does not mutate the input model', () => {
+    const input = agentModel({ r1: flatTransition('r1', 'auto', '') });
+    normalizeAgentModel(input as any);
+
+    expect((input.relationships.r1 as AnyModel).condition).toBe('auto');
+  });
+});
+
+describe('agent base model storage normalization', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('saveAgentBaseModel normalizes a flat model before persisting', () => {
+    LocalStorageRepository.saveAgentBaseModel(
+      'diagram-1',
+      agentModel({ r1: flatTransition('r1', 'when_intent_matched', 'Greeting_intent') }) as any,
+    );
+
+    const stored = LocalStorageRepository.getAgentBaseModel('diagram-1') as AnyModel;
+    const rel = stored.relationships.r1 as AnyModel;
+    expect(rel.predefined.predefinedType).toBe('when_intent_matched');
+    expect(rel.predefined.intentName).toBe('Greeting_intent');
+    expect('condition' in rel).toBe(false);
+  });
+
+  it('migrateToV4 normalizes a flat snapshot already in localStorage', () => {
+    // Seed localStorage directly with a legacy flat snapshot (bypassing the
+    // normalizing write path, simulating a project imported before the fix).
+    localStorage.setItem(
+      localStorageAgentBaseModels,
+      JSON.stringify({
+        'diagram-1': agentModel({ r1: flatTransition('r1', 'when_intent_matched', 'Greeting_intent') }),
+      }),
+    );
+
+    LocalStorageRepository.migrateToV4();
+
+    const migrated = LocalStorageRepository.getAgentBaseModel('diagram-1') as AnyModel;
+    const rel = migrated.relationships.r1 as AnyModel;
+    expect(rel.predefined.predefinedType).toBe('when_intent_matched');
+    expect('condition' in rel).toBe(false);
+  });
+});

--- a/packages/webapp/src/main/shared/services/storage/local-storage-repository.ts
+++ b/packages/webapp/src/main/shared/services/storage/local-storage-repository.ts
@@ -14,7 +14,7 @@ import {
   localStorageUserProfiles,
   localStorageUserThemePreference,
 } from '../../constants/constant';
-import { UMLModel } from '@besser/wme';
+import { UMLModel, normalizeAgentModel } from '@besser/wme';
 import { uuid } from '../../utils/uuid';
 import type { AgentConfigurationPayload, AgentLLMProvider, IntentRecognitionTechnology } from '../../types/agent-config';
 
@@ -160,8 +160,20 @@ const getStoredAgentBaseModels = (): AgentBaseModelMap => {
   }
 };
 
+/**
+ * Single chokepoint for writing ``besser_agentBaseModels``. Every entry is
+ * normalized to the canonical nested agent-transition shape before it lands in
+ * localStorage, so the legacy flat shape can never be persisted — whether the
+ * model came from the live editor, an imported project snapshot, or the V4
+ * migration. ``normalizeAgentModel`` is idempotent, so already-nested models are
+ * untouched.
+ */
 const persistAgentBaseModels = (entries: AgentBaseModelMap) => {
-  safeSetItem(localStorageAgentBaseModels, JSON.stringify(entries));
+  const normalized: AgentBaseModelMap = {};
+  for (const [diagramId, model] of Object.entries(entries)) {
+    normalized[diagramId] = model ? normalizeAgentModel(model) : model;
+  }
+  safeSetItem(localStorageAgentBaseModels, JSON.stringify(normalized));
 };
 
 export interface DeployLinkedRepo {
@@ -211,6 +223,24 @@ const parseDeployLinkedRepo = (raw: string | null): DeployLinkedRepo | null => {
 const migrateToV3 = (): void => {
   if (localStorage.getItem(localStorageSystemConfig) !== null) {
     localStorage.removeItem(localStorageSystemConfig);
+  }
+};
+
+/**
+ * v3 -> v4: normalize stored ``besser_agentBaseModels`` to the canonical nested
+ * agent-transition shape.
+ *
+ * Projects imported before this fix wrote their bundled ``agentBaseModels``
+ * snapshot to localStorage in the legacy flat shape (top-level
+ * ``condition`` / ``conditionValue``), which the backend collapses to
+ * ``when_no_intent_matched``. Re-persisting routes every entry through
+ * ``persistAgentBaseModels``, which normalizes them. Idempotent — already-nested
+ * snapshots round-trip unchanged, and an empty store is a no-op.
+ */
+const migrateToV4 = (): void => {
+  const stored = getStoredAgentBaseModels();
+  if (Object.keys(stored).length > 0) {
+    persistAgentBaseModels(stored);
   }
 };
 
@@ -519,4 +549,11 @@ export const LocalStorageRepository = {
    * Idempotent — safe to invoke on every boot.
    */
   migrateToV3,
+
+  /**
+   * v3 -> v4 migration: normalize stored agent base models to the canonical
+   * nested transition shape. Invoked by the storage-migration runner after V3.
+   * Idempotent — safe to invoke on every boot.
+   */
+  migrateToV4,
 };

--- a/packages/webapp/src/main/shared/utils/storage-migration.ts
+++ b/packages/webapp/src/main/shared/utils/storage-migration.ts
@@ -1,7 +1,7 @@
 import { LocalStorageRepository } from '../services/storage/local-storage-repository';
 
 const STORAGE_VERSION_KEY = 'besser_storage_version';
-const CURRENT_VERSION = 3;
+const CURRENT_VERSION = 4;
 
 interface Migration {
   version: number;
@@ -79,6 +79,19 @@ const migrations: Migration[] = [
     migrate: () => {
       LocalStorageRepository.migrateToV3();
       console.info('[storage-migration] v3: Removed deprecated besser_systemConfig key');
+    },
+  },
+  // v4: Normalize stored agent base models to the canonical nested transition
+  // shape. Projects imported before this fix wrote their bundled
+  // `agentBaseModels` snapshot in the legacy flat shape (top-level
+  // `condition`/`conditionValue`), which the backend collapses to
+  // `when_no_intent_matched`. Idempotent: already-nested snapshots round-trip
+  // unchanged, and an empty store is a no-op.
+  {
+    version: 4,
+    migrate: () => {
+      LocalStorageRepository.migrateToV4();
+      console.info('[storage-migration] v4: Normalized agent base models to nested shape');
     },
   },
 ];

--- a/packages/webapp/src/main/templates/pattern/agent/dbagent.json
+++ b/packages/webapp/src/main/templates/pattern/agent/dbagent.json
@@ -1,202 +1,200 @@
 {
-    "version": "3.0.0",
-    "type": "AgentDiagram",
-    "size": {
+  "version": "3.0.0",
+  "type": "AgentDiagram",
+  "size": {
     "width": 1260,
     "height": 400
-    },
-    "interactive": {
+  },
+  "interactive": {
     "elements": {},
     "relationships": {}
-    },
-    "elements": {
+  },
+  "elements": {
     "553fc567-842b-40f2-8ff1-3e24aa2e16a1": {
-        "id": "553fc567-842b-40f2-8ff1-3e24aa2e16a1",
-        "name": "initial",
-        "type": "AgentState",
-        "owner": null,
-        "bounds": {
+      "id": "553fc567-842b-40f2-8ff1-3e24aa2e16a1",
+      "name": "initial",
+      "type": "AgentState",
+      "owner": null,
+      "bounds": {
         "x": -470,
         "y": -170,
         "width": 170,
         "height": 40
-        },
-        "bodies": [],
-        "fallbackBodies": []
+      },
+      "bodies": [],
+      "fallbackBodies": []
     },
     "903f2a3e-1775-4439-b820-2fb117d1b2ff": {
-        "id": "903f2a3e-1775-4439-b820-2fb117d1b2ff",
-        "name": "",
-        "type": "StateInitialNode",
-        "owner": null,
-        "bounds": {
+      "id": "903f2a3e-1775-4439-b820-2fb117d1b2ff",
+      "name": "",
+      "type": "StateInitialNode",
+      "owner": null,
+      "bounds": {
         "x": -610,
         "y": -180,
         "width": 45,
         "height": 45
-        }
+      }
     },
     "6a1a4f06-38ee-48dc-976b-487a3c1f22e3": {
-        "id": "6a1a4f06-38ee-48dc-976b-487a3c1f22e3",
-        "name": "db_reply",
-        "type": "AgentState",
-        "owner": null,
-        "bounds": {
+      "id": "6a1a4f06-38ee-48dc-976b-487a3c1f22e3",
+      "name": "db_reply",
+      "type": "AgentState",
+      "owner": null,
+      "bounds": {
         "x": 30,
         "y": -180,
         "width": 420,
         "height": 70
-        },
-        "bodies": [
-        "8fd21f47-eacf-44e3-b245-0092fe729767"
-        ],
-        "fallbackBodies": []
+      },
+      "bodies": ["8fd21f47-eacf-44e3-b245-0092fe729767"],
+      "fallbackBodies": []
     },
     "8fd21f47-eacf-44e3-b245-0092fe729767": {
-        "id": "8fd21f47-eacf-44e3-b245-0092fe729767",
-        "name": "DB action using Default database (LLM query, SELECT)",
-        "type": "AgentStateBody",
-        "owner": "6a1a4f06-38ee-48dc-976b-487a3c1f22e3",
-        "bounds": {
+      "id": "8fd21f47-eacf-44e3-b245-0092fe729767",
+      "name": "DB action using Default database (LLM query, SELECT)",
+      "type": "AgentStateBody",
+      "owner": "6a1a4f06-38ee-48dc-976b-487a3c1f22e3",
+      "bounds": {
         "x": 30.5,
         "y": -139.5,
         "width": 419,
         "height": 30
-        },
-        "replyType": "db_reply",
-        "dbSelectionType": "default",
-        "dbCustomName": "",
-        "dbQueryMode": "llm_query",
-        "dbOperation": "select",
-        "dbSqlQuery": ""
+      },
+      "replyType": "db_reply",
+      "dbSelectionType": "default",
+      "dbCustomName": "",
+      "dbQueryMode": "llm_query",
+      "dbOperation": "select",
+      "dbSqlQuery": ""
     }
-    },
-    "relationships": {
+  },
+  "relationships": {
     "15348261-7ddf-4791-998a-5a3313e2356d": {
-        "id": "15348261-7ddf-4791-998a-5a3313e2356d",
-        "name": "",
-        "type": "AgentStateTransitionInit",
-        "owner": null,
-        "bounds": {
+      "id": "15348261-7ddf-4791-998a-5a3313e2356d",
+      "name": "",
+      "type": "AgentStateTransitionInit",
+      "owner": null,
+      "bounds": {
         "x": -565,
         "y": -150,
         "width": 95,
         "height": 3.75
-        },
-        "path": [
+      },
+      "path": [
         {
-            "x": 0,
-            "y": 3.75
-        },
-        {
-            "x": 47.5,
-            "y": 3.75
+          "x": 0,
+          "y": 3.75
         },
         {
-            "x": 47.5,
-            "y": 0
+          "x": 47.5,
+          "y": 3.75
         },
         {
-            "x": 95,
-            "y": 0
+          "x": 47.5,
+          "y": 0
+        },
+        {
+          "x": 95,
+          "y": 0
         }
-        ],
-        "source": {
+      ],
+      "source": {
         "direction": "Downright",
         "element": "903f2a3e-1775-4439-b820-2fb117d1b2ff"
-        },
-        "target": {
+      },
+      "target": {
         "direction": "Left",
         "element": "553fc567-842b-40f2-8ff1-3e24aa2e16a1"
-        },
-        "isManuallyLayouted": false
+      },
+      "isManuallyLayouted": false
     },
     "225835e1-3c7c-4f47-93e6-f9aec127cb83": {
-        "id": "225835e1-3c7c-4f47-93e6-f9aec127cb83",
-        "name": "",
-        "type": "AgentStateTransition",
-        "owner": null,
-        "bounds": {
+      "id": "225835e1-3c7c-4f47-93e6-f9aec127cb83",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
         "x": -300,
         "y": -150,
         "width": 330,
         "height": 1
-        },
-        "path": [
+      },
+      "path": [
         {
-            "x": 0,
-            "y": 0
+          "x": 0,
+          "y": 0
         },
         {
-            "x": 330,
-            "y": 0
+          "x": 330,
+          "y": 0
         }
-        ],
-        "source": {
+      ],
+      "source": {
         "direction": "Right",
         "element": "553fc567-842b-40f2-8ff1-3e24aa2e16a1"
-        },
-        "target": {
+      },
+      "target": {
         "direction": "Downleft",
         "element": "6a1a4f06-38ee-48dc-976b-487a3c1f22e3"
-        },
-        "isManuallyLayouted": false,
-        "transitionType": "custom",
-        "predefined": {
+      },
+      "isManuallyLayouted": false,
+      "transitionType": "custom",
+      "predefined": {
         "predefinedType": ""
-        },
-        "custom": {
+      },
+      "custom": {
         "event": "ReceiveTextEvent",
         "condition": []
-        }
+      }
     },
     "acb35c81-99cf-400e-9bfa-fcb062abbafc": {
-        "id": "acb35c81-99cf-400e-9bfa-fcb062abbafc",
-        "name": "",
-        "type": "AgentStateTransition",
-        "owner": null,
-        "bounds": {
+      "id": "acb35c81-99cf-400e-9bfa-fcb062abbafc",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
         "x": -385,
         "y": -130,
         "width": 625,
         "height": 60
-        },
-        "path": [
+      },
+      "path": [
         {
-            "x": 625,
-            "y": 20
-        },
-        {
-            "x": 625,
-            "y": 60
+          "x": 625,
+          "y": 20
         },
         {
-            "x": 0,
-            "y": 60
+          "x": 625,
+          "y": 60
         },
         {
-            "x": 0,
-            "y": 0
+          "x": 0,
+          "y": 60
+        },
+        {
+          "x": 0,
+          "y": 0
         }
-        ],
-        "source": {
+      ],
+      "source": {
         "direction": "Down",
         "element": "6a1a4f06-38ee-48dc-976b-487a3c1f22e3"
-        },
-        "target": {
+      },
+      "target": {
         "direction": "Down",
         "element": "553fc567-842b-40f2-8ff1-3e24aa2e16a1"
-        },
-        "isManuallyLayouted": false,
-        "transitionType": "predefined",
-        "predefined": {
+      },
+      "isManuallyLayouted": false,
+      "transitionType": "predefined",
+      "predefined": {
         "predefinedType": "auto",
         "conditionValue": ""
-        },
-        "custom": {
+      },
+      "custom": {
         "condition": []
-        }
+      }
     }
-    },
-    "assessments": {}
+  },
+  "assessments": {}
 }

--- a/packages/webapp/src/main/templates/pattern/agent/faqragagent.json
+++ b/packages/webapp/src/main/templates/pattern/agent/faqragagent.json
@@ -1,275 +1,293 @@
 {
   "version": "3.0.0",
   "type": "AgentDiagram",
-  "size": { "width": 1080, "height": 400 },
-  "interactive": { "elements": {}, "relationships": {} },
+  "size": {
+    "width": 1080,
+    "height": 400
+  },
+  "interactive": {
+    "elements": {},
+    "relationships": {}
+  },
   "elements": {
-            "0c1693ac-768b-44b0-83c4-7686fea85ee0": {
-              "id": "0c1693ac-768b-44b0-83c4-7686fea85ee0",
-              "name": "",
-              "type": "StateInitialNode",
-              "owner": null,
-              "bounds": {
-                "x": -640,
-                "y": -120,
-                "width": 45,
-                "height": 45
-              }
-            },
-            "8aa7d581-a5b7-4180-b205-0151cb7451d3": {
-              "id": "8aa7d581-a5b7-4180-b205-0151cb7451d3",
-              "name": "Greeting",
-              "type": "AgentState",
-              "owner": null,
-              "bounds": {
-                "x": -350,
-                "y": -170,
-                "width": 420,
-                "height": 70
-              },
-              "bodies": [
-                "0914f151-3e00-4fba-ba2d-89efb0e1467e"
-              ],
-              "fallbackBodies": []
-            },
-            "0914f151-3e00-4fba-ba2d-89efb0e1467e": {
-              "id": "0914f151-3e00-4fba-ba2d-89efb0e1467e",
-              "name": "Hi, I am your friendly assistant, I can answer questions related to BESSER.",
-              "type": "AgentStateBody",
-              "owner": "8aa7d581-a5b7-4180-b205-0151cb7451d3",
-              "bounds": {
-                "x": -349.5,
-                "y": -129.5,
-                "width": 419,
-                "height": 30
-              },
-              "replyType": "text",
-              "ragDatabaseName": ""
-            },
-            "073e90b9-9b2a-4a2e-807c-42c8ec90dc1f": {
-              "id": "073e90b9-9b2a-4a2e-807c-42c8ec90dc1f",
-              "name": "Idle",
-              "type": "AgentState",
-              "owner": null,
-              "bounds": {
-                "x": 350,
-                "y": -200,
-                "width": 420,
-                "height": 70
-              },
-              "bodies": [
-                "4ab8c422-2c84-493b-ae49-52bd0817e3d6"
-              ],
-              "fallbackBodies": []
-            },
-            "4ab8c422-2c84-493b-ae49-52bd0817e3d6": {
-              "id": "4ab8c422-2c84-493b-ae49-52bd0817e3d6",
-              "name": "What would you like to know about BESSER?",
-              "type": "AgentStateBody",
-              "owner": "073e90b9-9b2a-4a2e-807c-42c8ec90dc1f",
-              "bounds": {
-                "x": 350.5,
-                "y": -159.5,
-                "width": 419,
-                "height": 30
-              },
-              "replyType": "text",
-              "ragDatabaseName": ""
-            },
-            "72a9a181-3dc0-4f95-8adb-bddade2fccf4": {
-              "id": "72a9a181-3dc0-4f95-8adb-bddade2fccf4",
-              "name": "BESSER",
-              "type": "AgentRagElement",
-              "owner": null,
-              "bounds": {
-                "x": -200,
-                "y": 0,
-                "width": 120,
-                "height": 110
-              }
-            },
-            "ceeeda0d-b8f2-4025-ab23-4953ae07c264": {
-              "id": "ceeeda0d-b8f2-4025-ab23-4953ae07c264",
-              "name": "Response",
-              "type": "AgentState",
-              "owner": null,
-              "bounds": {
-                "x": 270,
-                "y": 120,
-                "width": 420,
-                "height": 70
-              },
-              "bodies": [
-                "10da515c-b8a4-489f-b3d9-fdf698922546"
-              ],
-              "fallbackBodies": []
-            },
-            "10da515c-b8a4-489f-b3d9-fdf698922546": {
-              "id": "10da515c-b8a4-489f-b3d9-fdf698922546",
-              "name": "RAG reply using BESSER database",
-              "type": "AgentStateBody",
-              "owner": "ceeeda0d-b8f2-4025-ab23-4953ae07c264",
-              "bounds": {
-                "x": 270.5,
-                "y": 160.5,
-                "width": 419,
-                "height": 30
-              },
-              "replyType": "rag",
-              "ragDatabaseName": "BESSER"
-            }
-          },
-        "relationships": {
-            "20b192c6-49fd-4260-b958-5c85fab9cdfa": {
-              "id": "20b192c6-49fd-4260-b958-5c85fab9cdfa",
-              "name": "",
-              "type": "AgentStateTransitionInit",
-              "owner": null,
-              "bounds": {
-                "x": -595,
-                "y": -152.5,
-                "width": 245,
-                "height": 55
-              },
-              "path": [
-                {
-                  "x": 0,
-                  "y": 55
-                },
-                {
-                  "x": 122.5,
-                  "y": 55
-                },
-                {
-                  "x": 122.5,
-                  "y": 0
-                },
-                {
-                  "x": 245,
-                  "y": 0
-                }
-              ],
-              "source": {
-                "direction": "Right",
-                "element": "0c1693ac-768b-44b0-83c4-7686fea85ee0"
-              },
-              "target": {
-                "direction": "Upleft",
-                "element": "8aa7d581-a5b7-4180-b205-0151cb7451d3"
-              },
-              "isManuallyLayouted": false
-            },
-            "db270a25-0697-4201-9275-da9c30a07dc2": {
-              "id": "db270a25-0697-4201-9275-da9c30a07dc2",
-              "name": "",
-              "type": "AgentStateTransition",
-              "owner": null,
-              "bounds": {
-                "x": 70,
-                "y": -150,
-                "width": 280,
-                "height": 1
-              },
-              "path": [
-                {
-                  "x": 0,
-                  "y": 0
-                },
-                {
-                  "x": 280,
-                  "y": 0
-                }
-              ],
-              "source": {
-                "direction": "Right",
-                "element": "8aa7d581-a5b7-4180-b205-0151cb7451d3"
-              },
-              "target": {
-                "direction": "Upleft",
-                "element": "073e90b9-9b2a-4a2e-807c-42c8ec90dc1f"
-              },
-              "isManuallyLayouted": false,
-              "condition": "auto",
-              "conditionValue": ""
-            },
-            "b8e27aba-df6f-4816-afb5-0bb39ebc1fda": {
-              "id": "b8e27aba-df6f-4816-afb5-0bb39ebc1fda",
-              "name": "",
-              "type": "AgentStateTransition",
-              "owner": null,
-              "bounds": {
-                "x": 230,
-                "y": -130,
-                "width": 225,
-                "height": 285
-              },
-              "path": [
-                {
-                  "x": 225,
-                  "y": 0
-                },
-                {
-                  "x": 225,
-                  "y": 40
-                },
-                {
-                  "x": 0,
-                  "y": 40
-                },
-                {
-                  "x": 0,
-                  "y": 285
-                },
-                {
-                  "x": 40,
-                  "y": 285
-                }
-              ],
-              "source": {
-                "direction": "Bottomleft",
-                "element": "073e90b9-9b2a-4a2e-807c-42c8ec90dc1f"
-              },
-              "target": {
-                "direction": "Left",
-                "element": "ceeeda0d-b8f2-4025-ab23-4953ae07c264"
-              },
-              "isManuallyLayouted": false,
-              "condition": "when_no_intent_matched",
-              "conditionValue": ""
-            },
-            "ee33f473-5d40-4a58-b5e8-5ad985e15644": {
-              "id": "ee33f473-5d40-4a58-b5e8-5ad985e15644",
-              "name": "",
-              "type": "AgentStateTransition",
-              "owner": null,
-              "bounds": {
-                "x": 520,
-                "y": -130,
-                "width": 1,
-                "height": 250
-              },
-              "path": [
-                {
-                  "x": 0,
-                  "y": 250
-                },
-                {
-                  "x": 0,
-                  "y": 0
-                }
-              ],
-              "source": {
-                "direction": "Topleft",
-                "element": "ceeeda0d-b8f2-4025-ab23-4953ae07c264"
-              },
-              "target": {
-                "direction": "Bottomleft",
-                "element": "073e90b9-9b2a-4a2e-807c-42c8ec90dc1f"
-              },
-              "isManuallyLayouted": false,
-              "condition": "auto",
-              "conditionValue": ""
-            }
-          },
+    "0c1693ac-768b-44b0-83c4-7686fea85ee0": {
+      "id": "0c1693ac-768b-44b0-83c4-7686fea85ee0",
+      "name": "",
+      "type": "StateInitialNode",
+      "owner": null,
+      "bounds": {
+        "x": -640,
+        "y": -120,
+        "width": 45,
+        "height": 45
+      }
+    },
+    "8aa7d581-a5b7-4180-b205-0151cb7451d3": {
+      "id": "8aa7d581-a5b7-4180-b205-0151cb7451d3",
+      "name": "Greeting",
+      "type": "AgentState",
+      "owner": null,
+      "bounds": {
+        "x": -350,
+        "y": -170,
+        "width": 420,
+        "height": 70
+      },
+      "bodies": ["0914f151-3e00-4fba-ba2d-89efb0e1467e"],
+      "fallbackBodies": []
+    },
+    "0914f151-3e00-4fba-ba2d-89efb0e1467e": {
+      "id": "0914f151-3e00-4fba-ba2d-89efb0e1467e",
+      "name": "Hi, I am your friendly assistant, I can answer questions related to BESSER.",
+      "type": "AgentStateBody",
+      "owner": "8aa7d581-a5b7-4180-b205-0151cb7451d3",
+      "bounds": {
+        "x": -349.5,
+        "y": -129.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "073e90b9-9b2a-4a2e-807c-42c8ec90dc1f": {
+      "id": "073e90b9-9b2a-4a2e-807c-42c8ec90dc1f",
+      "name": "Idle",
+      "type": "AgentState",
+      "owner": null,
+      "bounds": {
+        "x": 350,
+        "y": -200,
+        "width": 420,
+        "height": 70
+      },
+      "bodies": ["4ab8c422-2c84-493b-ae49-52bd0817e3d6"],
+      "fallbackBodies": []
+    },
+    "4ab8c422-2c84-493b-ae49-52bd0817e3d6": {
+      "id": "4ab8c422-2c84-493b-ae49-52bd0817e3d6",
+      "name": "What would you like to know about BESSER?",
+      "type": "AgentStateBody",
+      "owner": "073e90b9-9b2a-4a2e-807c-42c8ec90dc1f",
+      "bounds": {
+        "x": 350.5,
+        "y": -159.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "72a9a181-3dc0-4f95-8adb-bddade2fccf4": {
+      "id": "72a9a181-3dc0-4f95-8adb-bddade2fccf4",
+      "name": "BESSER",
+      "type": "AgentRagElement",
+      "owner": null,
+      "bounds": {
+        "x": -200,
+        "y": 0,
+        "width": 120,
+        "height": 110
+      }
+    },
+    "ceeeda0d-b8f2-4025-ab23-4953ae07c264": {
+      "id": "ceeeda0d-b8f2-4025-ab23-4953ae07c264",
+      "name": "Response",
+      "type": "AgentState",
+      "owner": null,
+      "bounds": {
+        "x": 270,
+        "y": 120,
+        "width": 420,
+        "height": 70
+      },
+      "bodies": ["10da515c-b8a4-489f-b3d9-fdf698922546"],
+      "fallbackBodies": []
+    },
+    "10da515c-b8a4-489f-b3d9-fdf698922546": {
+      "id": "10da515c-b8a4-489f-b3d9-fdf698922546",
+      "name": "RAG reply using BESSER database",
+      "type": "AgentStateBody",
+      "owner": "ceeeda0d-b8f2-4025-ab23-4953ae07c264",
+      "bounds": {
+        "x": 270.5,
+        "y": 160.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "rag",
+      "ragDatabaseName": "BESSER"
+    }
+  },
+  "relationships": {
+    "20b192c6-49fd-4260-b958-5c85fab9cdfa": {
+      "id": "20b192c6-49fd-4260-b958-5c85fab9cdfa",
+      "name": "",
+      "type": "AgentStateTransitionInit",
+      "owner": null,
+      "bounds": {
+        "x": -595,
+        "y": -152.5,
+        "width": 245,
+        "height": 55
+      },
+      "path": [
+        {
+          "x": 0,
+          "y": 55
+        },
+        {
+          "x": 122.5,
+          "y": 55
+        },
+        {
+          "x": 122.5,
+          "y": 0
+        },
+        {
+          "x": 245,
+          "y": 0
+        }
+      ],
+      "source": {
+        "direction": "Right",
+        "element": "0c1693ac-768b-44b0-83c4-7686fea85ee0"
+      },
+      "target": {
+        "direction": "Upleft",
+        "element": "8aa7d581-a5b7-4180-b205-0151cb7451d3"
+      },
+      "isManuallyLayouted": false
+    },
+    "db270a25-0697-4201-9275-da9c30a07dc2": {
+      "id": "db270a25-0697-4201-9275-da9c30a07dc2",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": 70,
+        "y": -150,
+        "width": 280,
+        "height": 1
+      },
+      "path": [
+        {
+          "x": 0,
+          "y": 0
+        },
+        {
+          "x": 280,
+          "y": 0
+        }
+      ],
+      "source": {
+        "direction": "Right",
+        "element": "8aa7d581-a5b7-4180-b205-0151cb7451d3"
+      },
+      "target": {
+        "direction": "Upleft",
+        "element": "073e90b9-9b2a-4a2e-807c-42c8ec90dc1f"
+      },
+      "isManuallyLayouted": false,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "auto",
+        "conditionValue": ""
+      },
+      "custom": {
+        "condition": []
+      }
+    },
+    "b8e27aba-df6f-4816-afb5-0bb39ebc1fda": {
+      "id": "b8e27aba-df6f-4816-afb5-0bb39ebc1fda",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": 230,
+        "y": -130,
+        "width": 225,
+        "height": 285
+      },
+      "path": [
+        {
+          "x": 225,
+          "y": 0
+        },
+        {
+          "x": 225,
+          "y": 40
+        },
+        {
+          "x": 0,
+          "y": 40
+        },
+        {
+          "x": 0,
+          "y": 285
+        },
+        {
+          "x": 40,
+          "y": 285
+        }
+      ],
+      "source": {
+        "direction": "Bottomleft",
+        "element": "073e90b9-9b2a-4a2e-807c-42c8ec90dc1f"
+      },
+      "target": {
+        "direction": "Left",
+        "element": "ceeeda0d-b8f2-4025-ab23-4953ae07c264"
+      },
+      "isManuallyLayouted": false,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "when_no_intent_matched",
+        "conditionValue": ""
+      },
+      "custom": {
+        "condition": []
+      }
+    },
+    "ee33f473-5d40-4a58-b5e8-5ad985e15644": {
+      "id": "ee33f473-5d40-4a58-b5e8-5ad985e15644",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": 520,
+        "y": -130,
+        "width": 1,
+        "height": 250
+      },
+      "path": [
+        {
+          "x": 0,
+          "y": 250
+        },
+        {
+          "x": 0,
+          "y": 0
+        }
+      ],
+      "source": {
+        "direction": "Topleft",
+        "element": "ceeeda0d-b8f2-4025-ab23-4953ae07c264"
+      },
+      "target": {
+        "direction": "Bottomleft",
+        "element": "073e90b9-9b2a-4a2e-807c-42c8ec90dc1f"
+      },
+      "isManuallyLayouted": false,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "auto",
+        "conditionValue": ""
+      },
+      "custom": {
+        "condition": []
+      }
+    }
+  },
   "assessments": {}
 }

--- a/packages/webapp/src/main/templates/pattern/agent/greetingagent.json
+++ b/packages/webapp/src/main/templates/pattern/agent/greetingagent.json
@@ -1,524 +1,554 @@
 {
   "version": "3.0.0",
   "type": "AgentDiagram",
-  "size": { "width": 1080, "height": 400 },
-  "interactive": { "elements": {}, "relationships": {} },
+  "size": {
+    "width": 1080,
+    "height": 400
+  },
+  "interactive": {
+    "elements": {},
+    "relationships": {}
+  },
   "elements": {
-            "97627a74-e4e6-48af-9989-8d714dfe83b8": {
-                "id": "97627a74-e4e6-48af-9989-8d714dfe83b8",
-                "name": "initial",
-                "type": "AgentState",
-                "owner": null,
-                "bounds": {
-                    "x": -350,
-                    "y": -30,
-                    "width": 140,
-                    "height": 40
-                },
-                "bodies": [],
-                "fallbackBodies": []
-            },
-            "269178e5-8e58-4ddc-803f-d91e99e93fde": {
-                "id": "269178e5-8e58-4ddc-803f-d91e99e93fde",
-                "name": "greeting",
-                "type": "AgentState",
-                "owner": null,
-                "bounds": {
-                    "x": -20,
-                    "y": -60,
-                    "width": 210,
-                    "height": 100
-                },
-                "bodies": [
-                    "354aee35-fcda-486b-85d8-854a3e620d2f",
-                    "40894ba0-5b4b-4229-9b17-49fffeeea4d8"
-                ],
-                "fallbackBodies": []
-            },
-            "354aee35-fcda-486b-85d8-854a3e620d2f": {
-                "id": "354aee35-fcda-486b-85d8-854a3e620d2f",
-                "name": "Hi!",
-                "type": "AgentStateBody",
-                "owner": "269178e5-8e58-4ddc-803f-d91e99e93fde",
-                "bounds": {
-                    "x": -19.5,
-                    "y": -19.5,
-                    "width": 209,
-                    "height": 30
-                },
-                "replyType": "text"
-            },
-            "40894ba0-5b4b-4229-9b17-49fffeeea4d8": {
-                "id": "40894ba0-5b4b-4229-9b17-49fffeeea4d8",
-                "name": "How are you?",
-                "type": "AgentStateBody",
-                "owner": "269178e5-8e58-4ddc-803f-d91e99e93fde",
-                "bounds": {
-                    "x": -19.5,
-                    "y": 10.5,
-                    "width": 209,
-                    "height": 30
-                },
-                "replyType": "text"
-            },
-            "d2c3ac6c-2869-4555-a599-4810168a3164": {
-                "id": "d2c3ac6c-2869-4555-a599-4810168a3164",
-                "name": "bad",
-                "type": "AgentState",
-                "owner": null,
-                "bounds": {
-                    "x": 310,
-                    "y": 120,
-                    "width": 220,
-                    "height": 70
-                },
-                "bodies": [
-                    "408f0c9a-e2f3-42b9-87fd-ec0e203b5d85"
-                ],
-                "fallbackBodies": []
-            },
-            "408f0c9a-e2f3-42b9-87fd-ec0e203b5d85": {
-                "id": "408f0c9a-e2f3-42b9-87fd-ec0e203b5d85",
-                "name": "I'm sorry to hear that...",
-                "type": "AgentStateBody",
-                "owner": "d2c3ac6c-2869-4555-a599-4810168a3164",
-                "bounds": {
-                    "x": 310.5,
-                    "y": 160.5,
-                    "width": 219,
-                    "height": 30
-                },
-                "replyType": "text"
-            },
-            "95bd55b0-680a-4f0c-9dd4-d4416344daca": {
-                "id": "95bd55b0-680a-4f0c-9dd4-d4416344daca",
-                "name": "",
-                "type": "StateInitialNode",
-                "owner": null,
-                "bounds": {
-                    "x": -470,
-                    "y": -30,
-                    "width": 45,
-                    "height": 45
-                }
-            },
-            "c629ac2b-4ce7-40bf-8382-41af767383c9": {
-                "id": "c629ac2b-4ce7-40bf-8382-41af767383c9",
-                "name": "Greeting_intent",
-                "type": "AgentIntent",
-                "owner": null,
-                "bounds": {
-                    "x": -640,
-                    "y": -350,
-                    "width": 230,
-                    "height": 130
-                },
-                "bodies": [
-                    "87648564-ea5f-43d2-aef0-0b8f1e4bb19c",
-                    "b230fdc3-0bf9-409e-b22e-a83b0017d9e3",
-                    "73e5374e-6fa8-42a8-b6ef-03f3b32be48b"
-                ]
-            },
-            "87648564-ea5f-43d2-aef0-0b8f1e4bb19c": {
-                "id": "87648564-ea5f-43d2-aef0-0b8f1e4bb19c",
-                "name": "Hi",
-                "type": "AgentIntentBody",
-                "owner": "c629ac2b-4ce7-40bf-8382-41af767383c9",
-                "bounds": {
-                    "x": -639.5,
-                    "y": -309.5,
-                    "width": 229,
-                    "height": 30
-                }
-            },
-            "b230fdc3-0bf9-409e-b22e-a83b0017d9e3": {
-                "id": "b230fdc3-0bf9-409e-b22e-a83b0017d9e3",
-                "name": "Hello",
-                "type": "AgentIntentBody",
-                "owner": "c629ac2b-4ce7-40bf-8382-41af767383c9",
-                "bounds": {
-                    "x": -639.5,
-                    "y": -279.5,
-                    "width": 229,
-                    "height": 30
-                }
-            },
-            "73e5374e-6fa8-42a8-b6ef-03f3b32be48b": {
-                "id": "73e5374e-6fa8-42a8-b6ef-03f3b32be48b",
-                "name": "Howdy",
-                "type": "AgentIntentBody",
-                "owner": "c629ac2b-4ce7-40bf-8382-41af767383c9",
-                "bounds": {
-                    "x": -639.5,
-                    "y": -249.5,
-                    "width": 229,
-                    "height": 30
-                }
-            },
-            "83ffb8ea-e7bc-489b-b799-89c79df708b8": {
-                "id": "83ffb8ea-e7bc-489b-b799-89c79df708b8",
-                "name": "good",
-                "type": "AgentState",
-                "owner": null,
-                "bounds": {
-                    "x": 320,
-                    "y": -170,
-                    "width": 220,
-                    "height": 70
-                },
-                "bodies": [
-                    "89df378b-5793-4fc4-bd6c-5ba8eeb173e0"
-                ],
-                "fallbackBodies": []
-            },
-            "89df378b-5793-4fc4-bd6c-5ba8eeb173e0": {
-                "id": "89df378b-5793-4fc4-bd6c-5ba8eeb173e0",
-                "name": "I am glad to hear that!",
-                "type": "AgentStateBody",
-                "owner": "83ffb8ea-e7bc-489b-b799-89c79df708b8",
-                "bounds": {
-                    "x": 320.5,
-                    "y": -129.5,
-                    "width": 219,
-                    "height": 30
-                },
-                "replyType": "text"
-            },
-            "4331ac3a-aac0-439e-a43b-622ceec672b4": {
-                "id": "4331ac3a-aac0-439e-a43b-622ceec672b4",
-                "name": "Good_intent",
-                "type": "AgentIntent",
-                "owner": null,
-                "bounds": {
-                    "x": -380,
-                    "y": -350,
-                    "width": 230,
-                    "height": 130
-                },
-                "bodies": [
-                    "a4f9f789-d4da-4db4-8f1f-1afd2c24fdff",
-                    "2e98b7ce-722a-4402-a995-3ca1d4e56605",
-                    "d58d039f-1851-4d83-aefb-b8adf392190e"
-                ]
-            },
-            "a4f9f789-d4da-4db4-8f1f-1afd2c24fdff": {
-                "id": "a4f9f789-d4da-4db4-8f1f-1afd2c24fdff",
-                "name": "Good",
-                "type": "AgentIntentBody",
-                "owner": "4331ac3a-aac0-439e-a43b-622ceec672b4",
-                "bounds": {
-                    "x": -379.5,
-                    "y": -309.5,
-                    "width": 229,
-                    "height": 30
-                }
-            },
-            "2e98b7ce-722a-4402-a995-3ca1d4e56605": {
-                "id": "2e98b7ce-722a-4402-a995-3ca1d4e56605",
-                "name": "Fine",
-                "type": "AgentIntentBody",
-                "owner": "4331ac3a-aac0-439e-a43b-622ceec672b4",
-                "bounds": {
-                    "x": -379.5,
-                    "y": -279.5,
-                    "width": 229,
-                    "height": 30
-                }
-            },
-            "d58d039f-1851-4d83-aefb-b8adf392190e": {
-                "id": "d58d039f-1851-4d83-aefb-b8adf392190e",
-                "name": "I'm alright",
-                "type": "AgentIntentBody",
-                "owner": "4331ac3a-aac0-439e-a43b-622ceec672b4",
-                "bounds": {
-                    "x": -379.5,
-                    "y": -249.5,
-                    "width": 229,
-                    "height": 30
-                }
-            },
-            "e999a3c8-25d5-4180-9c77-cdd78dcd9f74": {
-                "id": "e999a3c8-25d5-4180-9c77-cdd78dcd9f74",
-                "name": "Bad_intent",
-                "type": "AgentIntent",
-                "owner": null,
-                "bounds": {
-                    "x": -130,
-                    "y": -350,
-                    "width": 230,
-                    "height": 130
-                },
-                "bodies": [
-                    "b27ef549-9a7c-42b2-b64b-9923bc83a663",
-                    "cf17937f-875e-49c9-a39e-e99c09d9c466",
-                    "36e8e944-a64a-429b-8c36-907cc3bf80a0"
-                ]
-            },
-            "b27ef549-9a7c-42b2-b64b-9923bc83a663": {
-                "id": "b27ef549-9a7c-42b2-b64b-9923bc83a663",
-                "name": "Bad",
-                "type": "AgentIntentBody",
-                "owner": "e999a3c8-25d5-4180-9c77-cdd78dcd9f74",
-                "bounds": {
-                    "x": -129.5,
-                    "y": -309.5,
-                    "width": 229,
-                    "height": 30
-                }
-            },
-            "cf17937f-875e-49c9-a39e-e99c09d9c466": {
-                "id": "cf17937f-875e-49c9-a39e-e99c09d9c466",
-                "name": "Not so good",
-                "type": "AgentIntentBody",
-                "owner": "e999a3c8-25d5-4180-9c77-cdd78dcd9f74",
-                "bounds": {
-                    "x": -129.5,
-                    "y": -279.5,
-                    "width": 229,
-                    "height": 30
-                }
-            },
-            "36e8e944-a64a-429b-8c36-907cc3bf80a0": {
-                "id": "36e8e944-a64a-429b-8c36-907cc3bf80a0",
-                "name": "Could be better",
-                "type": "AgentIntentBody",
-                "owner": "e999a3c8-25d5-4180-9c77-cdd78dcd9f74",
-                "bounds": {
-                    "x": -129.5,
-                    "y": -249.5,
-                    "width": 229,
-                    "height": 30
-                }
-            }
+    "97627a74-e4e6-48af-9989-8d714dfe83b8": {
+      "id": "97627a74-e4e6-48af-9989-8d714dfe83b8",
+      "name": "initial",
+      "type": "AgentState",
+      "owner": null,
+      "bounds": {
+        "x": -350,
+        "y": -30,
+        "width": 140,
+        "height": 40
+      },
+      "bodies": [],
+      "fallbackBodies": []
+    },
+    "269178e5-8e58-4ddc-803f-d91e99e93fde": {
+      "id": "269178e5-8e58-4ddc-803f-d91e99e93fde",
+      "name": "greeting",
+      "type": "AgentState",
+      "owner": null,
+      "bounds": {
+        "x": -20,
+        "y": -60,
+        "width": 210,
+        "height": 100
+      },
+      "bodies": ["354aee35-fcda-486b-85d8-854a3e620d2f", "40894ba0-5b4b-4229-9b17-49fffeeea4d8"],
+      "fallbackBodies": []
+    },
+    "354aee35-fcda-486b-85d8-854a3e620d2f": {
+      "id": "354aee35-fcda-486b-85d8-854a3e620d2f",
+      "name": "Hi!",
+      "type": "AgentStateBody",
+      "owner": "269178e5-8e58-4ddc-803f-d91e99e93fde",
+      "bounds": {
+        "x": -19.5,
+        "y": -19.5,
+        "width": 209,
+        "height": 30
+      },
+      "replyType": "text"
+    },
+    "40894ba0-5b4b-4229-9b17-49fffeeea4d8": {
+      "id": "40894ba0-5b4b-4229-9b17-49fffeeea4d8",
+      "name": "How are you?",
+      "type": "AgentStateBody",
+      "owner": "269178e5-8e58-4ddc-803f-d91e99e93fde",
+      "bounds": {
+        "x": -19.5,
+        "y": 10.5,
+        "width": 209,
+        "height": 30
+      },
+      "replyType": "text"
+    },
+    "d2c3ac6c-2869-4555-a599-4810168a3164": {
+      "id": "d2c3ac6c-2869-4555-a599-4810168a3164",
+      "name": "bad",
+      "type": "AgentState",
+      "owner": null,
+      "bounds": {
+        "x": 310,
+        "y": 120,
+        "width": 220,
+        "height": 70
+      },
+      "bodies": ["408f0c9a-e2f3-42b9-87fd-ec0e203b5d85"],
+      "fallbackBodies": []
+    },
+    "408f0c9a-e2f3-42b9-87fd-ec0e203b5d85": {
+      "id": "408f0c9a-e2f3-42b9-87fd-ec0e203b5d85",
+      "name": "I'm sorry to hear that...",
+      "type": "AgentStateBody",
+      "owner": "d2c3ac6c-2869-4555-a599-4810168a3164",
+      "bounds": {
+        "x": 310.5,
+        "y": 160.5,
+        "width": 219,
+        "height": 30
+      },
+      "replyType": "text"
+    },
+    "95bd55b0-680a-4f0c-9dd4-d4416344daca": {
+      "id": "95bd55b0-680a-4f0c-9dd4-d4416344daca",
+      "name": "",
+      "type": "StateInitialNode",
+      "owner": null,
+      "bounds": {
+        "x": -470,
+        "y": -30,
+        "width": 45,
+        "height": 45
+      }
+    },
+    "c629ac2b-4ce7-40bf-8382-41af767383c9": {
+      "id": "c629ac2b-4ce7-40bf-8382-41af767383c9",
+      "name": "Greeting_intent",
+      "type": "AgentIntent",
+      "owner": null,
+      "bounds": {
+        "x": -640,
+        "y": -350,
+        "width": 230,
+        "height": 130
+      },
+      "bodies": [
+        "87648564-ea5f-43d2-aef0-0b8f1e4bb19c",
+        "b230fdc3-0bf9-409e-b22e-a83b0017d9e3",
+        "73e5374e-6fa8-42a8-b6ef-03f3b32be48b"
+      ]
+    },
+    "87648564-ea5f-43d2-aef0-0b8f1e4bb19c": {
+      "id": "87648564-ea5f-43d2-aef0-0b8f1e4bb19c",
+      "name": "Hi",
+      "type": "AgentIntentBody",
+      "owner": "c629ac2b-4ce7-40bf-8382-41af767383c9",
+      "bounds": {
+        "x": -639.5,
+        "y": -309.5,
+        "width": 229,
+        "height": 30
+      }
+    },
+    "b230fdc3-0bf9-409e-b22e-a83b0017d9e3": {
+      "id": "b230fdc3-0bf9-409e-b22e-a83b0017d9e3",
+      "name": "Hello",
+      "type": "AgentIntentBody",
+      "owner": "c629ac2b-4ce7-40bf-8382-41af767383c9",
+      "bounds": {
+        "x": -639.5,
+        "y": -279.5,
+        "width": 229,
+        "height": 30
+      }
+    },
+    "73e5374e-6fa8-42a8-b6ef-03f3b32be48b": {
+      "id": "73e5374e-6fa8-42a8-b6ef-03f3b32be48b",
+      "name": "Howdy",
+      "type": "AgentIntentBody",
+      "owner": "c629ac2b-4ce7-40bf-8382-41af767383c9",
+      "bounds": {
+        "x": -639.5,
+        "y": -249.5,
+        "width": 229,
+        "height": 30
+      }
+    },
+    "83ffb8ea-e7bc-489b-b799-89c79df708b8": {
+      "id": "83ffb8ea-e7bc-489b-b799-89c79df708b8",
+      "name": "good",
+      "type": "AgentState",
+      "owner": null,
+      "bounds": {
+        "x": 320,
+        "y": -170,
+        "width": 220,
+        "height": 70
+      },
+      "bodies": ["89df378b-5793-4fc4-bd6c-5ba8eeb173e0"],
+      "fallbackBodies": []
+    },
+    "89df378b-5793-4fc4-bd6c-5ba8eeb173e0": {
+      "id": "89df378b-5793-4fc4-bd6c-5ba8eeb173e0",
+      "name": "I am glad to hear that!",
+      "type": "AgentStateBody",
+      "owner": "83ffb8ea-e7bc-489b-b799-89c79df708b8",
+      "bounds": {
+        "x": 320.5,
+        "y": -129.5,
+        "width": 219,
+        "height": 30
+      },
+      "replyType": "text"
+    },
+    "4331ac3a-aac0-439e-a43b-622ceec672b4": {
+      "id": "4331ac3a-aac0-439e-a43b-622ceec672b4",
+      "name": "Good_intent",
+      "type": "AgentIntent",
+      "owner": null,
+      "bounds": {
+        "x": -380,
+        "y": -350,
+        "width": 230,
+        "height": 130
+      },
+      "bodies": [
+        "a4f9f789-d4da-4db4-8f1f-1afd2c24fdff",
+        "2e98b7ce-722a-4402-a995-3ca1d4e56605",
+        "d58d039f-1851-4d83-aefb-b8adf392190e"
+      ]
+    },
+    "a4f9f789-d4da-4db4-8f1f-1afd2c24fdff": {
+      "id": "a4f9f789-d4da-4db4-8f1f-1afd2c24fdff",
+      "name": "Good",
+      "type": "AgentIntentBody",
+      "owner": "4331ac3a-aac0-439e-a43b-622ceec672b4",
+      "bounds": {
+        "x": -379.5,
+        "y": -309.5,
+        "width": 229,
+        "height": 30
+      }
+    },
+    "2e98b7ce-722a-4402-a995-3ca1d4e56605": {
+      "id": "2e98b7ce-722a-4402-a995-3ca1d4e56605",
+      "name": "Fine",
+      "type": "AgentIntentBody",
+      "owner": "4331ac3a-aac0-439e-a43b-622ceec672b4",
+      "bounds": {
+        "x": -379.5,
+        "y": -279.5,
+        "width": 229,
+        "height": 30
+      }
+    },
+    "d58d039f-1851-4d83-aefb-b8adf392190e": {
+      "id": "d58d039f-1851-4d83-aefb-b8adf392190e",
+      "name": "I'm alright",
+      "type": "AgentIntentBody",
+      "owner": "4331ac3a-aac0-439e-a43b-622ceec672b4",
+      "bounds": {
+        "x": -379.5,
+        "y": -249.5,
+        "width": 229,
+        "height": 30
+      }
+    },
+    "e999a3c8-25d5-4180-9c77-cdd78dcd9f74": {
+      "id": "e999a3c8-25d5-4180-9c77-cdd78dcd9f74",
+      "name": "Bad_intent",
+      "type": "AgentIntent",
+      "owner": null,
+      "bounds": {
+        "x": -130,
+        "y": -350,
+        "width": 230,
+        "height": 130
+      },
+      "bodies": [
+        "b27ef549-9a7c-42b2-b64b-9923bc83a663",
+        "cf17937f-875e-49c9-a39e-e99c09d9c466",
+        "36e8e944-a64a-429b-8c36-907cc3bf80a0"
+      ]
+    },
+    "b27ef549-9a7c-42b2-b64b-9923bc83a663": {
+      "id": "b27ef549-9a7c-42b2-b64b-9923bc83a663",
+      "name": "Bad",
+      "type": "AgentIntentBody",
+      "owner": "e999a3c8-25d5-4180-9c77-cdd78dcd9f74",
+      "bounds": {
+        "x": -129.5,
+        "y": -309.5,
+        "width": 229,
+        "height": 30
+      }
+    },
+    "cf17937f-875e-49c9-a39e-e99c09d9c466": {
+      "id": "cf17937f-875e-49c9-a39e-e99c09d9c466",
+      "name": "Not so good",
+      "type": "AgentIntentBody",
+      "owner": "e999a3c8-25d5-4180-9c77-cdd78dcd9f74",
+      "bounds": {
+        "x": -129.5,
+        "y": -279.5,
+        "width": 229,
+        "height": 30
+      }
+    },
+    "36e8e944-a64a-429b-8c36-907cc3bf80a0": {
+      "id": "36e8e944-a64a-429b-8c36-907cc3bf80a0",
+      "name": "Could be better",
+      "type": "AgentIntentBody",
+      "owner": "e999a3c8-25d5-4180-9c77-cdd78dcd9f74",
+      "bounds": {
+        "x": -129.5,
+        "y": -249.5,
+        "width": 229,
+        "height": 30
+      }
+    }
+  },
+  "relationships": {
+    "f21d5200-0820-4ea2-a1a7-1f208d8bfa3a": {
+      "id": "f21d5200-0820-4ea2-a1a7-1f208d8bfa3a",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": -210,
+        "y": -10,
+        "width": 190,
+        "height": 1
+      },
+      "path": [
+        {
+          "x": 0,
+          "y": 0
         },
-        "relationships": {
-            "f21d5200-0820-4ea2-a1a7-1f208d8bfa3a": {
-                "id": "f21d5200-0820-4ea2-a1a7-1f208d8bfa3a",
-                "name": "",
-                "type": "AgentStateTransition",
-                "owner": null,
-                "bounds": {
-                    "x": -210,
-                    "y": -10,
-                    "width": 190,
-                    "height": 1
-                },
-                "path": [
-                    {
-                        "x": 0,
-                        "y": 0
-                    },
-                    {
-                        "x": 190,
-                        "y": 0
-                    }
-                ],
-                "source": {
-                    "direction": "Right",
-                    "element": "97627a74-e4e6-48af-9989-8d714dfe83b8"
-                },
-                "target": {
-                    "direction": "Downleft",
-                    "element": "269178e5-8e58-4ddc-803f-d91e99e93fde"
-                },
-                "isManuallyLayouted": false,
-                "condition": "when_intent_matched",
-                "conditionValue": "Greeting_intent"
-            },
-            "44b4863b-d7da-4316-bfc1-8dc0cfefc2d0": {
-                "id": "44b4863b-d7da-4316-bfc1-8dc0cfefc2d0",
-                "name": "",
-                "type": "AgentStateTransitionInit",
-                "owner": null,
-                "bounds": {
-                    "x": -425,
-                    "y": -10,
-                    "width": 75,
-                    "height": 1
-                },
-                "path": [
-                    {
-                        "x": 0,
-                        "y": 0
-                    },
-                    {
-                        "x": 75,
-                        "y": 0
-                    }
-                ],
-                "source": {
-                    "direction": "Right",
-                    "element": "95bd55b0-680a-4f0c-9dd4-d4416344daca"
-                },
-                "target": {
-                    "direction": "Left",
-                    "element": "97627a74-e4e6-48af-9989-8d714dfe83b8"
-                },
-                "isManuallyLayouted": false
-            },
-            "324b41be-02fe-4dfa-8ab3-079b8e84fd01": {
-                "id": "324b41be-02fe-4dfa-8ab3-079b8e84fd01",
-                "name": "",
-                "type": "AgentStateTransition",
-                "owner": null,
-                "bounds": {
-                    "x": 190,
-                    "y": -135,
-                    "width": 130,
-                    "height": 125
-                },
-                "path": [
-                    {
-                        "x": 0,
-                        "y": 125
-                    },
-                    {
-                        "x": 65,
-                        "y": 125
-                    },
-                    {
-                        "x": 65,
-                        "y": 0
-                    },
-                    {
-                        "x": 130,
-                        "y": 0
-                    }
-                ],
-                "source": {
-                    "direction": "Right",
-                    "element": "269178e5-8e58-4ddc-803f-d91e99e93fde"
-                },
-                "target": {
-                    "direction": "Left",
-                    "element": "83ffb8ea-e7bc-489b-b799-89c79df708b8"
-                },
-                "isManuallyLayouted": true,
-                "condition": "when_intent_matched",
-                "conditionValue": "Good_intent"
-            },
-            "08c4c033-e087-4e5a-948d-d694f951fd9e": {
-                "id": "08c4c033-e087-4e5a-948d-d694f951fd9e",
-                "name": "",
-                "type": "AgentStateTransition",
-                "owner": null,
-                "bounds": {
-                    "x": 190,
-                    "y": 15,
-                    "width": 120,
-                    "height": 140
-                },
-                "path": [
-                    {
-                        "x": 0,
-                        "y": 0
-                    },
-                    {
-                        "x": 60,
-                        "y": 0
-                    },
-                    {
-                        "x": 60,
-                        "y": 140
-                    },
-                    {
-                        "x": 120,
-                        "y": 140
-                    }
-                ],
-                "source": {
-                    "direction": "Downright",
-                    "element": "269178e5-8e58-4ddc-803f-d91e99e93fde"
-                },
-                "target": {
-                    "direction": "Left",
-                    "element": "d2c3ac6c-2869-4555-a599-4810168a3164"
-                },
-                "isManuallyLayouted": false,
-                "condition": "when_intent_matched",
-                "conditionValue": "Bad_intent"
-            },
-            "b10d2d94-f9b2-431b-bce1-dea689ea34ae": {
-                "id": "b10d2d94-f9b2-431b-bce1-dea689ea34ae",
-                "name": "",
-                "type": "AgentStateTransition",
-                "owner": null,
-                "bounds": {
-                    "x": -280,
-                    "y": -210,
-                    "width": 720,
-                    "height": 180
-                },
-                "path": [
-                    {
-                        "x": 710,
-                        "y": 40
-                    },
-                    {
-                        "x": 710,
-                        "y": 29
-                    },
-                    {
-                        "x": 0,
-                        "y": 29
-                    },
-                    {
-                        "x": 0,
-                        "y": 180
-                    }
-                ],
-                "source": {
-                    "direction": "Up",
-                    "element": "83ffb8ea-e7bc-489b-b799-89c79df708b8"
-                },
-                "target": {
-                    "direction": "Up",
-                    "element": "97627a74-e4e6-48af-9989-8d714dfe83b8"
-                },
-                "isManuallyLayouted": true,
-                "condition": "auto",
-                "conditionValue": ""
-            },
-            "a744cb97-e58a-431b-b1fa-f2dbe0905192": {
-                "id": "a744cb97-e58a-431b-b1fa-f2dbe0905192",
-                "name": "",
-                "type": "AgentStateTransition",
-                "owner": null,
-                "bounds": {
-                    "x": -280,
-                    "y": 10,
-                    "width": 645,
-                    "height": 220
-                },
-                "path": [
-                    {
-                        "x": 645,
-                        "y": 180
-                    },
-                    {
-                        "x": 645,
-                        "y": 220
-                    },
-                    {
-                        "x": 0,
-                        "y": 220
-                    },
-                    {
-                        "x": 0,
-                        "y": 0
-                    }
-                ],
-                "source": {
-                    "direction": "Bottomleft",
-                    "element": "d2c3ac6c-2869-4555-a599-4810168a3164"
-                },
-                "target": {
-                    "direction": "Down",
-                    "element": "97627a74-e4e6-48af-9989-8d714dfe83b8"
-                },
-                "isManuallyLayouted": true,
-                "condition": "auto",                "conditionValue": ""
-            }
+        {
+          "x": 190,
+          "y": 0
+        }
+      ],
+      "source": {
+        "direction": "Right",
+        "element": "97627a74-e4e6-48af-9989-8d714dfe83b8"
+      },
+      "target": {
+        "direction": "Downleft",
+        "element": "269178e5-8e58-4ddc-803f-d91e99e93fde"
+      },
+      "isManuallyLayouted": false,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "when_intent_matched",
+        "intentName": "Greeting_intent"
+      },
+      "custom": {
+        "condition": []
+      }
+    },
+    "44b4863b-d7da-4316-bfc1-8dc0cfefc2d0": {
+      "id": "44b4863b-d7da-4316-bfc1-8dc0cfefc2d0",
+      "name": "",
+      "type": "AgentStateTransitionInit",
+      "owner": null,
+      "bounds": {
+        "x": -425,
+        "y": -10,
+        "width": 75,
+        "height": 1
+      },
+      "path": [
+        {
+          "x": 0,
+          "y": 0
         },
+        {
+          "x": 75,
+          "y": 0
+        }
+      ],
+      "source": {
+        "direction": "Right",
+        "element": "95bd55b0-680a-4f0c-9dd4-d4416344daca"
+      },
+      "target": {
+        "direction": "Left",
+        "element": "97627a74-e4e6-48af-9989-8d714dfe83b8"
+      },
+      "isManuallyLayouted": false
+    },
+    "324b41be-02fe-4dfa-8ab3-079b8e84fd01": {
+      "id": "324b41be-02fe-4dfa-8ab3-079b8e84fd01",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": 190,
+        "y": -135,
+        "width": 130,
+        "height": 125
+      },
+      "path": [
+        {
+          "x": 0,
+          "y": 125
+        },
+        {
+          "x": 65,
+          "y": 125
+        },
+        {
+          "x": 65,
+          "y": 0
+        },
+        {
+          "x": 130,
+          "y": 0
+        }
+      ],
+      "source": {
+        "direction": "Right",
+        "element": "269178e5-8e58-4ddc-803f-d91e99e93fde"
+      },
+      "target": {
+        "direction": "Left",
+        "element": "83ffb8ea-e7bc-489b-b799-89c79df708b8"
+      },
+      "isManuallyLayouted": true,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "when_intent_matched",
+        "intentName": "Good_intent"
+      },
+      "custom": {
+        "condition": []
+      }
+    },
+    "08c4c033-e087-4e5a-948d-d694f951fd9e": {
+      "id": "08c4c033-e087-4e5a-948d-d694f951fd9e",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": 190,
+        "y": 15,
+        "width": 120,
+        "height": 140
+      },
+      "path": [
+        {
+          "x": 0,
+          "y": 0
+        },
+        {
+          "x": 60,
+          "y": 0
+        },
+        {
+          "x": 60,
+          "y": 140
+        },
+        {
+          "x": 120,
+          "y": 140
+        }
+      ],
+      "source": {
+        "direction": "Downright",
+        "element": "269178e5-8e58-4ddc-803f-d91e99e93fde"
+      },
+      "target": {
+        "direction": "Left",
+        "element": "d2c3ac6c-2869-4555-a599-4810168a3164"
+      },
+      "isManuallyLayouted": false,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "when_intent_matched",
+        "intentName": "Bad_intent"
+      },
+      "custom": {
+        "condition": []
+      }
+    },
+    "b10d2d94-f9b2-431b-bce1-dea689ea34ae": {
+      "id": "b10d2d94-f9b2-431b-bce1-dea689ea34ae",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": -280,
+        "y": -210,
+        "width": 720,
+        "height": 180
+      },
+      "path": [
+        {
+          "x": 710,
+          "y": 40
+        },
+        {
+          "x": 710,
+          "y": 29
+        },
+        {
+          "x": 0,
+          "y": 29
+        },
+        {
+          "x": 0,
+          "y": 180
+        }
+      ],
+      "source": {
+        "direction": "Up",
+        "element": "83ffb8ea-e7bc-489b-b799-89c79df708b8"
+      },
+      "target": {
+        "direction": "Up",
+        "element": "97627a74-e4e6-48af-9989-8d714dfe83b8"
+      },
+      "isManuallyLayouted": true,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "auto",
+        "conditionValue": ""
+      },
+      "custom": {
+        "condition": []
+      }
+    },
+    "a744cb97-e58a-431b-b1fa-f2dbe0905192": {
+      "id": "a744cb97-e58a-431b-b1fa-f2dbe0905192",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": -280,
+        "y": 10,
+        "width": 645,
+        "height": 220
+      },
+      "path": [
+        {
+          "x": 645,
+          "y": 180
+        },
+        {
+          "x": 645,
+          "y": 220
+        },
+        {
+          "x": 0,
+          "y": 220
+        },
+        {
+          "x": 0,
+          "y": 0
+        }
+      ],
+      "source": {
+        "direction": "Bottomleft",
+        "element": "d2c3ac6c-2869-4555-a599-4810168a3164"
+      },
+      "target": {
+        "direction": "Down",
+        "element": "97627a74-e4e6-48af-9989-8d714dfe83b8"
+      },
+      "isManuallyLayouted": true,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "auto",
+        "conditionValue": ""
+      },
+      "custom": {
+        "condition": []
+      }
+    }
+  },
   "assessments": {}
 }

--- a/packages/webapp/src/main/templates/pattern/agent/gymagent.json
+++ b/packages/webapp/src/main/templates/pattern/agent/gymagent.json
@@ -1,674 +1,707 @@
 {
   "version": "3.0.0",
   "type": "AgentDiagram",
-  "size": { "width": 1080, "height": 400 },
-  "interactive": { "elements": {}, "relationships": {} },
-  "elements": {
-    
-            "699853eb-918b-4674-b08c-cf0af3cc61d7": {
-              "id": "699853eb-918b-4674-b08c-cf0af3cc61d7",
-              "name": "",
-              "type": "StateInitialNode",
-              "owner": null,
-              "bounds": {
-                "x": -230,
-                "y": -370,
-                "width": 45,
-                "height": 45
-              }
-            },
-            "0cba5357-2c30-414b-8d74-ac74ac4ab158": {
-              "id": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
-              "name": "Idle",
-              "type": "AgentState",
-              "owner": null,
-              "bounds": {
-                "x": -180,
-                "y": -200,
-                "width": 420,
-                "height": 100
-              },
-              "bodies": [
-                "63a2c160-ebbb-457b-953a-93fd2e643224"
-              ],
-              "fallbackBodies": [
-                "1f369122-06c2-4050-ba54-4ea160f95a8c"
-              ]
-            },
-            "63a2c160-ebbb-457b-953a-93fd2e643224": {
-              "id": "63a2c160-ebbb-457b-953a-93fd2e643224",
-              "name": "I am here to answer any questions regarding exercises, nutrition and recovery.",
-              "type": "AgentStateBody",
-              "owner": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
-              "bounds": {
-                "x": -179.5,
-                "y": -159.5,
-                "width": 419,
-                "height": 30
-              },
-              "replyType": "text",
-              "ragDatabaseName": ""
-            },
-            "1f369122-06c2-4050-ba54-4ea160f95a8c": {
-              "id": "1f369122-06c2-4050-ba54-4ea160f95a8c",
-              "name": "I focus on gym and fitness topics only dude.",
-              "type": "AgentStateFallbackBody",
-              "owner": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
-              "bounds": {
-                "x": -179.5,
-                "y": -129.5,
-                "width": 419,
-                "height": 30
-              },
-              "replyType": "text",
-              "ragDatabaseName": ""
-            },
-            "8dba49ff-2fc1-4066-b124-19e2df7981e2": {
-              "id": "8dba49ff-2fc1-4066-b124-19e2df7981e2",
-              "name": "Muscles_intent",
-              "type": "AgentIntent",
-              "owner": null,
-              "bounds": {
-                "x": -900,
-                "y": -400,
-                "width": 630,
-                "height": 100
-              },
-              "bodies": [
-                "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b"
-              ],
-              "intent_description": "Question about how to become muscular and which exercises to perform."
-            },
-            "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b": {
-              "id": "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b",
-              "name": "I want muscles",
-              "type": "AgentIntentBody",
-              "owner": "8dba49ff-2fc1-4066-b124-19e2df7981e2",
-              "bounds": {
-                "x": -899.5,
-                "y": -329.5,
-                "width": 629,
-                "height": 30
-              }
-            },
-            "68ccb630-b264-41a0-b70e-1e369bd5706c": {
-              "id": "68ccb630-b264-41a0-b70e-1e369bd5706c",
-              "name": "TrainingPlan",
-              "type": "AgentState",
-              "owner": null,
-              "bounds": {
-                "x": -800,
-                "y": -30,
-                "width": 420,
-                "height": 130
-              },
-              "bodies": [
-                "aa261be5-9c53-4df1-a72f-5a107ce8f1b7",
-                "747b8558-325d-4a15-baba-0d18a6602a8d",
-                "900f7fd9-738a-4981-a7d9-6c7334621981"
-              ],
-              "fallbackBodies": []
-            },
-            "aa261be5-9c53-4df1-a72f-5a107ce8f1b7": {
-              "id": "aa261be5-9c53-4df1-a72f-5a107ce8f1b7",
-              "name": "Focus on heavy compound lifts like squats, deadlifts, bench press, overhead press, and rows to build overall muscle mass. ",
-              "type": "AgentStateBody",
-              "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
-              "bounds": {
-                "x": -799.5,
-                "y": 10.5,
-                "width": 419,
-                "height": 30
-              },
-              "replyType": "text",
-              "ragDatabaseName": ""
-            },
-            "747b8558-325d-4a15-baba-0d18a6602a8d": {
-              "id": "747b8558-325d-4a15-baba-0d18a6602a8d",
-              "name": "Train 3–5 times per week, progressively increasing the weight while eating enough protein and calories to support growth. ",
-              "type": "AgentStateBody",
-              "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
-              "bounds": {
-                "x": -799.5,
-                "y": 40.5,
-                "width": 419,
-                "height": 30
-              },
-              "replyType": "text",
-              "ragDatabaseName": ""
-            },
-            "900f7fd9-738a-4981-a7d9-6c7334621981": {
-              "id": "900f7fd9-738a-4981-a7d9-6c7334621981",
-              "name": "Get good sleep and stay consistent—muscle comes from steady effort over time.",
-              "type": "AgentStateBody",
-              "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
-              "bounds": {
-                "x": -799.5,
-                "y": 70.5,
-                "width": 419,
-                "height": 30
-              },
-              "replyType": "text",
-              "ragDatabaseName": ""
-            },
-            "77976ef7-599d-4c49-9f4d-1ecb23239fe3": {
-              "id": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
-              "name": "Initial",
-              "type": "AgentState",
-              "owner": null,
-              "bounds": {
-                "x": -100,
-                "y": -370,
-                "width": 420,
-                "height": 70
-              },
-              "bodies": [
-                "ad226172-93d8-4644-80c5-62825565dd24"
-              ],
-              "fallbackBodies": []
-            },
-            "ad226172-93d8-4644-80c5-62825565dd24": {
-              "id": "ad226172-93d8-4644-80c5-62825565dd24",
-              "name": "Hi, I am your buddy, the fitness agent.",
-              "type": "AgentStateBody",
-              "owner": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
-              "bounds": {
-                "x": -99.5,
-                "y": -329.5,
-                "width": 419,
-                "height": 30
-              },
-              "replyType": "text",
-              "ragDatabaseName": ""
-            },
-            "7610bbda-21ef-4637-a188-1da1352bea17": {
-              "id": "7610bbda-21ef-4637-a188-1da1352bea17",
-              "name": "Nutrition",
-              "type": "AgentState",
-              "owner": null,
-              "bounds": {
-                "x": -150,
-                "y": 130,
-                "width": 420,
-                "height": 190
-              },
-              "bodies": [
-                "bb7e67bd-ead9-4f14-93db-c18af0d806af",
-                "13072ea8-9b51-45fe-927e-a9323627701b",
-                "95241c3a-f8a2-4bf0-b169-5dcff5a926fb",
-                "44904a03-ac46-4f9f-983a-f6a740b81c0e",
-                "90dfba4f-6dec-4ca8-8c15-786ed36587a1"
-              ],
-              "fallbackBodies": []
-            },
-            "bb7e67bd-ead9-4f14-93db-c18af0d806af": {
-              "id": "bb7e67bd-ead9-4f14-93db-c18af0d806af",
-              "name": "Nutrition basics: Eat mostly whole foods (lean protein, vegetables, fruits, whole grains, healthy fats). Protein: ~1.6–2.2 g per kg of body weight daily..",
-              "type": "AgentStateBody",
-              "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
-              "bounds": {
-                "x": -149.5,
-                "y": 170.5,
-                "width": 419,
-                "height": 30
-              },
-              "replyType": "text",
-              "ragDatabaseName": ""
-            },
-            "13072ea8-9b51-45fe-927e-a9323627701b": {
-              "id": "13072ea8-9b51-45fe-927e-a9323627701b",
-              "name": "Match calories to your goal: slight surplus to gain muscle, deficit to lose fat, maintenance to stay the same. ",
-              "type": "AgentStateBody",
-              "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
-              "bounds": {
-                "x": -149.5,
-                "y": 200.5,
-                "width": 419,
-                "height": 30
-              },
-              "replyType": "text",
-              "ragDatabaseName": ""
-            },
-            "95241c3a-f8a2-4bf0-b169-5dcff5a926fb": {
-              "id": "95241c3a-f8a2-4bf0-b169-5dcff5a926fb",
-              "name": " Carbs fuel training; fats support hormones.",
-              "type": "AgentStateBody",
-              "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
-              "bounds": {
-                "x": -149.5,
-                "y": 230.5,
-                "width": 419,
-                "height": 30
-              },
-              "replyType": "text",
-              "ragDatabaseName": ""
-            },
-            "44904a03-ac46-4f9f-983a-f6a740b81c0e": {
-              "id": "44904a03-ac46-4f9f-983a-f6a740b81c0e",
-              "name": " Drink plenty of water and limit ultra-processed foods and alcohol. ",
-              "type": "AgentStateBody",
-              "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
-              "bounds": {
-                "x": -149.5,
-                "y": 260.5,
-                "width": 419,
-                "height": 30
-              },
-              "replyType": "text",
-              "ragDatabaseName": ""
-            },
-            "90dfba4f-6dec-4ca8-8c15-786ed36587a1": {
-              "id": "90dfba4f-6dec-4ca8-8c15-786ed36587a1",
-              "name": "Be consistent — results come from habits, not perfection",
-              "type": "AgentStateBody",
-              "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
-              "bounds": {
-                "x": -149.5,
-                "y": 290.5,
-                "width": 419,
-                "height": 30
-              },
-              "replyType": "text",
-              "ragDatabaseName": ""
-            },
-            "8c760b7d-7e72-4cd7-a92a-d5491c021a5b": {
-              "id": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b",
-              "name": "OtherQuestions",
-              "type": "AgentState",
-              "owner": null,
-              "bounds": {
-                "x": 350,
-                "y": -90,
-                "width": 180,
-                "height": 70
-              },
-              "bodies": [
-                "6a3aeb02-bb44-4472-8489-595e8dc8ceb1"
-              ],
-              "fallbackBodies": []
-            },
-            "6a3aeb02-bb44-4472-8489-595e8dc8ceb1": {
-              "id": "6a3aeb02-bb44-4472-8489-595e8dc8ceb1",
-              "name": "AI response 🪄",
-              "type": "AgentStateBody",
-              "owner": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b",
-              "bounds": {
-                "x": 350.5,
-                "y": -49.5,
-                "width": 179,
-                "height": 30
-              },
-              "replyType": "llm",
-              "ragDatabaseName": ""
-            },
-            "659e810a-f686-47fb-aea8-d23ad06e482c": {
-              "id": "659e810a-f686-47fb-aea8-d23ad06e482c",
-              "name": "Nutrition_intent",
-              "type": "AgentIntent",
-              "owner": null,
-              "bounds": {
-                "x": -900,
-                "y": -290,
-                "width": 630,
-                "height": 100
-              },
-              "bodies": [
-                "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0"
-              ],
-              "intent_description": "Question about nutrition in gym."
-            },
-            "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0": {
-              "id": "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0",
-              "name": "Which food to eat?",
-              "type": "AgentIntentBody",
-              "owner": "659e810a-f686-47fb-aea8-d23ad06e482c",
-              "bounds": {
-                "x": -899.5,
-                "y": -219.5,
-                "width": 629,
-                "height": 30
-              }
-            },
-            "37dff3e2-013c-42f0-ad6e-bbc197247d14": {
-              "id": "37dff3e2-013c-42f0-ad6e-bbc197247d14",
-              "name": "Other",
-              "type": "AgentIntent",
-              "owner": null,
-              "bounds": {
-                "x": -860,
-                "y": 150,
-                "width": 630,
-                "height": 70
-              },
-              "bodies": [],
-              "intent_description": "Any question that does not fit in \"Muscles\" or \"Nutrition\""
-            }
-        
+  "size": {
+    "width": 1080,
+    "height": 400
   },
-        "relationships": {
-           
-            "bbd03bdd-b76e-47df-9e13-5a305885f94c": {
-              "id": "bbd03bdd-b76e-47df-9e13-5a305885f94c",
-              "name": "",
-              "type": "AgentStateTransitionInit",
-              "owner": null,
-              "bounds": {
-                "x": -185,
-                "y": -347.5,
-                "width": 85,
-                "height": 1
-              },
-              "path": [
-                {
-                  "x": 0,
-                  "y": 0
-                },
-                {
-                  "x": 85,
-                  "y": 0
-                }
-              ],
-              "source": {
-                "direction": "Right",
-                "element": "699853eb-918b-4674-b08c-cf0af3cc61d7",
-                "bounds": {
-                  "x": -535,
-                  "y": -37.5,
-                  "width": 0,
-                  "height": 0
-                }
-              },
-              "target": {
-                "direction": "Left",
-                "element": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
-                "bounds": {
-                  "x": -280,
-                  "y": -45,
-                  "width": 0,
-                  "height": 0
-                }
-              },
-              "isManuallyLayouted": false
-            },
-            "0d7d8895-3eb0-44b0-bb41-e902684d0d2c": {
-              "id": "0d7d8895-3eb0-44b0-bb41-e902684d0d2c",
-              "name": "",
-              "type": "AgentStateTransition",
-              "owner": null,
-              "bounds": {
-                "x": -590,
-                "y": -150,
-                "width": 410,
-                "height": 120
-              },
-              "path": [
-                {
-                  "x": 410,
-                  "y": 0
-                },
-                {
-                  "x": 0,
-                  "y": 0
-                },
-                {
-                  "x": 0,
-                  "y": 120
-                }
-              ],
-              "source": {
-                "direction": "Left",
-                "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
-              },
-              "target": {
-                "direction": "Up",
-                "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
-              },
-              "isManuallyLayouted": false,
-              "condition": "when_intent_matched",
-              "conditionValue": "Muscles_intent"
-            },
-            "7d65df96-e669-4fc6-a882-dbfe92a57073": {
-              "id": "7d65df96-e669-4fc6-a882-dbfe92a57073",
-              "name": "",
-              "type": "AgentStateTransition",
-              "owner": null,
-              "bounds": {
-                "x": 70,
-                "y": -300,
-                "width": 1,
-                "height": 100
-              },
-              "path": [
-                {
-                  "x": 0,
-                  "y": 0
-                },
-                {
-                  "x": 0,
-                  "y": 100
-                }
-              ],
-              "source": {
-                "direction": "Down",
-                "element": "77976ef7-599d-4c49-9f4d-1ecb23239fe3"
-              },
-              "target": {
-                "direction": "Up",
-                "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
-              },
-              "isManuallyLayouted": false,
-              "condition": "auto",
-              "conditionValue": ""
-            },
-            "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31": {
-              "id": "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31",
-              "name": "",
-              "type": "AgentStateTransition",
-              "owner": null,
-              "bounds": {
-                "x": 240,
-                "y": -130,
-                "width": 200,
-                "height": 40
-              },
-              "path": [
-                {
-                  "x": 0,
-                  "y": 5
-                },
-                {
-                  "x": 40,
-                  "y": 5
-                },
-                {
-                  "x": 40,
-                  "y": 0
-                },
-                {
-                  "x": 200,
-                  "y": 0
-                },
-                {
-                  "x": 200,
-                  "y": 40
-                }
-              ],
-              "source": {
-                "direction": "Downright",
-                "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
-              },
-              "target": {
-                "direction": "Up",
-                "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
-              },
-              "isManuallyLayouted": true,
-              "condition": "when_intent_matched",
-              "conditionValue": "Other"
-            },
-            "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e": {
-              "id": "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e",
-              "name": "",
-              "type": "AgentStateTransition",
-              "owner": null,
-              "bounds": {
-                "x": -380,
-                "y": -125,
-                "width": 200,
-                "height": 127.5
-              },
-              "path": [
-                {
-                  "x": 0,
-                  "y": 127.5
-                },
-                {
-                  "x": 100,
-                  "y": 127.5
-                },
-                {
-                  "x": 100,
-                  "y": 0
-                },
-                {
-                  "x": 200,
-                  "y": 0
-                }
-              ],
-              "source": {
-                "direction": "Upright",
-                "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
-              },
-              "target": {
-                "direction": "Downleft",
-                "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
-              },
-              "isManuallyLayouted": false,
-              "condition": "auto",
-              "conditionValue": ""
-            },
-            "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32": {
-              "id": "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32",
-              "name": "",
-              "type": "AgentStateTransition",
-              "owner": null,
-              "bounds": {
-                "x": 135,
-                "y": -100,
-                "width": 215,
-                "height": 40
-              },
-              "path": [
-                {
-                  "x": 215,
-                  "y": 27.5
-                },
-                {
-                  "x": 175,
-                  "y": 27.5
-                },
-                {
-                  "x": 175,
-                  "y": 40
-                },
-                {
-                  "x": 0,
-                  "y": 40
-                },
-                {
-                  "x": 0,
-                  "y": 0
-                }
-              ],
-              "source": {
-                "direction": "Upleft",
-                "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
-              },
-              "target": {
-                "direction": "Bottomright",
-                "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
-              },
-              "isManuallyLayouted": false,
-              "condition": "auto",
-              "conditionValue": ""
-            },
-            "3564da62-bea0-4489-81b2-fda2effddd02": {
-              "id": "3564da62-bea0-4489-81b2-fda2effddd02",
-              "name": "",
-              "type": "AgentStateTransition",
-              "owner": null,
-              "bounds": {
-                "x": -190,
-                "y": -100,
-                "width": 115,
-                "height": 277.5
-              },
-              "path": [
-                {
-                  "x": 40,
-                  "y": 277.5
-                },
-                {
-                  "x": 0,
-                  "y": 277.5
-                },
-                {
-                  "x": 0,
-                  "y": 115
-                },
-                {
-                  "x": 115,
-                  "y": 115
-                },
-                {
-                  "x": 115,
-                  "y": 0
-                }
-              ],
-              "source": {
-                "direction": "Upleft",
-                "element": "7610bbda-21ef-4637-a188-1da1352bea17"
-              },
-              "target": {
-                "direction": "Bottomleft",
-                "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
-              },
-              "isManuallyLayouted": false,
-              "condition": "auto",
-              "conditionValue": ""
-            },
-            "b696a5f6-f328-42fb-bdbc-83569b2beb06": {
-              "id": "b696a5f6-f328-42fb-bdbc-83569b2beb06",
-              "name": "",
-              "type": "AgentStateTransition",
-              "owner": null,
-              "bounds": {
-                "x": 45,
-                "y": -100,
-                "width": 1,
-                "height": 230
-              },
-              "path": [
-                {
-                  "x": 0,
-                  "y": 0
-                },
-                {
-                  "x": 0,
-                  "y": 230
-                }
-              ],
-              "source": {
-                "direction": "Down",
-                "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
-              },
-              "target": {
-                "direction": "Up",
-                "element": "7610bbda-21ef-4637-a188-1da1352bea17"
-              },
-              "isManuallyLayouted": false,
-              "condition": "when_intent_matched",
-              "conditionValue": "Nutrition_intent"
-            }
-           },
+  "interactive": {
+    "elements": {},
+    "relationships": {}
+  },
+  "elements": {
+    "699853eb-918b-4674-b08c-cf0af3cc61d7": {
+      "id": "699853eb-918b-4674-b08c-cf0af3cc61d7",
+      "name": "",
+      "type": "StateInitialNode",
+      "owner": null,
+      "bounds": {
+        "x": -230,
+        "y": -370,
+        "width": 45,
+        "height": 45
+      }
+    },
+    "0cba5357-2c30-414b-8d74-ac74ac4ab158": {
+      "id": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
+      "name": "Idle",
+      "type": "AgentState",
+      "owner": null,
+      "bounds": {
+        "x": -180,
+        "y": -200,
+        "width": 420,
+        "height": 100
+      },
+      "bodies": ["63a2c160-ebbb-457b-953a-93fd2e643224"],
+      "fallbackBodies": ["1f369122-06c2-4050-ba54-4ea160f95a8c"]
+    },
+    "63a2c160-ebbb-457b-953a-93fd2e643224": {
+      "id": "63a2c160-ebbb-457b-953a-93fd2e643224",
+      "name": "I am here to answer any questions regarding exercises, nutrition and recovery.",
+      "type": "AgentStateBody",
+      "owner": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
+      "bounds": {
+        "x": -179.5,
+        "y": -159.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "1f369122-06c2-4050-ba54-4ea160f95a8c": {
+      "id": "1f369122-06c2-4050-ba54-4ea160f95a8c",
+      "name": "I focus on gym and fitness topics only dude.",
+      "type": "AgentStateFallbackBody",
+      "owner": "0cba5357-2c30-414b-8d74-ac74ac4ab158",
+      "bounds": {
+        "x": -179.5,
+        "y": -129.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "8dba49ff-2fc1-4066-b124-19e2df7981e2": {
+      "id": "8dba49ff-2fc1-4066-b124-19e2df7981e2",
+      "name": "Muscles_intent",
+      "type": "AgentIntent",
+      "owner": null,
+      "bounds": {
+        "x": -900,
+        "y": -400,
+        "width": 630,
+        "height": 100
+      },
+      "bodies": ["a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b"],
+      "intent_description": "Question about how to become muscular and which exercises to perform."
+    },
+    "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b": {
+      "id": "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b",
+      "name": "I want muscles",
+      "type": "AgentIntentBody",
+      "owner": "8dba49ff-2fc1-4066-b124-19e2df7981e2",
+      "bounds": {
+        "x": -899.5,
+        "y": -329.5,
+        "width": 629,
+        "height": 30
+      }
+    },
+    "68ccb630-b264-41a0-b70e-1e369bd5706c": {
+      "id": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+      "name": "TrainingPlan",
+      "type": "AgentState",
+      "owner": null,
+      "bounds": {
+        "x": -800,
+        "y": -30,
+        "width": 420,
+        "height": 130
+      },
+      "bodies": [
+        "aa261be5-9c53-4df1-a72f-5a107ce8f1b7",
+        "747b8558-325d-4a15-baba-0d18a6602a8d",
+        "900f7fd9-738a-4981-a7d9-6c7334621981"
+      ],
+      "fallbackBodies": []
+    },
+    "aa261be5-9c53-4df1-a72f-5a107ce8f1b7": {
+      "id": "aa261be5-9c53-4df1-a72f-5a107ce8f1b7",
+      "name": "Focus on heavy compound lifts like squats, deadlifts, bench press, overhead press, and rows to build overall muscle mass. ",
+      "type": "AgentStateBody",
+      "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+      "bounds": {
+        "x": -799.5,
+        "y": 10.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "747b8558-325d-4a15-baba-0d18a6602a8d": {
+      "id": "747b8558-325d-4a15-baba-0d18a6602a8d",
+      "name": "Train 3–5 times per week, progressively increasing the weight while eating enough protein and calories to support growth. ",
+      "type": "AgentStateBody",
+      "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+      "bounds": {
+        "x": -799.5,
+        "y": 40.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "900f7fd9-738a-4981-a7d9-6c7334621981": {
+      "id": "900f7fd9-738a-4981-a7d9-6c7334621981",
+      "name": "Get good sleep and stay consistent—muscle comes from steady effort over time.",
+      "type": "AgentStateBody",
+      "owner": "68ccb630-b264-41a0-b70e-1e369bd5706c",
+      "bounds": {
+        "x": -799.5,
+        "y": 70.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "77976ef7-599d-4c49-9f4d-1ecb23239fe3": {
+      "id": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
+      "name": "Initial",
+      "type": "AgentState",
+      "owner": null,
+      "bounds": {
+        "x": -100,
+        "y": -370,
+        "width": 420,
+        "height": 70
+      },
+      "bodies": ["ad226172-93d8-4644-80c5-62825565dd24"],
+      "fallbackBodies": []
+    },
+    "ad226172-93d8-4644-80c5-62825565dd24": {
+      "id": "ad226172-93d8-4644-80c5-62825565dd24",
+      "name": "Hi, I am your buddy, the fitness agent.",
+      "type": "AgentStateBody",
+      "owner": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
+      "bounds": {
+        "x": -99.5,
+        "y": -329.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "7610bbda-21ef-4637-a188-1da1352bea17": {
+      "id": "7610bbda-21ef-4637-a188-1da1352bea17",
+      "name": "Nutrition",
+      "type": "AgentState",
+      "owner": null,
+      "bounds": {
+        "x": -150,
+        "y": 130,
+        "width": 420,
+        "height": 190
+      },
+      "bodies": [
+        "bb7e67bd-ead9-4f14-93db-c18af0d806af",
+        "13072ea8-9b51-45fe-927e-a9323627701b",
+        "95241c3a-f8a2-4bf0-b169-5dcff5a926fb",
+        "44904a03-ac46-4f9f-983a-f6a740b81c0e",
+        "90dfba4f-6dec-4ca8-8c15-786ed36587a1"
+      ],
+      "fallbackBodies": []
+    },
+    "bb7e67bd-ead9-4f14-93db-c18af0d806af": {
+      "id": "bb7e67bd-ead9-4f14-93db-c18af0d806af",
+      "name": "Nutrition basics: Eat mostly whole foods (lean protein, vegetables, fruits, whole grains, healthy fats). Protein: ~1.6–2.2 g per kg of body weight daily..",
+      "type": "AgentStateBody",
+      "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+      "bounds": {
+        "x": -149.5,
+        "y": 170.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "13072ea8-9b51-45fe-927e-a9323627701b": {
+      "id": "13072ea8-9b51-45fe-927e-a9323627701b",
+      "name": "Match calories to your goal: slight surplus to gain muscle, deficit to lose fat, maintenance to stay the same. ",
+      "type": "AgentStateBody",
+      "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+      "bounds": {
+        "x": -149.5,
+        "y": 200.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "95241c3a-f8a2-4bf0-b169-5dcff5a926fb": {
+      "id": "95241c3a-f8a2-4bf0-b169-5dcff5a926fb",
+      "name": " Carbs fuel training; fats support hormones.",
+      "type": "AgentStateBody",
+      "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+      "bounds": {
+        "x": -149.5,
+        "y": 230.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "44904a03-ac46-4f9f-983a-f6a740b81c0e": {
+      "id": "44904a03-ac46-4f9f-983a-f6a740b81c0e",
+      "name": " Drink plenty of water and limit ultra-processed foods and alcohol. ",
+      "type": "AgentStateBody",
+      "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+      "bounds": {
+        "x": -149.5,
+        "y": 260.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "90dfba4f-6dec-4ca8-8c15-786ed36587a1": {
+      "id": "90dfba4f-6dec-4ca8-8c15-786ed36587a1",
+      "name": "Be consistent — results come from habits, not perfection",
+      "type": "AgentStateBody",
+      "owner": "7610bbda-21ef-4637-a188-1da1352bea17",
+      "bounds": {
+        "x": -149.5,
+        "y": 290.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "8c760b7d-7e72-4cd7-a92a-d5491c021a5b": {
+      "id": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b",
+      "name": "OtherQuestions",
+      "type": "AgentState",
+      "owner": null,
+      "bounds": {
+        "x": 350,
+        "y": -90,
+        "width": 180,
+        "height": 70
+      },
+      "bodies": ["6a3aeb02-bb44-4472-8489-595e8dc8ceb1"],
+      "fallbackBodies": []
+    },
+    "6a3aeb02-bb44-4472-8489-595e8dc8ceb1": {
+      "id": "6a3aeb02-bb44-4472-8489-595e8dc8ceb1",
+      "name": "AI response 🪄",
+      "type": "AgentStateBody",
+      "owner": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b",
+      "bounds": {
+        "x": 350.5,
+        "y": -49.5,
+        "width": 179,
+        "height": 30
+      },
+      "replyType": "llm",
+      "ragDatabaseName": ""
+    },
+    "659e810a-f686-47fb-aea8-d23ad06e482c": {
+      "id": "659e810a-f686-47fb-aea8-d23ad06e482c",
+      "name": "Nutrition_intent",
+      "type": "AgentIntent",
+      "owner": null,
+      "bounds": {
+        "x": -900,
+        "y": -290,
+        "width": 630,
+        "height": 100
+      },
+      "bodies": ["f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0"],
+      "intent_description": "Question about nutrition in gym."
+    },
+    "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0": {
+      "id": "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0",
+      "name": "Which food to eat?",
+      "type": "AgentIntentBody",
+      "owner": "659e810a-f686-47fb-aea8-d23ad06e482c",
+      "bounds": {
+        "x": -899.5,
+        "y": -219.5,
+        "width": 629,
+        "height": 30
+      }
+    },
+    "37dff3e2-013c-42f0-ad6e-bbc197247d14": {
+      "id": "37dff3e2-013c-42f0-ad6e-bbc197247d14",
+      "name": "Other",
+      "type": "AgentIntent",
+      "owner": null,
+      "bounds": {
+        "x": -860,
+        "y": 150,
+        "width": 630,
+        "height": 70
+      },
+      "bodies": [],
+      "intent_description": "Any question that does not fit in \"Muscles\" or \"Nutrition\""
+    }
+  },
+  "relationships": {
+    "bbd03bdd-b76e-47df-9e13-5a305885f94c": {
+      "id": "bbd03bdd-b76e-47df-9e13-5a305885f94c",
+      "name": "",
+      "type": "AgentStateTransitionInit",
+      "owner": null,
+      "bounds": {
+        "x": -185,
+        "y": -347.5,
+        "width": 85,
+        "height": 1
+      },
+      "path": [
+        {
+          "x": 0,
+          "y": 0
+        },
+        {
+          "x": 85,
+          "y": 0
+        }
+      ],
+      "source": {
+        "direction": "Right",
+        "element": "699853eb-918b-4674-b08c-cf0af3cc61d7",
+        "bounds": {
+          "x": -535,
+          "y": -37.5,
+          "width": 0,
+          "height": 0
+        }
+      },
+      "target": {
+        "direction": "Left",
+        "element": "77976ef7-599d-4c49-9f4d-1ecb23239fe3",
+        "bounds": {
+          "x": -280,
+          "y": -45,
+          "width": 0,
+          "height": 0
+        }
+      },
+      "isManuallyLayouted": false
+    },
+    "0d7d8895-3eb0-44b0-bb41-e902684d0d2c": {
+      "id": "0d7d8895-3eb0-44b0-bb41-e902684d0d2c",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": -590,
+        "y": -150,
+        "width": 410,
+        "height": 120
+      },
+      "path": [
+        {
+          "x": 410,
+          "y": 0
+        },
+        {
+          "x": 0,
+          "y": 0
+        },
+        {
+          "x": 0,
+          "y": 120
+        }
+      ],
+      "source": {
+        "direction": "Left",
+        "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+      },
+      "target": {
+        "direction": "Up",
+        "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
+      },
+      "isManuallyLayouted": false,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "when_intent_matched",
+        "intentName": "Muscles_intent"
+      },
+      "custom": {
+        "condition": []
+      }
+    },
+    "7d65df96-e669-4fc6-a882-dbfe92a57073": {
+      "id": "7d65df96-e669-4fc6-a882-dbfe92a57073",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": 70,
+        "y": -300,
+        "width": 1,
+        "height": 100
+      },
+      "path": [
+        {
+          "x": 0,
+          "y": 0
+        },
+        {
+          "x": 0,
+          "y": 100
+        }
+      ],
+      "source": {
+        "direction": "Down",
+        "element": "77976ef7-599d-4c49-9f4d-1ecb23239fe3"
+      },
+      "target": {
+        "direction": "Up",
+        "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+      },
+      "isManuallyLayouted": false,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "auto",
+        "conditionValue": ""
+      },
+      "custom": {
+        "condition": []
+      }
+    },
+    "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31": {
+      "id": "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": 240,
+        "y": -130,
+        "width": 200,
+        "height": 40
+      },
+      "path": [
+        {
+          "x": 0,
+          "y": 5
+        },
+        {
+          "x": 40,
+          "y": 5
+        },
+        {
+          "x": 40,
+          "y": 0
+        },
+        {
+          "x": 200,
+          "y": 0
+        },
+        {
+          "x": 200,
+          "y": 40
+        }
+      ],
+      "source": {
+        "direction": "Downright",
+        "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+      },
+      "target": {
+        "direction": "Up",
+        "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
+      },
+      "isManuallyLayouted": true,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "when_intent_matched",
+        "intentName": "Other"
+      },
+      "custom": {
+        "condition": []
+      }
+    },
+    "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e": {
+      "id": "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": -380,
+        "y": -125,
+        "width": 200,
+        "height": 127.5
+      },
+      "path": [
+        {
+          "x": 0,
+          "y": 127.5
+        },
+        {
+          "x": 100,
+          "y": 127.5
+        },
+        {
+          "x": 100,
+          "y": 0
+        },
+        {
+          "x": 200,
+          "y": 0
+        }
+      ],
+      "source": {
+        "direction": "Upright",
+        "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
+      },
+      "target": {
+        "direction": "Downleft",
+        "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+      },
+      "isManuallyLayouted": false,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "auto",
+        "conditionValue": ""
+      },
+      "custom": {
+        "condition": []
+      }
+    },
+    "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32": {
+      "id": "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": 135,
+        "y": -100,
+        "width": 215,
+        "height": 40
+      },
+      "path": [
+        {
+          "x": 215,
+          "y": 27.5
+        },
+        {
+          "x": 175,
+          "y": 27.5
+        },
+        {
+          "x": 175,
+          "y": 40
+        },
+        {
+          "x": 0,
+          "y": 40
+        },
+        {
+          "x": 0,
+          "y": 0
+        }
+      ],
+      "source": {
+        "direction": "Upleft",
+        "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
+      },
+      "target": {
+        "direction": "Bottomright",
+        "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+      },
+      "isManuallyLayouted": false,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "auto",
+        "conditionValue": ""
+      },
+      "custom": {
+        "condition": []
+      }
+    },
+    "3564da62-bea0-4489-81b2-fda2effddd02": {
+      "id": "3564da62-bea0-4489-81b2-fda2effddd02",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": -190,
+        "y": -100,
+        "width": 115,
+        "height": 277.5
+      },
+      "path": [
+        {
+          "x": 40,
+          "y": 277.5
+        },
+        {
+          "x": 0,
+          "y": 277.5
+        },
+        {
+          "x": 0,
+          "y": 115
+        },
+        {
+          "x": 115,
+          "y": 115
+        },
+        {
+          "x": 115,
+          "y": 0
+        }
+      ],
+      "source": {
+        "direction": "Upleft",
+        "element": "7610bbda-21ef-4637-a188-1da1352bea17"
+      },
+      "target": {
+        "direction": "Bottomleft",
+        "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+      },
+      "isManuallyLayouted": false,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "auto",
+        "conditionValue": ""
+      },
+      "custom": {
+        "condition": []
+      }
+    },
+    "b696a5f6-f328-42fb-bdbc-83569b2beb06": {
+      "id": "b696a5f6-f328-42fb-bdbc-83569b2beb06",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": 45,
+        "y": -100,
+        "width": 1,
+        "height": 230
+      },
+      "path": [
+        {
+          "x": 0,
+          "y": 0
+        },
+        {
+          "x": 0,
+          "y": 230
+        }
+      ],
+      "source": {
+        "direction": "Down",
+        "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
+      },
+      "target": {
+        "direction": "Up",
+        "element": "7610bbda-21ef-4637-a188-1da1352bea17"
+      },
+      "isManuallyLayouted": false,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "when_intent_matched",
+        "intentName": "Nutrition_intent"
+      },
+      "custom": {
+        "condition": []
+      }
+    }
+  },
   "assessments": {}
 }

--- a/packages/webapp/src/main/templates/pattern/agent/libraryagent.json
+++ b/packages/webapp/src/main/templates/pattern/agent/libraryagent.json
@@ -1,754 +1,784 @@
 {
   "version": "3.0.0",
   "type": "AgentDiagram",
-  "size": { "width": 1080, "height": 400 },
-  "interactive": { "elements": {}, "relationships": {} },
+  "size": {
+    "width": 1080,
+    "height": 400
+  },
+  "interactive": {
+    "elements": {},
+    "relationships": {}
+  },
   "elements": {
-      "initial_72th6ksf3_mm9b38u1": {
-        "id": "initial_72th6ksf3_mm9b38u1",
-        "name": "",
-        "type": "StateInitialNode",
-        "owner": null,
-        "bounds": {
-          "x": -1120,
-          "y": -620,
-          "width": 45,
-          "height": 45
-        }
-      },
-      "intent_jtmr4apyg_mm9b38u1": {
-        "id": "intent_jtmr4apyg_mm9b38u1",
-        "name": "OpeningHours",
-        "type": "AgentIntent",
-        "owner": null,
-        "bounds": {
-          "x": -680,
-          "y": -100,
-          "width": 410,
-          "height": 190
-        },
-        "bodies": [
-          "intentBody_jn9sy9wl2_mm9b38u1",
-          "intentBody_61dj9fnk0_mm9b38u1",
-          "intentBody_b8jkj9t1s_mm9b38u1",
-          "intentBody_jl9eozt0r_mm9b38u1"
-        ],
-        "intent_description": "Asking for the opening hours of the library."
-      },
-      "intentBody_jn9sy9wl2_mm9b38u1": {
-        "id": "intentBody_jn9sy9wl2_mm9b38u1",
-        "name": "what are the opening hours?",
-        "type": "AgentIntentBody",
-        "owner": "intent_jtmr4apyg_mm9b38u1",
-        "bounds": {
-          "x": -679.5,
-          "y": -29.5,
-          "width": 409,
-          "height": 30
-        }
-      },
-      "intentBody_61dj9fnk0_mm9b38u1": {
-        "id": "intentBody_61dj9fnk0_mm9b38u1",
-        "name": "library hours",
-        "type": "AgentIntentBody",
-        "owner": "intent_jtmr4apyg_mm9b38u1",
-        "bounds": {
-          "x": -679.5,
-          "y": 0.5,
-          "width": 409,
-          "height": 30
-        }
-      },
-      "intentBody_b8jkj9t1s_mm9b38u1": {
-        "id": "intentBody_b8jkj9t1s_mm9b38u1",
-        "name": "when do you open?",
-        "type": "AgentIntentBody",
-        "owner": "intent_jtmr4apyg_mm9b38u1",
-        "bounds": {
-          "x": -679.5,
-          "y": 30.5,
-          "width": 409,
-          "height": 30
-        }
-      },
-      "intentBody_jl9eozt0r_mm9b38u1": {
-        "id": "intentBody_jl9eozt0r_mm9b38u1",
-        "name": "hours of operation",
-        "type": "AgentIntentBody",
-        "owner": "intent_jtmr4apyg_mm9b38u1",
-        "bounds": {
-          "x": -679.5,
-          "y": 60.5,
-          "width": 409,
-          "height": 30
-        }
-      },
-      "intent_ggq3p9gv8_mm9b38u1": {
-        "id": "intent_ggq3p9gv8_mm9b38u1",
-        "name": "CheapestBook",
-        "type": "AgentIntent",
-        "owner": null,
-        "bounds": {
-          "x": -250,
-          "y": -100,
-          "width": 490,
-          "height": 130
-        },
-        "bodies": [
-          "intentBody_06wxt0vga_mm9b38u1",
-          "intentBody_14tgxxf1f_mm9b38u1",
-          "intentBody_j2ugmtuh8_mm9b38u1"
-        ],
-        "intent_description": ""
-      },
-      "intentBody_06wxt0vga_mm9b38u1": {
-        "id": "intentBody_06wxt0vga_mm9b38u1",
-        "name": "how to get the title of the cheapest book of an author?",
-        "type": "AgentIntentBody",
-        "owner": "intent_ggq3p9gv8_mm9b38u1",
-        "bounds": {
-          "x": -249.5,
-          "y": -59.5,
-          "width": 489,
-          "height": 30
-        }
-      },
-      "intentBody_14tgxxf1f_mm9b38u1": {
-        "id": "intentBody_14tgxxf1f_mm9b38u1",
-        "name": "I want to know the cheapest book",
-        "type": "AgentIntentBody",
-        "owner": "intent_ggq3p9gv8_mm9b38u1",
-        "bounds": {
-          "x": -249.5,
-          "y": -29.5,
-          "width": 489,
-          "height": 30
-        }
-      },
-      "intentBody_j2ugmtuh8_mm9b38u1": {
-        "id": "intentBody_j2ugmtuh8_mm9b38u1",
-        "name": "which is the cheapest book?",
-        "type": "AgentIntentBody",
-        "owner": "intent_ggq3p9gv8_mm9b38u1",
-        "bounds": {
-          "x": -249.5,
-          "y": 0.5,
-          "width": 489,
-          "height": 30
-        }
-      },
-      "intent_zuidaui0x_mm9b38u1": {
-        "id": "intent_zuidaui0x_mm9b38u1",
-        "name": "Contact",
-        "type": "AgentIntent",
-        "owner": null,
-        "bounds": {
-          "x": -1130,
-          "y": -100,
-          "width": 430,
-          "height": 160
-        },
-        "bodies": [
-          "intentBody_9kmxc6vnq_mm9b38u1",
-          "intentBody_mxczpzj8h_mm9b38u1",
-          "intentBody_8yqem5n2k_mm9b38u1"
-        ],
-        "intent_description": "Requesting to speak with a human assistant."
-      },
-      "intentBody_9kmxc6vnq_mm9b38u1": {
-        "id": "intentBody_9kmxc6vnq_mm9b38u1",
-        "name": "I need to speak to someone",
-        "type": "AgentIntentBody",
-        "owner": "intent_zuidaui0x_mm9b38u1",
-        "bounds": {
-          "x": -1129.5,
-          "y": -29.5,
-          "width": 429,
-          "height": 30
-        }
-      },
-      "intentBody_mxczpzj8h_mm9b38u1": {
-        "id": "intentBody_mxczpzj8h_mm9b38u1",
-        "name": "contact support",
-        "type": "AgentIntentBody",
-        "owner": "intent_zuidaui0x_mm9b38u1",
-        "bounds": {
-          "x": -1129.5,
-          "y": 0.5,
-          "width": 429,
-          "height": 30
-        }
-      },
-      "intentBody_8yqem5n2k_mm9b38u1": {
-        "id": "intentBody_8yqem5n2k_mm9b38u1",
-        "name": "human assistance",
-        "type": "AgentIntentBody",
-        "owner": "intent_zuidaui0x_mm9b38u1",
-        "bounds": {
-          "x": -1129.5,
-          "y": 30.5,
-          "width": 429,
-          "height": 30
-        }
-      },
-      "state_zl3bfe65n_mm9b38u1": {
-        "id": "state_zl3bfe65n_mm9b38u1",
-        "name": "Idle",
-        "type": "AgentState",
-        "owner": null,
-        "bounds": {
-          "x": -480,
-          "y": -520,
-          "width": 260,
-          "height": 70
-        },
-        "bodies": [
-          "body_wybm5pc31_mm9b38u1"
-        ],
-        "fallbackBodies": []
-      },
-      "body_wybm5pc31_mm9b38u1": {
-        "id": "body_wybm5pc31_mm9b38u1",
-        "name": "How can I assist you today?",
-        "type": "AgentStateBody",
-        "owner": "state_zl3bfe65n_mm9b38u1",
-        "bounds": {
-          "x": -479.5,
-          "y": -479.5,
-          "width": 259,
-          "height": 30
-        },
-        "replyType": "text",
-        "ragDatabaseName": ""
-      },
-      "state_j5tnma02n_mm9b38u1": {
-        "id": "state_j5tnma02n_mm9b38u1",
-        "name": "OpeningHoursState",
-        "type": "AgentState",
-        "owner": null,
-        "bounds": {
-          "x": 80,
-          "y": -530,
-          "width": 420,
-          "height": 100
-        },
-        "bodies": [
-          "body_a8ph8sxrt_mm9b38u1",
-          "fb1432f7-1778-4c8b-90f3-e471e86cec31"
-        ],
-        "fallbackBodies": []
-      },
-      "body_a8ph8sxrt_mm9b38u1": {
-        "id": "body_a8ph8sxrt_mm9b38u1",
-        "name": "Our opening hours are Monday–Friday 9 AM–6 PM.",
-        "type": "AgentStateBody",
-        "owner": "state_j5tnma02n_mm9b38u1",
-        "bounds": {
-          "x": 80.5,
-          "y": -489.5,
-          "width": 419,
-          "height": 30
-        },
-        "replyType": "text",
-        "ragDatabaseName": ""
-      },
-      "fb1432f7-1778-4c8b-90f3-e471e86cec31": {
-        "id": "fb1432f7-1778-4c8b-90f3-e471e86cec31",
-        "name": "Saturday 10 AM–4 PM. Closed Sunday.",
-        "type": "AgentStateBody",
-        "owner": "state_j5tnma02n_mm9b38u1",
-        "bounds": {
-          "x": 80.5,
-          "y": -459.5,
-          "width": 419,
-          "height": 30
-        },
-        "replyType": "text",
-        "ragDatabaseName": ""
-      },
-      "state_krso67h8q_mm9b38u1": {
-        "id": "state_krso67h8q_mm9b38u1",
-        "name": "CheapestBookState",
-        "type": "AgentState",
-        "owner": null,
-        "bounds": {
-          "x": 80,
-          "y": -750,
-          "width": 420,
-          "height": 190
-        },
-        "bodies": [
-          "body_38x5jthwr_mm9b38u1",
-          "body_0yl3shkws_mm9b38u1",
-          "b533e6a5-cc51-4f0d-a269-98bf81a02c31",
-          "7c8e27fb-8cce-4f3d-9cc4-19ef5a963b8a",
-          "b779be48-1bc4-4984-9274-00c91203552a"
-        ],
-        "fallbackBodies": []
-      },
-      "body_38x5jthwr_mm9b38u1": {
-        "id": "body_38x5jthwr_mm9b38u1",
-        "name": "To get the cheapest book of an author, follow these steps:",
-        "type": "AgentStateBody",
-        "owner": "state_krso67h8q_mm9b38u1",
-        "bounds": {
-          "x": 80.5,
-          "y": -709.5,
-          "width": 419,
-          "height": 30
-        },
-        "replyType": "text",
-        "ragDatabaseName": ""
-      },
-      "body_0yl3shkws_mm9b38u1": {
-        "id": "body_0yl3shkws_mm9b38u1",
-        "name": "1. Go to the Library tab.",
-        "type": "AgentStateBody",
-        "owner": "state_krso67h8q_mm9b38u1",
-        "bounds": {
-          "x": 80.5,
-          "y": -679.5,
-          "width": 419,
-          "height": 30
-        },
-        "replyType": "text",
-        "ragDatabaseName": ""
-      },
-      "b533e6a5-cc51-4f0d-a269-98bf81a02c31": {
-        "id": "b533e6a5-cc51-4f0d-a269-98bf81a02c31",
-        "name": "2. In the table, select the library where you want to search.",
-        "type": "AgentStateBody",
-        "owner": "state_krso67h8q_mm9b38u1",
-        "bounds": {
-          "x": 80.5,
-          "y": -649.5,
-          "width": 419,
-          "height": 30
-        },
-        "replyType": "text",
-        "ragDatabaseName": ""
-      },
-      "7c8e27fb-8cce-4f3d-9cc4-19ef5a963b8a": {
-        "id": "7c8e27fb-8cce-4f3d-9cc4-19ef5a963b8a",
-        "name": "3. Click on “Cheapest Book”.",
-        "type": "AgentStateBody",
-        "owner": "state_krso67h8q_mm9b38u1",
-        "bounds": {
-          "x": 80.5,
-          "y": -619.5,
-          "width": 419,
-          "height": 30
-        },
-        "replyType": "text",
-        "ragDatabaseName": ""
-      },
-      "b779be48-1bc4-4984-9274-00c91203552a": {
-        "id": "b779be48-1bc4-4984-9274-00c91203552a",
-        "name": "4. Select an author and click “Execute”.",
-        "type": "AgentStateBody",
-        "owner": "state_krso67h8q_mm9b38u1",
-        "bounds": {
-          "x": 80.5,
-          "y": -589.5,
-          "width": 419,
-          "height": 30
-        },
-        "replyType": "text",
-        "ragDatabaseName": ""
-      },
-      "state_5emfhqwzt_mm9b38u1": {
-        "id": "state_5emfhqwzt_mm9b38u1",
-        "name": "ContactState",
-        "type": "AgentState",
-        "owner": null,
-        "bounds": {
-          "x": 80,
-          "y": -330,
-          "width": 420,
-          "height": 100
-        },
-        "bodies": [
-          "body_b6vkku4r1_mm9b38u1",
-          "body_8i8n5kbs0_mm9b38u1"
-        ],
-        "fallbackBodies": []
-      },
-      "body_b6vkku4r1_mm9b38u1": {
-        "id": "body_b6vkku4r1_mm9b38u1",
-        "name": "You can contact a librarian at library@example.com or call +1 555-123-4567.",
-        "type": "AgentStateBody",
-        "owner": "state_5emfhqwzt_mm9b38u1",
-        "bounds": {
-          "x": 80.5,
-          "y": -289.5,
-          "width": 419,
-          "height": 30
-        },
-        "replyType": "text",
-        "ragDatabaseName": ""
-      },
-      "body_8i8n5kbs0_mm9b38u1": {
-        "id": "body_8i8n5kbs0_mm9b38u1",
-        "name": "They will get back to you shortly.",
-        "type": "AgentStateBody",
-        "owner": "state_5emfhqwzt_mm9b38u1",
-        "bounds": {
-          "x": 80.5,
-          "y": -259.5,
-          "width": 419,
-          "height": 30
-        },
-        "replyType": "text",
-        "ragDatabaseName": ""
-      },
-      "46badadf-e50d-481e-8246-3ba2393fce47": {
-        "id": "46badadf-e50d-481e-8246-3ba2393fce47",
-        "name": "Greeting",
-        "type": "AgentState",
-        "owner": null,
-        "bounds": {
-          "x": -980,
-          "y": -630,
-          "width": 340,
-          "height": 70
-        },
-        "bodies": [
-          "e3aad61a-89b4-46a6-8c16-6f80b861d717"
-        ],
-        "fallbackBodies": []
-      },
-      "e3aad61a-89b4-46a6-8c16-6f80b861d717": {
-        "id": "e3aad61a-89b4-46a6-8c16-6f80b861d717",
-        "name": "Welcome to the library support system!",
-        "type": "AgentStateBody",
-        "owner": "46badadf-e50d-481e-8246-3ba2393fce47",
-        "bounds": {
-          "x": -979.5,
-          "y": -589.5,
-          "width": 339,
-          "height": 30
-        },
-        "replyType": "text",
-        "ragDatabaseName": ""
-      },
-      "0edea0d9-cfa4-48e4-ae68-dfd226aa9f13": {
-        "id": "0edea0d9-cfa4-48e4-ae68-dfd226aa9f13",
-        "name": "Other",
-        "type": "AgentIntent",
-        "owner": null,
-        "bounds": {
-          "x": 260,
-          "y": -100,
-          "width": 250,
-          "height": 70
-        },
-        "bodies": [],
-        "intent_description": "Any other question."
+    "initial_72th6ksf3_mm9b38u1": {
+      "id": "initial_72th6ksf3_mm9b38u1",
+      "name": "",
+      "type": "StateInitialNode",
+      "owner": null,
+      "bounds": {
+        "x": -1120,
+        "y": -620,
+        "width": 45,
+        "height": 45
       }
     },
-    "relationships": {
-      "transition_ixdyt9fr7_mm9b38u1": {
-        "id": "transition_ixdyt9fr7_mm9b38u1",
-        "name": "",
-        "type": "AgentStateTransitionInit",
-        "owner": null,
-        "bounds": {
-          "x": -1075,
-          "y": -597.5,
-          "width": 95,
-          "height": 1
-        },
-        "path": [
-          {
-            "x": 0,
-            "y": 0
-          },
-          {
-            "x": 95,
-            "y": 0
-          }
-        ],
-        "source": {
-          "direction": "Right",
-          "element": "initial_72th6ksf3_mm9b38u1"
-        },
-        "target": {
-          "direction": "Left",
-          "element": "46badadf-e50d-481e-8246-3ba2393fce47"
-        },
-        "isManuallyLayouted": false
+    "intent_jtmr4apyg_mm9b38u1": {
+      "id": "intent_jtmr4apyg_mm9b38u1",
+      "name": "OpeningHours",
+      "type": "AgentIntent",
+      "owner": null,
+      "bounds": {
+        "x": -680,
+        "y": -100,
+        "width": 410,
+        "height": 190
       },
-      "transition_x8h483xz2_mm9b38u1": {
-        "id": "transition_x8h483xz2_mm9b38u1",
-        "name": "",
-        "type": "AgentStateTransition",
-        "owner": null,
-        "bounds": {
-          "x": -220,
-          "y": -485,
-          "width": 300,
-          "height": 1
-        },
-        "path": [
-          {
-            "x": 0,
-            "y": 0
-          },
-          {
-            "x": 300,
-            "y": 0
-          }
-        ],
-        "source": {
-          "direction": "Upright",
-          "element": "state_zl3bfe65n_mm9b38u1"
-        },
-        "target": {
-          "direction": "Upleft",
-          "element": "state_j5tnma02n_mm9b38u1"
-        },
-        "isManuallyLayouted": false,
-        "condition": "when_intent_matched",
-        "conditionValue": "OpeningHours"
-      },
-      "transition_53oz6z5cc_mm9b38u1": {
-        "id": "transition_53oz6z5cc_mm9b38u1",
-        "name": "",
-        "type": "AgentStateTransition",
-        "owner": null,
-        "bounds": {
-          "x": -285,
-          "y": -655,
-          "width": 365,
-          "height": 135
-        },
-        "path": [
-          {
-            "x": 0,
-            "y": 135
-          },
-          {
-            "x": 0,
-            "y": 0
-          },
-          {
-            "x": 365,
-            "y": 0
-          }
-        ],
-        "source": {
-          "direction": "Topright",
-          "element": "state_zl3bfe65n_mm9b38u1"
-        },
-        "target": {
-          "direction": "Left",
-          "element": "state_krso67h8q_mm9b38u1"
-        },
-        "isManuallyLayouted": false,
-        "condition": "when_intent_matched",
-        "conditionValue": "CheapestBook"
-      },
-      "transition_jc0mk7kpn_mm9b38u1": {
-        "id": "transition_jc0mk7kpn_mm9b38u1",
-        "name": "",
-        "type": "AgentStateTransition",
-        "owner": null,
-        "bounds": {
-          "x": -285,
-          "y": -450,
-          "width": 365,
-          "height": 170
-        },
-        "path": [
-          {
-            "x": 0,
-            "y": 0
-          },
-          {
-            "x": 0,
-            "y": 170
-          },
-          {
-            "x": 365,
-            "y": 170
-          }
-        ],
-        "source": {
-          "direction": "Bottomright",
-          "element": "state_zl3bfe65n_mm9b38u1"
-        },
-        "target": {
-          "direction": "Left",
-          "element": "state_5emfhqwzt_mm9b38u1"
-        },
-        "isManuallyLayouted": false,
-        "condition": "when_intent_matched",
-        "conditionValue": "Contact"
-      },
-      "transition_zuuhzl5f9_mm9b38u1": {
-        "id": "transition_zuuhzl5f9_mm9b38u1",
-        "name": "",
-        "type": "AgentStateTransition",
-        "owner": null,
-        "bounds": {
-          "x": -350,
-          "y": -702.5,
-          "width": 430,
-          "height": 182.5
-        },
-        "path": [
-          {
-            "x": 430,
-            "y": 0
-          },
-          {
-            "x": 0,
-            "y": 0
-          },
-          {
-            "x": 0,
-            "y": 182.5
-          }
-        ],
-        "source": {
-          "direction": "Upleft",
-          "element": "state_krso67h8q_mm9b38u1"
-        },
-        "target": {
-          "direction": "Up",
-          "element": "state_zl3bfe65n_mm9b38u1"
-        },
-        "isManuallyLayouted": false,
-        "condition": "auto",
-        "conditionValue": ""
-      },
-      "transition_rjozmqoco_mm9b38u1": {
-        "id": "transition_rjozmqoco_mm9b38u1",
-        "name": "",
-        "type": "AgentStateTransition",
-        "owner": null,
-        "bounds": {
-          "x": -350,
-          "y": -450,
-          "width": 640,
-          "height": 260
-        },
-        "path": [
-          {
-            "x": 640,
-            "y": 220
-          },
-          {
-            "x": 640,
-            "y": 260
-          },
-          {
-            "x": 0,
-            "y": 260
-          },
-          {
-            "x": 0,
-            "y": 0
-          }
-        ],
-        "source": {
-          "direction": "Down",
-          "element": "state_5emfhqwzt_mm9b38u1"
-        },
-        "target": {
-          "direction": "Down",
-          "element": "state_zl3bfe65n_mm9b38u1"
-        },
-        "isManuallyLayouted": false,
-        "condition": "auto",
-        "conditionValue": ""
-      },
-      "5f574d18-6641-4c80-bd19-92b862b47b7c": {
-        "id": "5f574d18-6641-4c80-bd19-92b862b47b7c",
-        "name": "",
-        "type": "AgentStateTransition",
-        "owner": null,
-        "bounds": {
-          "x": -220,
-          "y": -467.5,
-          "width": 405,
-          "height": 77.5
-        },
-        "path": [
-          {
-            "x": 405,
-            "y": 37.5
-          },
-          {
-            "x": 405,
-            "y": 77.5
-          },
-          {
-            "x": 150,
-            "y": 77.5
-          },
-          {
-            "x": 150,
-            "y": 0
-          },
-          {
-            "x": 0,
-            "y": 0
-          }
-        ],
-        "source": {
-          "direction": "Bottomleft",
-          "element": "state_j5tnma02n_mm9b38u1"
-        },
-        "target": {
-          "direction": "Downright",
-          "element": "state_zl3bfe65n_mm9b38u1"
-        },
-        "isManuallyLayouted": false,
-        "condition": "auto",
-        "conditionValue": ""
-      },
-      "5cf30015-c8cf-47be-8ad0-80bbba94d35e": {
-        "id": "5cf30015-c8cf-47be-8ad0-80bbba94d35e",
-        "name": "",
-        "type": "AgentStateTransition",
-        "owner": null,
-        "bounds": {
-          "x": -640,
-          "y": -577.5,
-          "width": 160,
-          "height": 92.5
-        },
-        "path": [
-          {
-            "x": 0,
-            "y": 0
-          },
-          {
-            "x": 80,
-            "y": 0
-          },
-          {
-            "x": 80,
-            "y": 92.5
-          },
-          {
-            "x": 160,
-            "y": 92.5
-          }
-        ],
-        "source": {
-          "direction": "Downright",
-          "element": "46badadf-e50d-481e-8246-3ba2393fce47"
-        },
-        "target": {
-          "direction": "Left",
-          "element": "state_zl3bfe65n_mm9b38u1"
-        },
-        "isManuallyLayouted": false,
-        "condition": "auto",
-        "conditionValue": ""
+      "bodies": [
+        "intentBody_jn9sy9wl2_mm9b38u1",
+        "intentBody_61dj9fnk0_mm9b38u1",
+        "intentBody_b8jkj9t1s_mm9b38u1",
+        "intentBody_jl9eozt0r_mm9b38u1"
+      ],
+      "intent_description": "Asking for the opening hours of the library."
+    },
+    "intentBody_jn9sy9wl2_mm9b38u1": {
+      "id": "intentBody_jn9sy9wl2_mm9b38u1",
+      "name": "what are the opening hours?",
+      "type": "AgentIntentBody",
+      "owner": "intent_jtmr4apyg_mm9b38u1",
+      "bounds": {
+        "x": -679.5,
+        "y": -29.5,
+        "width": 409,
+        "height": 30
       }
     },
+    "intentBody_61dj9fnk0_mm9b38u1": {
+      "id": "intentBody_61dj9fnk0_mm9b38u1",
+      "name": "library hours",
+      "type": "AgentIntentBody",
+      "owner": "intent_jtmr4apyg_mm9b38u1",
+      "bounds": {
+        "x": -679.5,
+        "y": 0.5,
+        "width": 409,
+        "height": 30
+      }
+    },
+    "intentBody_b8jkj9t1s_mm9b38u1": {
+      "id": "intentBody_b8jkj9t1s_mm9b38u1",
+      "name": "when do you open?",
+      "type": "AgentIntentBody",
+      "owner": "intent_jtmr4apyg_mm9b38u1",
+      "bounds": {
+        "x": -679.5,
+        "y": 30.5,
+        "width": 409,
+        "height": 30
+      }
+    },
+    "intentBody_jl9eozt0r_mm9b38u1": {
+      "id": "intentBody_jl9eozt0r_mm9b38u1",
+      "name": "hours of operation",
+      "type": "AgentIntentBody",
+      "owner": "intent_jtmr4apyg_mm9b38u1",
+      "bounds": {
+        "x": -679.5,
+        "y": 60.5,
+        "width": 409,
+        "height": 30
+      }
+    },
+    "intent_ggq3p9gv8_mm9b38u1": {
+      "id": "intent_ggq3p9gv8_mm9b38u1",
+      "name": "CheapestBook",
+      "type": "AgentIntent",
+      "owner": null,
+      "bounds": {
+        "x": -250,
+        "y": -100,
+        "width": 490,
+        "height": 130
+      },
+      "bodies": ["intentBody_06wxt0vga_mm9b38u1", "intentBody_14tgxxf1f_mm9b38u1", "intentBody_j2ugmtuh8_mm9b38u1"],
+      "intent_description": ""
+    },
+    "intentBody_06wxt0vga_mm9b38u1": {
+      "id": "intentBody_06wxt0vga_mm9b38u1",
+      "name": "how to get the title of the cheapest book of an author?",
+      "type": "AgentIntentBody",
+      "owner": "intent_ggq3p9gv8_mm9b38u1",
+      "bounds": {
+        "x": -249.5,
+        "y": -59.5,
+        "width": 489,
+        "height": 30
+      }
+    },
+    "intentBody_14tgxxf1f_mm9b38u1": {
+      "id": "intentBody_14tgxxf1f_mm9b38u1",
+      "name": "I want to know the cheapest book",
+      "type": "AgentIntentBody",
+      "owner": "intent_ggq3p9gv8_mm9b38u1",
+      "bounds": {
+        "x": -249.5,
+        "y": -29.5,
+        "width": 489,
+        "height": 30
+      }
+    },
+    "intentBody_j2ugmtuh8_mm9b38u1": {
+      "id": "intentBody_j2ugmtuh8_mm9b38u1",
+      "name": "which is the cheapest book?",
+      "type": "AgentIntentBody",
+      "owner": "intent_ggq3p9gv8_mm9b38u1",
+      "bounds": {
+        "x": -249.5,
+        "y": 0.5,
+        "width": 489,
+        "height": 30
+      }
+    },
+    "intent_zuidaui0x_mm9b38u1": {
+      "id": "intent_zuidaui0x_mm9b38u1",
+      "name": "Contact",
+      "type": "AgentIntent",
+      "owner": null,
+      "bounds": {
+        "x": -1130,
+        "y": -100,
+        "width": 430,
+        "height": 160
+      },
+      "bodies": ["intentBody_9kmxc6vnq_mm9b38u1", "intentBody_mxczpzj8h_mm9b38u1", "intentBody_8yqem5n2k_mm9b38u1"],
+      "intent_description": "Requesting to speak with a human assistant."
+    },
+    "intentBody_9kmxc6vnq_mm9b38u1": {
+      "id": "intentBody_9kmxc6vnq_mm9b38u1",
+      "name": "I need to speak to someone",
+      "type": "AgentIntentBody",
+      "owner": "intent_zuidaui0x_mm9b38u1",
+      "bounds": {
+        "x": -1129.5,
+        "y": -29.5,
+        "width": 429,
+        "height": 30
+      }
+    },
+    "intentBody_mxczpzj8h_mm9b38u1": {
+      "id": "intentBody_mxczpzj8h_mm9b38u1",
+      "name": "contact support",
+      "type": "AgentIntentBody",
+      "owner": "intent_zuidaui0x_mm9b38u1",
+      "bounds": {
+        "x": -1129.5,
+        "y": 0.5,
+        "width": 429,
+        "height": 30
+      }
+    },
+    "intentBody_8yqem5n2k_mm9b38u1": {
+      "id": "intentBody_8yqem5n2k_mm9b38u1",
+      "name": "human assistance",
+      "type": "AgentIntentBody",
+      "owner": "intent_zuidaui0x_mm9b38u1",
+      "bounds": {
+        "x": -1129.5,
+        "y": 30.5,
+        "width": 429,
+        "height": 30
+      }
+    },
+    "state_zl3bfe65n_mm9b38u1": {
+      "id": "state_zl3bfe65n_mm9b38u1",
+      "name": "Idle",
+      "type": "AgentState",
+      "owner": null,
+      "bounds": {
+        "x": -480,
+        "y": -520,
+        "width": 260,
+        "height": 70
+      },
+      "bodies": ["body_wybm5pc31_mm9b38u1"],
+      "fallbackBodies": []
+    },
+    "body_wybm5pc31_mm9b38u1": {
+      "id": "body_wybm5pc31_mm9b38u1",
+      "name": "How can I assist you today?",
+      "type": "AgentStateBody",
+      "owner": "state_zl3bfe65n_mm9b38u1",
+      "bounds": {
+        "x": -479.5,
+        "y": -479.5,
+        "width": 259,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "state_j5tnma02n_mm9b38u1": {
+      "id": "state_j5tnma02n_mm9b38u1",
+      "name": "OpeningHoursState",
+      "type": "AgentState",
+      "owner": null,
+      "bounds": {
+        "x": 80,
+        "y": -530,
+        "width": 420,
+        "height": 100
+      },
+      "bodies": ["body_a8ph8sxrt_mm9b38u1", "fb1432f7-1778-4c8b-90f3-e471e86cec31"],
+      "fallbackBodies": []
+    },
+    "body_a8ph8sxrt_mm9b38u1": {
+      "id": "body_a8ph8sxrt_mm9b38u1",
+      "name": "Our opening hours are Monday–Friday 9 AM–6 PM.",
+      "type": "AgentStateBody",
+      "owner": "state_j5tnma02n_mm9b38u1",
+      "bounds": {
+        "x": 80.5,
+        "y": -489.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "fb1432f7-1778-4c8b-90f3-e471e86cec31": {
+      "id": "fb1432f7-1778-4c8b-90f3-e471e86cec31",
+      "name": "Saturday 10 AM–4 PM. Closed Sunday.",
+      "type": "AgentStateBody",
+      "owner": "state_j5tnma02n_mm9b38u1",
+      "bounds": {
+        "x": 80.5,
+        "y": -459.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "state_krso67h8q_mm9b38u1": {
+      "id": "state_krso67h8q_mm9b38u1",
+      "name": "CheapestBookState",
+      "type": "AgentState",
+      "owner": null,
+      "bounds": {
+        "x": 80,
+        "y": -750,
+        "width": 420,
+        "height": 190
+      },
+      "bodies": [
+        "body_38x5jthwr_mm9b38u1",
+        "body_0yl3shkws_mm9b38u1",
+        "b533e6a5-cc51-4f0d-a269-98bf81a02c31",
+        "7c8e27fb-8cce-4f3d-9cc4-19ef5a963b8a",
+        "b779be48-1bc4-4984-9274-00c91203552a"
+      ],
+      "fallbackBodies": []
+    },
+    "body_38x5jthwr_mm9b38u1": {
+      "id": "body_38x5jthwr_mm9b38u1",
+      "name": "To get the cheapest book of an author, follow these steps:",
+      "type": "AgentStateBody",
+      "owner": "state_krso67h8q_mm9b38u1",
+      "bounds": {
+        "x": 80.5,
+        "y": -709.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "body_0yl3shkws_mm9b38u1": {
+      "id": "body_0yl3shkws_mm9b38u1",
+      "name": "1. Go to the Library tab.",
+      "type": "AgentStateBody",
+      "owner": "state_krso67h8q_mm9b38u1",
+      "bounds": {
+        "x": 80.5,
+        "y": -679.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "b533e6a5-cc51-4f0d-a269-98bf81a02c31": {
+      "id": "b533e6a5-cc51-4f0d-a269-98bf81a02c31",
+      "name": "2. In the table, select the library where you want to search.",
+      "type": "AgentStateBody",
+      "owner": "state_krso67h8q_mm9b38u1",
+      "bounds": {
+        "x": 80.5,
+        "y": -649.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "7c8e27fb-8cce-4f3d-9cc4-19ef5a963b8a": {
+      "id": "7c8e27fb-8cce-4f3d-9cc4-19ef5a963b8a",
+      "name": "3. Click on “Cheapest Book”.",
+      "type": "AgentStateBody",
+      "owner": "state_krso67h8q_mm9b38u1",
+      "bounds": {
+        "x": 80.5,
+        "y": -619.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "b779be48-1bc4-4984-9274-00c91203552a": {
+      "id": "b779be48-1bc4-4984-9274-00c91203552a",
+      "name": "4. Select an author and click “Execute”.",
+      "type": "AgentStateBody",
+      "owner": "state_krso67h8q_mm9b38u1",
+      "bounds": {
+        "x": 80.5,
+        "y": -589.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "state_5emfhqwzt_mm9b38u1": {
+      "id": "state_5emfhqwzt_mm9b38u1",
+      "name": "ContactState",
+      "type": "AgentState",
+      "owner": null,
+      "bounds": {
+        "x": 80,
+        "y": -330,
+        "width": 420,
+        "height": 100
+      },
+      "bodies": ["body_b6vkku4r1_mm9b38u1", "body_8i8n5kbs0_mm9b38u1"],
+      "fallbackBodies": []
+    },
+    "body_b6vkku4r1_mm9b38u1": {
+      "id": "body_b6vkku4r1_mm9b38u1",
+      "name": "You can contact a librarian at library@example.com or call +1 555-123-4567.",
+      "type": "AgentStateBody",
+      "owner": "state_5emfhqwzt_mm9b38u1",
+      "bounds": {
+        "x": 80.5,
+        "y": -289.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "body_8i8n5kbs0_mm9b38u1": {
+      "id": "body_8i8n5kbs0_mm9b38u1",
+      "name": "They will get back to you shortly.",
+      "type": "AgentStateBody",
+      "owner": "state_5emfhqwzt_mm9b38u1",
+      "bounds": {
+        "x": 80.5,
+        "y": -259.5,
+        "width": 419,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "46badadf-e50d-481e-8246-3ba2393fce47": {
+      "id": "46badadf-e50d-481e-8246-3ba2393fce47",
+      "name": "Greeting",
+      "type": "AgentState",
+      "owner": null,
+      "bounds": {
+        "x": -980,
+        "y": -630,
+        "width": 340,
+        "height": 70
+      },
+      "bodies": ["e3aad61a-89b4-46a6-8c16-6f80b861d717"],
+      "fallbackBodies": []
+    },
+    "e3aad61a-89b4-46a6-8c16-6f80b861d717": {
+      "id": "e3aad61a-89b4-46a6-8c16-6f80b861d717",
+      "name": "Welcome to the library support system!",
+      "type": "AgentStateBody",
+      "owner": "46badadf-e50d-481e-8246-3ba2393fce47",
+      "bounds": {
+        "x": -979.5,
+        "y": -589.5,
+        "width": 339,
+        "height": 30
+      },
+      "replyType": "text",
+      "ragDatabaseName": ""
+    },
+    "0edea0d9-cfa4-48e4-ae68-dfd226aa9f13": {
+      "id": "0edea0d9-cfa4-48e4-ae68-dfd226aa9f13",
+      "name": "Other",
+      "type": "AgentIntent",
+      "owner": null,
+      "bounds": {
+        "x": 260,
+        "y": -100,
+        "width": 250,
+        "height": 70
+      },
+      "bodies": [],
+      "intent_description": "Any other question."
+    }
+  },
+  "relationships": {
+    "transition_ixdyt9fr7_mm9b38u1": {
+      "id": "transition_ixdyt9fr7_mm9b38u1",
+      "name": "",
+      "type": "AgentStateTransitionInit",
+      "owner": null,
+      "bounds": {
+        "x": -1075,
+        "y": -597.5,
+        "width": 95,
+        "height": 1
+      },
+      "path": [
+        {
+          "x": 0,
+          "y": 0
+        },
+        {
+          "x": 95,
+          "y": 0
+        }
+      ],
+      "source": {
+        "direction": "Right",
+        "element": "initial_72th6ksf3_mm9b38u1"
+      },
+      "target": {
+        "direction": "Left",
+        "element": "46badadf-e50d-481e-8246-3ba2393fce47"
+      },
+      "isManuallyLayouted": false
+    },
+    "transition_x8h483xz2_mm9b38u1": {
+      "id": "transition_x8h483xz2_mm9b38u1",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": -220,
+        "y": -485,
+        "width": 300,
+        "height": 1
+      },
+      "path": [
+        {
+          "x": 0,
+          "y": 0
+        },
+        {
+          "x": 300,
+          "y": 0
+        }
+      ],
+      "source": {
+        "direction": "Upright",
+        "element": "state_zl3bfe65n_mm9b38u1"
+      },
+      "target": {
+        "direction": "Upleft",
+        "element": "state_j5tnma02n_mm9b38u1"
+      },
+      "isManuallyLayouted": false,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "when_intent_matched",
+        "intentName": "OpeningHours"
+      },
+      "custom": {
+        "condition": []
+      }
+    },
+    "transition_53oz6z5cc_mm9b38u1": {
+      "id": "transition_53oz6z5cc_mm9b38u1",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": -285,
+        "y": -655,
+        "width": 365,
+        "height": 135
+      },
+      "path": [
+        {
+          "x": 0,
+          "y": 135
+        },
+        {
+          "x": 0,
+          "y": 0
+        },
+        {
+          "x": 365,
+          "y": 0
+        }
+      ],
+      "source": {
+        "direction": "Topright",
+        "element": "state_zl3bfe65n_mm9b38u1"
+      },
+      "target": {
+        "direction": "Left",
+        "element": "state_krso67h8q_mm9b38u1"
+      },
+      "isManuallyLayouted": false,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "when_intent_matched",
+        "intentName": "CheapestBook"
+      },
+      "custom": {
+        "condition": []
+      }
+    },
+    "transition_jc0mk7kpn_mm9b38u1": {
+      "id": "transition_jc0mk7kpn_mm9b38u1",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": -285,
+        "y": -450,
+        "width": 365,
+        "height": 170
+      },
+      "path": [
+        {
+          "x": 0,
+          "y": 0
+        },
+        {
+          "x": 0,
+          "y": 170
+        },
+        {
+          "x": 365,
+          "y": 170
+        }
+      ],
+      "source": {
+        "direction": "Bottomright",
+        "element": "state_zl3bfe65n_mm9b38u1"
+      },
+      "target": {
+        "direction": "Left",
+        "element": "state_5emfhqwzt_mm9b38u1"
+      },
+      "isManuallyLayouted": false,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "when_intent_matched",
+        "intentName": "Contact"
+      },
+      "custom": {
+        "condition": []
+      }
+    },
+    "transition_zuuhzl5f9_mm9b38u1": {
+      "id": "transition_zuuhzl5f9_mm9b38u1",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": -350,
+        "y": -702.5,
+        "width": 430,
+        "height": 182.5
+      },
+      "path": [
+        {
+          "x": 430,
+          "y": 0
+        },
+        {
+          "x": 0,
+          "y": 0
+        },
+        {
+          "x": 0,
+          "y": 182.5
+        }
+      ],
+      "source": {
+        "direction": "Upleft",
+        "element": "state_krso67h8q_mm9b38u1"
+      },
+      "target": {
+        "direction": "Up",
+        "element": "state_zl3bfe65n_mm9b38u1"
+      },
+      "isManuallyLayouted": false,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "auto",
+        "conditionValue": ""
+      },
+      "custom": {
+        "condition": []
+      }
+    },
+    "transition_rjozmqoco_mm9b38u1": {
+      "id": "transition_rjozmqoco_mm9b38u1",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": -350,
+        "y": -450,
+        "width": 640,
+        "height": 260
+      },
+      "path": [
+        {
+          "x": 640,
+          "y": 220
+        },
+        {
+          "x": 640,
+          "y": 260
+        },
+        {
+          "x": 0,
+          "y": 260
+        },
+        {
+          "x": 0,
+          "y": 0
+        }
+      ],
+      "source": {
+        "direction": "Down",
+        "element": "state_5emfhqwzt_mm9b38u1"
+      },
+      "target": {
+        "direction": "Down",
+        "element": "state_zl3bfe65n_mm9b38u1"
+      },
+      "isManuallyLayouted": false,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "auto",
+        "conditionValue": ""
+      },
+      "custom": {
+        "condition": []
+      }
+    },
+    "5f574d18-6641-4c80-bd19-92b862b47b7c": {
+      "id": "5f574d18-6641-4c80-bd19-92b862b47b7c",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": -220,
+        "y": -467.5,
+        "width": 405,
+        "height": 77.5
+      },
+      "path": [
+        {
+          "x": 405,
+          "y": 37.5
+        },
+        {
+          "x": 405,
+          "y": 77.5
+        },
+        {
+          "x": 150,
+          "y": 77.5
+        },
+        {
+          "x": 150,
+          "y": 0
+        },
+        {
+          "x": 0,
+          "y": 0
+        }
+      ],
+      "source": {
+        "direction": "Bottomleft",
+        "element": "state_j5tnma02n_mm9b38u1"
+      },
+      "target": {
+        "direction": "Downright",
+        "element": "state_zl3bfe65n_mm9b38u1"
+      },
+      "isManuallyLayouted": false,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "auto",
+        "conditionValue": ""
+      },
+      "custom": {
+        "condition": []
+      }
+    },
+    "5cf30015-c8cf-47be-8ad0-80bbba94d35e": {
+      "id": "5cf30015-c8cf-47be-8ad0-80bbba94d35e",
+      "name": "",
+      "type": "AgentStateTransition",
+      "owner": null,
+      "bounds": {
+        "x": -640,
+        "y": -577.5,
+        "width": 160,
+        "height": 92.5
+      },
+      "path": [
+        {
+          "x": 0,
+          "y": 0
+        },
+        {
+          "x": 80,
+          "y": 0
+        },
+        {
+          "x": 80,
+          "y": 92.5
+        },
+        {
+          "x": 160,
+          "y": 92.5
+        }
+      ],
+      "source": {
+        "direction": "Downright",
+        "element": "46badadf-e50d-481e-8246-3ba2393fce47"
+      },
+      "target": {
+        "direction": "Left",
+        "element": "state_zl3bfe65n_mm9b38u1"
+      },
+      "isManuallyLayouted": false,
+      "transitionType": "predefined",
+      "predefined": {
+        "predefinedType": "auto",
+        "conditionValue": ""
+      },
+      "custom": {
+        "condition": []
+      }
+    }
+  },
   "assessments": {}
 }

--- a/packages/webapp/src/main/templates/pattern/project/library_full_stack.json
+++ b/packages/webapp/src/main/templates/pattern/project/library_full_stack.json
@@ -54,9 +54,7 @@
                   "attr_785suq5yn_mjikkmod",
                   "attr_urp7jb0c0_mjikkmod"
                 ],
-                "methods": [
-                  "method_rb01uirsh_mjikkmod"
-                ]
+                "methods": ["method_rb01uirsh_mjikkmod"]
               },
               "attr_a87fqdtdi_mjikkmod": {
                 "id": "attr_a87fqdtdi_mjikkmod",
@@ -229,9 +227,7 @@
                   "4391886d-13b5-4fa0-9894-09f1894af27f",
                   "a487fd85-dec0-47b9-bd37-71ff92026963"
                 ],
-                "methods": [
-                  "35ef5329-889b-40f0-89ce-9836936fd8a9"
-                ]
+                "methods": ["35ef5329-889b-40f0-89ce-9836936fd8a9"]
               },
               "attr_eryfh37kl_mjikkmod": {
                 "id": "attr_eryfh37kl_mjikkmod",
@@ -354,10 +350,7 @@
                   "width": 220,
                   "height": 95
                 },
-                "attributes": [
-                  "attr_p3zqpt65k_mjikkmoe",
-                  "4321afe8-8ec2-48da-a0ec-b2ce9ccaf1db"
-                ],
+                "attributes": ["attr_p3zqpt65k_mjikkmoe", "4321afe8-8ec2-48da-a0ec-b2ce9ccaf1db"],
                 "methods": []
               },
               "attr_p3zqpt65k_mjikkmoe": {
@@ -986,9 +979,7 @@
                   "width": 260,
                   "height": 70
                 },
-                "bodies": [
-                  "body_wybm5pc31_mm9b38u1"
-                ],
+                "bodies": ["body_wybm5pc31_mm9b38u1"],
                 "fallbackBodies": []
               },
               "body_wybm5pc31_mm9b38u1": {
@@ -1015,10 +1006,7 @@
                   "width": 420,
                   "height": 100
                 },
-                "bodies": [
-                  "body_a8ph8sxrt_mm9b38u1",
-                  "fb1432f7-1778-4c8b-90f3-e471e86cec31"
-                ],
+                "bodies": ["body_a8ph8sxrt_mm9b38u1", "fb1432f7-1778-4c8b-90f3-e471e86cec31"],
                 "fallbackBodies": []
               },
               "body_a8ph8sxrt_mm9b38u1": {
@@ -1143,10 +1131,7 @@
                   "width": 420,
                   "height": 100
                 },
-                "bodies": [
-                  "body_b6vkku4r1_mm9b38u1",
-                  "body_8i8n5kbs0_mm9b38u1"
-                ],
+                "bodies": ["body_b6vkku4r1_mm9b38u1", "body_8i8n5kbs0_mm9b38u1"],
                 "fallbackBodies": []
               },
               "body_b6vkku4r1_mm9b38u1": {
@@ -1186,9 +1171,7 @@
                   "width": 420,
                   "height": 70
                 },
-                "bodies": [
-                  "e3aad61a-89b4-46a6-8c16-6f80b861d717"
-                ],
+                "bodies": ["e3aad61a-89b4-46a6-8c16-6f80b861d717"],
                 "fallbackBodies": []
               },
               "e3aad61a-89b4-46a6-8c16-6f80b861d717": {
@@ -1842,36 +1825,19 @@
                                   "components": [
                                     {
                                       "type": "tbody",
-                                      "draggable": [
-                                        "table"
-                                      ],
-                                      "droppable": [
-                                        "tr"
-                                      ],
+                                      "draggable": ["table"],
+                                      "droppable": ["tr"],
                                       "components": [
                                         {
                                           "type": "row",
-                                          "draggable": [
-                                            "thead",
-                                            "tbody",
-                                            "tfoot"
-                                          ],
-                                          "droppable": [
-                                            "th",
-                                            "td"
-                                          ],
-                                          "classes": [
-                                            "row"
-                                          ],
+                                          "draggable": ["thead", "tbody", "tfoot"],
+                                          "droppable": ["th", "td"],
+                                          "classes": ["row"],
                                           "components": [
                                             {
                                               "type": "cell",
-                                              "draggable": [
-                                                "tr"
-                                              ],
-                                              "classes": [
-                                                "cell"
-                                              ]
+                                              "draggable": ["tr"],
+                                              "classes": ["cell"]
                                             }
                                           ]
                                         }
@@ -1889,9 +1855,7 @@
                                       "type": "action-button",
                                       "content": "+ decrease_stock",
                                       "style": "",
-                                      "classes": [
-                                        "action-button-component"
-                                      ],
+                                      "classes": ["action-button-component"],
                                       "attributes": {
                                         "type": "button",
                                         "data-button-label": "+ decrease_stock",
@@ -1920,9 +1884,7 @@
                                     {
                                       "type": "agent-component",
                                       "style": "",
-                                      "classes": [
-                                        "agent-component"
-                                      ],
+                                      "classes": ["agent-component"],
                                       "attributes": {
                                         "agent-name": "Library Agent",
                                         "agent-title": "BESSER Agent",
@@ -2177,36 +2139,19 @@
                                   "components": [
                                     {
                                       "type": "tbody",
-                                      "draggable": [
-                                        "table"
-                                      ],
-                                      "droppable": [
-                                        "tr"
-                                      ],
+                                      "draggable": ["table"],
+                                      "droppable": ["tr"],
                                       "components": [
                                         {
                                           "type": "row",
-                                          "draggable": [
-                                            "thead",
-                                            "tbody",
-                                            "tfoot"
-                                          ],
-                                          "droppable": [
-                                            "th",
-                                            "td"
-                                          ],
-                                          "classes": [
-                                            "row"
-                                          ],
+                                          "draggable": ["thead", "tbody", "tfoot"],
+                                          "droppable": ["th", "td"],
+                                          "classes": ["row"],
                                           "components": [
                                             {
                                               "type": "cell",
-                                              "draggable": [
-                                                "tr"
-                                              ],
-                                              "classes": [
-                                                "cell"
-                                              ]
+                                              "draggable": ["tr"],
+                                              "classes": ["cell"]
                                             }
                                           ]
                                         }
@@ -2223,9 +2168,7 @@
                                     {
                                       "type": "action-button",
                                       "style": "",
-                                      "classes": [
-                                        "action-button-component"
-                                      ],
+                                      "classes": ["action-button-component"],
                                       "attributes": {
                                         "type": "button",
                                         "data-button-label": "+ cheapest_book_by",
@@ -2402,9 +2345,7 @@
                                 {
                                   "type": "table",
                                   "style": "",
-                                  "classes": [
-                                    "has-data-binding"
-                                  ],
+                                  "classes": ["has-data-binding"],
                                   "attributes": {
                                     "chart-color": "#2c3e50",
                                     "chart-title": "Author List",
@@ -2472,36 +2413,19 @@
                                   "components": [
                                     {
                                       "type": "tbody",
-                                      "draggable": [
-                                        "table"
-                                      ],
-                                      "droppable": [
-                                        "tr"
-                                      ],
+                                      "draggable": ["table"],
+                                      "droppable": ["tr"],
                                       "components": [
                                         {
                                           "type": "row",
-                                          "draggable": [
-                                            "thead",
-                                            "tbody",
-                                            "tfoot"
-                                          ],
-                                          "droppable": [
-                                            "th",
-                                            "td"
-                                          ],
-                                          "classes": [
-                                            "row"
-                                          ],
+                                          "draggable": ["thead", "tbody", "tfoot"],
+                                          "droppable": ["th", "td"],
+                                          "classes": ["row"],
                                           "components": [
                                             {
                                               "type": "cell",
-                                              "draggable": [
-                                                "tr"
-                                              ],
-                                              "classes": [
-                                                "cell"
-                                              ]
+                                              "draggable": ["tr"],
+                                              "classes": ["cell"]
                                             }
                                           ]
                                         }
@@ -2531,9 +2455,7 @@
             ],
             "styles": [
               {
-                "selectors": [
-                  "#i7thg"
-                ],
+                "selectors": ["#i7thg"],
                 "style": {
                   "margin-top": "0",
                   "font-size": "24px",
@@ -2542,9 +2464,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#ih8h6"
-                ],
+                "selectors": ["#ih8h6"],
                 "style": {
                   "color": "white",
                   "text-decoration": "none",
@@ -2556,9 +2476,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#i9l4g"
-                ],
+                "selectors": ["#i9l4g"],
                 "style": {
                   "color": "white",
                   "text-decoration": "none",
@@ -2570,9 +2488,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#io6eh"
-                ],
+                "selectors": ["#io6eh"],
                 "style": {
                   "color": "white",
                   "text-decoration": "none",
@@ -2584,9 +2500,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#iwntp"
-                ],
+                "selectors": ["#iwntp"],
                 "style": {
                   "display": "flex",
                   "flex-direction": "column",
@@ -2594,9 +2508,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#ixx2i"
-                ],
+                "selectors": ["#ixx2i"],
                 "style": {
                   "margin-top": "auto",
                   "padding-top": "20px",
@@ -2607,9 +2519,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#ihyzm"
-                ],
+                "selectors": ["#ihyzm"],
                 "style": {
                   "width": "250px",
                   "background": "linear-gradient(135deg, #4b3c82 0%, #5a3d91 100%)",
@@ -2621,9 +2531,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#iyjpg"
-                ],
+                "selectors": ["#iyjpg"],
                 "style": {
                   "margin-top": "0",
                   "color": "#333",
@@ -2632,27 +2540,21 @@
                 }
               },
               {
-                "selectors": [
-                  "#itizf"
-                ],
+                "selectors": ["#itizf"],
                 "style": {
                   "color": "#666",
                   "margin-bottom": "30px"
                 }
               },
               {
-                "selectors": [
-                  "#table-book-0"
-                ],
+                "selectors": ["#table-book-0"],
                 "style": {
                   "width": "100%",
                   "min-height": "400px"
                 }
               },
               {
-                "selectors": [
-                  "#idgyv"
-                ],
+                "selectors": ["#idgyv"],
                 "style": {
                   "display": "inline-flex",
                   "align-items": "center",
@@ -2671,9 +2573,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#ioq13"
-                ],
+                "selectors": ["#ioq13"],
                 "style": {
                   "margin-top": "20px",
                   "display": "flex",
@@ -2682,9 +2582,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#i0mrm"
-                ],
+                "selectors": ["#i0mrm"],
                 "style": {
                   "flex": "1",
                   "padding": "40px",
@@ -2693,9 +2591,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#iir99"
-                ],
+                "selectors": ["#iir99"],
                 "style": {
                   "display": "flex",
                   "height": "100vh",
@@ -2703,9 +2599,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#iopqh"
-                ],
+                "selectors": ["#iopqh"],
                 "style": {
                   "margin-top": "0",
                   "font-size": "24px",
@@ -2714,9 +2608,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#ix6dg"
-                ],
+                "selectors": ["#ix6dg"],
                 "style": {
                   "color": "white",
                   "text-decoration": "none",
@@ -2728,9 +2620,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#ixrwm"
-                ],
+                "selectors": ["#ixrwm"],
                 "style": {
                   "color": "white",
                   "text-decoration": "none",
@@ -2742,9 +2632,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#iauyc"
-                ],
+                "selectors": ["#iauyc"],
                 "style": {
                   "color": "white",
                   "text-decoration": "none",
@@ -2756,9 +2644,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#iui4i"
-                ],
+                "selectors": ["#iui4i"],
                 "style": {
                   "display": "flex",
                   "flex-direction": "column",
@@ -2766,9 +2652,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#iijek"
-                ],
+                "selectors": ["#iijek"],
                 "style": {
                   "margin-top": "auto",
                   "padding-top": "20px",
@@ -2779,9 +2663,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#i5v1l"
-                ],
+                "selectors": ["#i5v1l"],
                 "style": {
                   "width": "250px",
                   "background": "linear-gradient(135deg, #4b3c82 0%, #5a3d91 100%)",
@@ -2793,9 +2675,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#ihqgf"
-                ],
+                "selectors": ["#ihqgf"],
                 "style": {
                   "margin-top": "0",
                   "color": "#333",
@@ -2804,27 +2684,21 @@
                 }
               },
               {
-                "selectors": [
-                  "#ij47n"
-                ],
+                "selectors": ["#ij47n"],
                 "style": {
                   "color": "#666",
                   "margin-bottom": "30px"
                 }
               },
               {
-                "selectors": [
-                  "#table-library-1"
-                ],
+                "selectors": ["#table-library-1"],
                 "style": {
                   "width": "100%",
                   "min-height": "400px"
                 }
               },
               {
-                "selectors": [
-                  "#ir5xw"
-                ],
+                "selectors": ["#ir5xw"],
                 "style": {
                   "display": "inline-flex",
                   "align-items": "center",
@@ -2843,9 +2717,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#i0iia"
-                ],
+                "selectors": ["#i0iia"],
                 "style": {
                   "margin-top": "20px",
                   "display": "flex",
@@ -2854,9 +2726,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#i845n"
-                ],
+                "selectors": ["#i845n"],
                 "style": {
                   "flex": "1",
                   "padding": "40px",
@@ -2865,9 +2735,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#ipfo8"
-                ],
+                "selectors": ["#ipfo8"],
                 "style": {
                   "display": "flex",
                   "height": "100vh",
@@ -2875,9 +2743,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#i3xv3"
-                ],
+                "selectors": ["#i3xv3"],
                 "style": {
                   "margin-top": "0",
                   "font-size": "24px",
@@ -2886,9 +2752,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#ibxxn"
-                ],
+                "selectors": ["#ibxxn"],
                 "style": {
                   "color": "white",
                   "text-decoration": "none",
@@ -2900,9 +2764,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#ik9yu"
-                ],
+                "selectors": ["#ik9yu"],
                 "style": {
                   "color": "white",
                   "text-decoration": "none",
@@ -2914,9 +2776,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#ibnlk"
-                ],
+                "selectors": ["#ibnlk"],
                 "style": {
                   "color": "white",
                   "text-decoration": "none",
@@ -2928,9 +2788,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#itt6j"
-                ],
+                "selectors": ["#itt6j"],
                 "style": {
                   "display": "flex",
                   "flex-direction": "column",
@@ -2938,9 +2796,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#il285"
-                ],
+                "selectors": ["#il285"],
                 "style": {
                   "margin-top": "auto",
                   "padding-top": "20px",
@@ -2951,9 +2807,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#is7w8"
-                ],
+                "selectors": ["#is7w8"],
                 "style": {
                   "width": "250px",
                   "background": "linear-gradient(135deg, #4b3c82 0%, #5a3d91 100%)",
@@ -2965,9 +2819,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#iqnfa"
-                ],
+                "selectors": ["#iqnfa"],
                 "style": {
                   "margin-top": "0",
                   "color": "#333",
@@ -2976,27 +2828,21 @@
                 }
               },
               {
-                "selectors": [
-                  "#i8odx"
-                ],
+                "selectors": ["#i8odx"],
                 "style": {
                   "color": "#666",
                   "margin-bottom": "30px"
                 }
               },
               {
-                "selectors": [
-                  "#table-author-2"
-                ],
+                "selectors": ["#table-author-2"],
                 "style": {
                   "width": "100%",
                   "min-height": "400px"
                 }
               },
               {
-                "selectors": [
-                  "#ih5us"
-                ],
+                "selectors": ["#ih5us"],
                 "style": {
                   "flex": "1",
                   "padding": "40px",
@@ -3005,9 +2851,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#in05f"
-                ],
+                "selectors": ["#in05f"],
                 "style": {
                   "display": "flex",
                   "height": "100vh",
@@ -3015,9 +2859,7 @@
                 }
               },
               {
-                "selectors": [
-                  "#im47u"
-                ],
+                "selectors": ["#im47u"],
                 "style": {
                   "width": "100%",
                   "min-height": "400px"

--- a/packages/webapp/src/main/templates/pattern/project/personalized_gym_agent.json
+++ b/packages/webapp/src/main/templates/pattern/project/personalized_gym_agent.json
@@ -58,12 +58,8 @@
                   "width": 420,
                   "height": 100
                 },
-                "bodies": [
-                  "63a2c160-ebbb-457b-953a-93fd2e643224"
-                ],
-                "fallbackBodies": [
-                  "1f369122-06c2-4050-ba54-4ea160f95a8c"
-                ]
+                "bodies": ["63a2c160-ebbb-457b-953a-93fd2e643224"],
+                "fallbackBodies": ["1f369122-06c2-4050-ba54-4ea160f95a8c"]
               },
               "63a2c160-ebbb-457b-953a-93fd2e643224": {
                 "id": "63a2c160-ebbb-457b-953a-93fd2e643224",
@@ -104,9 +100,7 @@
                   "width": 630,
                   "height": 100
                 },
-                "bodies": [
-                  "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b"
-                ],
+                "bodies": ["a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b"],
                 "intent_description": "Question about how to become muscular and which exercises to perform."
               },
               "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b": {
@@ -192,9 +186,7 @@
                   "width": 420,
                   "height": 70
                 },
-                "bodies": [
-                  "ad226172-93d8-4644-80c5-62825565dd24"
-                ],
+                "bodies": ["ad226172-93d8-4644-80c5-62825565dd24"],
                 "fallbackBodies": []
               },
               "ad226172-93d8-4644-80c5-62825565dd24": {
@@ -312,9 +304,7 @@
                   "width": 180,
                   "height": 70
                 },
-                "bodies": [
-                  "6a3aeb02-bb44-4472-8489-595e8dc8ceb1"
-                ],
+                "bodies": ["6a3aeb02-bb44-4472-8489-595e8dc8ceb1"],
                 "fallbackBodies": []
               },
               "6a3aeb02-bb44-4472-8489-595e8dc8ceb1": {
@@ -342,9 +332,7 @@
                   "width": 630,
                   "height": 100
                 },
-                "bodies": [
-                  "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0"
-                ],
+                "bodies": ["f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0"],
                 "intent_description": "Question about nutrition in gym."
               },
               "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0": {
@@ -452,8 +440,14 @@
                   "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
                 },
                 "isManuallyLayouted": false,
-                "condition": "when_intent_matched",
-                "conditionValue": "Muscles_intent"
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "when_intent_matched",
+                  "intentName": "Muscles_intent"
+                },
+                "custom": {
+                  "condition": []
+                }
               },
               "7d65df96-e669-4fc6-a882-dbfe92a57073": {
                 "id": "7d65df96-e669-4fc6-a882-dbfe92a57073",
@@ -485,8 +479,14 @@
                   "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
                 },
                 "isManuallyLayouted": false,
-                "condition": "auto",
-                "conditionValue": ""
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "auto",
+                  "conditionValue": ""
+                },
+                "custom": {
+                  "condition": []
+                }
               },
               "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31": {
                 "id": "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31",
@@ -530,8 +530,14 @@
                   "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
                 },
                 "isManuallyLayouted": true,
-                "condition": "when_intent_matched",
-                "conditionValue": "Other"
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "when_intent_matched",
+                  "intentName": "Other"
+                },
+                "custom": {
+                  "condition": []
+                }
               },
               "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e": {
                 "id": "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e",
@@ -571,8 +577,14 @@
                   "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
                 },
                 "isManuallyLayouted": false,
-                "condition": "auto",
-                "conditionValue": ""
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "auto",
+                  "conditionValue": ""
+                },
+                "custom": {
+                  "condition": []
+                }
               },
               "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32": {
                 "id": "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32",
@@ -616,8 +628,14 @@
                   "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
                 },
                 "isManuallyLayouted": false,
-                "condition": "auto",
-                "conditionValue": ""
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "auto",
+                  "conditionValue": ""
+                },
+                "custom": {
+                  "condition": []
+                }
               },
               "3564da62-bea0-4489-81b2-fda2effddd02": {
                 "id": "3564da62-bea0-4489-81b2-fda2effddd02",
@@ -661,8 +679,14 @@
                   "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
                 },
                 "isManuallyLayouted": false,
-                "condition": "auto",
-                "conditionValue": ""
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "auto",
+                  "conditionValue": ""
+                },
+                "custom": {
+                  "condition": []
+                }
               },
               "b696a5f6-f328-42fb-bdbc-83569b2beb06": {
                 "id": "b696a5f6-f328-42fb-bdbc-83569b2beb06",
@@ -694,8 +718,14 @@
                   "element": "7610bbda-21ef-4637-a188-1da1352bea17"
                 },
                 "isManuallyLayouted": false,
-                "condition": "when_intent_matched",
-                "conditionValue": "Nutrition_intent"
+                "transitionType": "predefined",
+                "predefined": {
+                  "predefinedType": "when_intent_matched",
+                  "intentName": "Nutrition_intent"
+                },
+                "custom": {
+                  "condition": []
+                }
               }
             },
             "assessments": {}
@@ -703,12 +733,8 @@
           "lastUpdate": "2026-05-06T13:49:26.796Z",
           "config": {
             "agentLanguage": "original",
-            "inputModalities": [
-              "text"
-            ],
-            "outputModalities": [
-              "text"
-            ],
+            "inputModalities": ["text"],
+            "outputModalities": ["text"],
             "agentPlatform": "streamlit",
             "responseTiming": "instant",
             "agentStyle": "original",
@@ -778,9 +804,7 @@
                         "width": 160,
                         "height": 100
                       },
-                      "bodies": [
-                        "ccd1dced-243c-49c4-9a00-80e7f772327a"
-                      ],
+                      "bodies": ["ccd1dced-243c-49c4-9a00-80e7f772327a"],
                       "intent_description": "Question about how to become muscular and which exercises to perform."
                     },
                     "651f4205-d406-482c-8bb4-975fdf9e456f": {
@@ -806,9 +830,7 @@
                         "width": 160,
                         "height": 100
                       },
-                      "bodies": [
-                        "651f4205-d406-482c-8bb4-975fdf9e456f"
-                      ],
+                      "bodies": ["651f4205-d406-482c-8bb4-975fdf9e456f"],
                       "intent_description": "Question about nutrition in gym."
                     },
                     "4037bf46-f138-4c9c-a891-c8f5639a19a0": {
@@ -848,9 +870,7 @@
                         "width": 160,
                         "height": 100
                       },
-                      "bodies": [
-                        "e082c986-9bb3-45be-8f43-2e6b8af7a9d7"
-                      ],
+                      "bodies": ["e082c986-9bb3-45be-8f43-2e6b8af7a9d7"],
                       "fallbackBodies": []
                     },
                     "07601353-ee34-4ca9-bbe4-bdd711e624c4": {
@@ -864,12 +884,8 @@
                         "width": 160,
                         "height": 100
                       },
-                      "bodies": [
-                        "ac420544-4ccf-4a49-9b3f-0c1eb9278f7e"
-                      ],
-                      "fallbackBodies": [
-                        "3e3e5cbe-d409-4601-9cb2-11b371cfb064"
-                      ]
+                      "bodies": ["ac420544-4ccf-4a49-9b3f-0c1eb9278f7e"],
+                      "fallbackBodies": ["3e3e5cbe-d409-4601-9cb2-11b371cfb064"]
                     },
                     "8f57a878-84ca-409d-b89d-cc62fc815507": {
                       "id": "8f57a878-84ca-409d-b89d-cc62fc815507",
@@ -920,9 +936,7 @@
                         "width": 160,
                         "height": 100
                       },
-                      "bodies": [
-                        "4499b560-b246-4b3f-b703-d9709836b98e"
-                      ],
+                      "bodies": ["4499b560-b246-4b3f-b703-d9709836b98e"],
                       "fallbackBodies": []
                     },
                     "e082c986-9bb3-45be-8f43-2e6b8af7a9d7": {
@@ -1182,7 +1196,6 @@
                         "conditionValue": ""
                       },
                       "custom": {
-                        "event": "None",
                         "condition": []
                       }
                     },
@@ -1242,7 +1255,6 @@
                         "intentName": "Muscles_intent"
                       },
                       "custom": {
-                        "event": "None",
                         "condition": []
                       }
                     },
@@ -1302,7 +1314,6 @@
                         "intentName": "Other"
                       },
                       "custom": {
-                        "event": "None",
                         "condition": []
                       }
                     },
@@ -1362,7 +1373,6 @@
                         "intentName": "Nutrition_intent"
                       },
                       "custom": {
-                        "event": "None",
                         "condition": []
                       }
                     },
@@ -1422,7 +1432,6 @@
                         "conditionValue": ""
                       },
                       "custom": {
-                        "event": "None",
                         "condition": []
                       }
                     },
@@ -1482,7 +1491,6 @@
                         "conditionValue": ""
                       },
                       "custom": {
-                        "event": "None",
                         "condition": []
                       }
                     },
@@ -1542,7 +1550,6 @@
                         "conditionValue": ""
                       },
                       "custom": {
-                        "event": "None",
                         "condition": []
                       }
                     },
@@ -1635,9 +1642,7 @@
                         "width": 160,
                         "height": 100
                       },
-                      "bodies": [
-                        "6b718df7-70ef-4e1c-8c6b-c82133964f86"
-                      ],
+                      "bodies": ["6b718df7-70ef-4e1c-8c6b-c82133964f86"],
                       "intent_description": "Question about how to become muscular and which exercises to perform."
                     },
                     "192db72d-4d0e-49b0-b49c-5050fb0dbb68": {
@@ -1663,9 +1668,7 @@
                         "width": 160,
                         "height": 100
                       },
-                      "bodies": [
-                        "192db72d-4d0e-49b0-b49c-5050fb0dbb68"
-                      ],
+                      "bodies": ["192db72d-4d0e-49b0-b49c-5050fb0dbb68"],
                       "intent_description": "Question about nutrition in gym."
                     },
                     "90d28305-378e-4bad-b3ea-61c3ddaa5921": {
@@ -1705,9 +1708,7 @@
                         "width": 160,
                         "height": 100
                       },
-                      "bodies": [
-                        "82783f5d-8ef3-47f7-8feb-9651bdf73d63"
-                      ],
+                      "bodies": ["82783f5d-8ef3-47f7-8feb-9651bdf73d63"],
                       "fallbackBodies": []
                     },
                     "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8": {
@@ -1721,12 +1722,8 @@
                         "width": 160,
                         "height": 100
                       },
-                      "bodies": [
-                        "d91b1fe8-cd6c-4b20-928c-70021c0f044d"
-                      ],
-                      "fallbackBodies": [
-                        "10a044fe-f0bd-41e8-ae27-0f2c2afc2cac"
-                      ]
+                      "bodies": ["d91b1fe8-cd6c-4b20-928c-70021c0f044d"],
+                      "fallbackBodies": ["10a044fe-f0bd-41e8-ae27-0f2c2afc2cac"]
                     },
                     "aa0bf687-2e08-4cba-aa98-335bcce5ecc7": {
                       "id": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
@@ -1777,9 +1774,7 @@
                         "width": 160,
                         "height": 100
                       },
-                      "bodies": [
-                        "3721c5e6-19b1-4811-8b00-17415913c3aa"
-                      ],
+                      "bodies": ["3721c5e6-19b1-4811-8b00-17415913c3aa"],
                       "fallbackBodies": []
                     },
                     "82783f5d-8ef3-47f7-8feb-9651bdf73d63": {
@@ -2039,7 +2034,6 @@
                         "conditionValue": ""
                       },
                       "custom": {
-                        "event": "None",
                         "condition": []
                       }
                     },
@@ -2099,7 +2093,6 @@
                         "intentName": "Muscles_intent"
                       },
                       "custom": {
-                        "event": "None",
                         "condition": []
                       }
                     },
@@ -2159,7 +2152,6 @@
                         "intentName": "Other"
                       },
                       "custom": {
-                        "event": "None",
                         "condition": []
                       }
                     },
@@ -2219,7 +2211,6 @@
                         "intentName": "Nutrition_intent"
                       },
                       "custom": {
-                        "event": "None",
                         "condition": []
                       }
                     },
@@ -2279,7 +2270,6 @@
                         "conditionValue": ""
                       },
                       "custom": {
-                        "event": "None",
                         "condition": []
                       }
                     },
@@ -2339,7 +2329,6 @@
                         "conditionValue": ""
                       },
                       "custom": {
-                        "event": "None",
                         "condition": []
                       }
                     },
@@ -2399,7 +2388,6 @@
                         "conditionValue": ""
                       },
                       "custom": {
-                        "event": "None",
                         "condition": []
                       }
                     },
@@ -3041,12 +3029,8 @@
       "savedAt": "2026-05-06T13:45:22.587Z",
       "config": {
         "agentLanguage": "original",
-        "inputModalities": [
-          "text"
-        ],
-        "outputModalities": [
-          "text"
-        ],
+        "inputModalities": ["text"],
+        "outputModalities": ["text"],
         "agentPlatform": "streamlit",
         "responseTiming": "instant",
         "agentStyle": "informal",
@@ -3109,12 +3093,8 @@
               "width": 420,
               "height": 100
             },
-            "bodies": [
-              "63a2c160-ebbb-457b-953a-93fd2e643224"
-            ],
-            "fallbackBodies": [
-              "1f369122-06c2-4050-ba54-4ea160f95a8c"
-            ]
+            "bodies": ["63a2c160-ebbb-457b-953a-93fd2e643224"],
+            "fallbackBodies": ["1f369122-06c2-4050-ba54-4ea160f95a8c"]
           },
           "63a2c160-ebbb-457b-953a-93fd2e643224": {
             "id": "63a2c160-ebbb-457b-953a-93fd2e643224",
@@ -3155,9 +3135,7 @@
               "width": 630,
               "height": 100
             },
-            "bodies": [
-              "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b"
-            ],
+            "bodies": ["a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b"],
             "intent_description": "Question about how to become muscular and which exercises to perform."
           },
           "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b": {
@@ -3243,9 +3221,7 @@
               "width": 420,
               "height": 70
             },
-            "bodies": [
-              "ad226172-93d8-4644-80c5-62825565dd24"
-            ],
+            "bodies": ["ad226172-93d8-4644-80c5-62825565dd24"],
             "fallbackBodies": []
           },
           "ad226172-93d8-4644-80c5-62825565dd24": {
@@ -3363,9 +3339,7 @@
               "width": 180,
               "height": 70
             },
-            "bodies": [
-              "6a3aeb02-bb44-4472-8489-595e8dc8ceb1"
-            ],
+            "bodies": ["6a3aeb02-bb44-4472-8489-595e8dc8ceb1"],
             "fallbackBodies": []
           },
           "6a3aeb02-bb44-4472-8489-595e8dc8ceb1": {
@@ -3393,9 +3367,7 @@
               "width": 630,
               "height": 100
             },
-            "bodies": [
-              "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0"
-            ],
+            "bodies": ["f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0"],
             "intent_description": "Question about nutrition in gym."
           },
           "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0": {
@@ -3503,8 +3475,14 @@
               "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
             },
             "isManuallyLayouted": false,
-            "condition": "when_intent_matched",
-            "conditionValue": "Muscles_intent"
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "when_intent_matched",
+              "intentName": "Muscles_intent"
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "7d65df96-e669-4fc6-a882-dbfe92a57073": {
             "id": "7d65df96-e669-4fc6-a882-dbfe92a57073",
@@ -3536,8 +3514,14 @@
               "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
             },
             "isManuallyLayouted": false,
-            "condition": "auto",
-            "conditionValue": ""
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31": {
             "id": "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31",
@@ -3581,8 +3565,14 @@
               "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
             },
             "isManuallyLayouted": true,
-            "condition": "when_intent_matched",
-            "conditionValue": "Other"
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "when_intent_matched",
+              "intentName": "Other"
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e": {
             "id": "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e",
@@ -3622,8 +3612,14 @@
               "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
             },
             "isManuallyLayouted": false,
-            "condition": "auto",
-            "conditionValue": ""
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32": {
             "id": "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32",
@@ -3667,8 +3663,14 @@
               "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
             },
             "isManuallyLayouted": false,
-            "condition": "auto",
-            "conditionValue": ""
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "3564da62-bea0-4489-81b2-fda2effddd02": {
             "id": "3564da62-bea0-4489-81b2-fda2effddd02",
@@ -3712,8 +3714,14 @@
               "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
             },
             "isManuallyLayouted": false,
-            "condition": "auto",
-            "conditionValue": ""
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "b696a5f6-f328-42fb-bdbc-83569b2beb06": {
             "id": "b696a5f6-f328-42fb-bdbc-83569b2beb06",
@@ -3745,8 +3753,14 @@
               "element": "7610bbda-21ef-4637-a188-1da1352bea17"
             },
             "isManuallyLayouted": false,
-            "condition": "when_intent_matched",
-            "conditionValue": "Nutrition_intent"
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "when_intent_matched",
+              "intentName": "Nutrition_intent"
+            },
+            "custom": {
+              "condition": []
+            }
           }
         },
         "assessments": {}
@@ -3786,12 +3800,8 @@
               "width": 420,
               "height": 100
             },
-            "bodies": [
-              "63a2c160-ebbb-457b-953a-93fd2e643224"
-            ],
-            "fallbackBodies": [
-              "1f369122-06c2-4050-ba54-4ea160f95a8c"
-            ]
+            "bodies": ["63a2c160-ebbb-457b-953a-93fd2e643224"],
+            "fallbackBodies": ["1f369122-06c2-4050-ba54-4ea160f95a8c"]
           },
           "63a2c160-ebbb-457b-953a-93fd2e643224": {
             "id": "63a2c160-ebbb-457b-953a-93fd2e643224",
@@ -3832,9 +3842,7 @@
               "width": 630,
               "height": 100
             },
-            "bodies": [
-              "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b"
-            ],
+            "bodies": ["a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b"],
             "intent_description": "Question about how to become muscular and which exercises to perform."
           },
           "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b": {
@@ -3920,9 +3928,7 @@
               "width": 420,
               "height": 70
             },
-            "bodies": [
-              "ad226172-93d8-4644-80c5-62825565dd24"
-            ],
+            "bodies": ["ad226172-93d8-4644-80c5-62825565dd24"],
             "fallbackBodies": []
           },
           "ad226172-93d8-4644-80c5-62825565dd24": {
@@ -4040,9 +4046,7 @@
               "width": 180,
               "height": 70
             },
-            "bodies": [
-              "6a3aeb02-bb44-4472-8489-595e8dc8ceb1"
-            ],
+            "bodies": ["6a3aeb02-bb44-4472-8489-595e8dc8ceb1"],
             "fallbackBodies": []
           },
           "6a3aeb02-bb44-4472-8489-595e8dc8ceb1": {
@@ -4070,9 +4074,7 @@
               "width": 630,
               "height": 100
             },
-            "bodies": [
-              "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0"
-            ],
+            "bodies": ["f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0"],
             "intent_description": "Question about nutrition in gym."
           },
           "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0": {
@@ -4180,8 +4182,14 @@
               "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
             },
             "isManuallyLayouted": false,
-            "condition": "when_intent_matched",
-            "conditionValue": "Muscles_intent"
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "when_intent_matched",
+              "intentName": "Muscles_intent"
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "7d65df96-e669-4fc6-a882-dbfe92a57073": {
             "id": "7d65df96-e669-4fc6-a882-dbfe92a57073",
@@ -4213,8 +4221,14 @@
               "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
             },
             "isManuallyLayouted": false,
-            "condition": "auto",
-            "conditionValue": ""
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31": {
             "id": "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31",
@@ -4258,8 +4272,14 @@
               "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
             },
             "isManuallyLayouted": true,
-            "condition": "when_intent_matched",
-            "conditionValue": "Other"
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "when_intent_matched",
+              "intentName": "Other"
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e": {
             "id": "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e",
@@ -4299,8 +4319,14 @@
               "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
             },
             "isManuallyLayouted": false,
-            "condition": "auto",
-            "conditionValue": ""
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32": {
             "id": "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32",
@@ -4344,8 +4370,14 @@
               "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
             },
             "isManuallyLayouted": false,
-            "condition": "auto",
-            "conditionValue": ""
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "3564da62-bea0-4489-81b2-fda2effddd02": {
             "id": "3564da62-bea0-4489-81b2-fda2effddd02",
@@ -4389,8 +4421,14 @@
               "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
             },
             "isManuallyLayouted": false,
-            "condition": "auto",
-            "conditionValue": ""
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "b696a5f6-f328-42fb-bdbc-83569b2beb06": {
             "id": "b696a5f6-f328-42fb-bdbc-83569b2beb06",
@@ -4422,8 +4460,14 @@
               "element": "7610bbda-21ef-4637-a188-1da1352bea17"
             },
             "isManuallyLayouted": false,
-            "condition": "when_intent_matched",
-            "conditionValue": "Nutrition_intent"
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "when_intent_matched",
+              "intentName": "Nutrition_intent"
+            },
+            "custom": {
+              "condition": []
+            }
           }
         },
         "assessments": {}
@@ -4463,9 +4507,7 @@
               "width": 160,
               "height": 100
             },
-            "bodies": [
-              "ccd1dced-243c-49c4-9a00-80e7f772327a"
-            ],
+            "bodies": ["ccd1dced-243c-49c4-9a00-80e7f772327a"],
             "intent_description": "Question about how to become muscular and which exercises to perform."
           },
           "651f4205-d406-482c-8bb4-975fdf9e456f": {
@@ -4491,9 +4533,7 @@
               "width": 160,
               "height": 100
             },
-            "bodies": [
-              "651f4205-d406-482c-8bb4-975fdf9e456f"
-            ],
+            "bodies": ["651f4205-d406-482c-8bb4-975fdf9e456f"],
             "intent_description": "Question about nutrition in gym."
           },
           "4037bf46-f138-4c9c-a891-c8f5639a19a0": {
@@ -4533,9 +4573,7 @@
               "width": 160,
               "height": 100
             },
-            "bodies": [
-              "e082c986-9bb3-45be-8f43-2e6b8af7a9d7"
-            ],
+            "bodies": ["e082c986-9bb3-45be-8f43-2e6b8af7a9d7"],
             "fallbackBodies": []
           },
           "07601353-ee34-4ca9-bbe4-bdd711e624c4": {
@@ -4549,12 +4587,8 @@
               "width": 160,
               "height": 100
             },
-            "bodies": [
-              "ac420544-4ccf-4a49-9b3f-0c1eb9278f7e"
-            ],
-            "fallbackBodies": [
-              "3e3e5cbe-d409-4601-9cb2-11b371cfb064"
-            ]
+            "bodies": ["ac420544-4ccf-4a49-9b3f-0c1eb9278f7e"],
+            "fallbackBodies": ["3e3e5cbe-d409-4601-9cb2-11b371cfb064"]
           },
           "8f57a878-84ca-409d-b89d-cc62fc815507": {
             "id": "8f57a878-84ca-409d-b89d-cc62fc815507",
@@ -4605,9 +4639,7 @@
               "width": 160,
               "height": 100
             },
-            "bodies": [
-              "4499b560-b246-4b3f-b703-d9709836b98e"
-            ],
+            "bodies": ["4499b560-b246-4b3f-b703-d9709836b98e"],
             "fallbackBodies": []
           },
           "e082c986-9bb3-45be-8f43-2e6b8af7a9d7": {
@@ -4867,7 +4899,6 @@
               "conditionValue": ""
             },
             "custom": {
-              "event": "None",
               "condition": []
             }
           },
@@ -4927,7 +4958,6 @@
               "intentName": "Muscles_intent"
             },
             "custom": {
-              "event": "None",
               "condition": []
             }
           },
@@ -4987,7 +5017,6 @@
               "intentName": "Other"
             },
             "custom": {
-              "event": "None",
               "condition": []
             }
           },
@@ -5047,7 +5076,6 @@
               "intentName": "Nutrition_intent"
             },
             "custom": {
-              "event": "None",
               "condition": []
             }
           },
@@ -5107,7 +5135,6 @@
               "conditionValue": ""
             },
             "custom": {
-              "event": "None",
               "condition": []
             }
           },
@@ -5167,7 +5194,6 @@
               "conditionValue": ""
             },
             "custom": {
-              "event": "None",
               "condition": []
             }
           },
@@ -5227,7 +5253,6 @@
               "conditionValue": ""
             },
             "custom": {
-              "event": "None",
               "condition": []
             }
           },
@@ -5284,12 +5309,8 @@
       "savedAt": "2026-05-06T13:49:25.848Z",
       "config": {
         "agentLanguage": "original",
-        "inputModalities": [
-          "text"
-        ],
-        "outputModalities": [
-          "text"
-        ],
+        "inputModalities": ["text"],
+        "outputModalities": ["text"],
         "agentPlatform": "streamlit",
         "responseTiming": "instant",
         "agentStyle": "original",
@@ -5352,12 +5373,8 @@
               "width": 420,
               "height": 100
             },
-            "bodies": [
-              "63a2c160-ebbb-457b-953a-93fd2e643224"
-            ],
-            "fallbackBodies": [
-              "1f369122-06c2-4050-ba54-4ea160f95a8c"
-            ]
+            "bodies": ["63a2c160-ebbb-457b-953a-93fd2e643224"],
+            "fallbackBodies": ["1f369122-06c2-4050-ba54-4ea160f95a8c"]
           },
           "63a2c160-ebbb-457b-953a-93fd2e643224": {
             "id": "63a2c160-ebbb-457b-953a-93fd2e643224",
@@ -5398,9 +5415,7 @@
               "width": 630,
               "height": 100
             },
-            "bodies": [
-              "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b"
-            ],
+            "bodies": ["a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b"],
             "intent_description": "Question about how to become muscular and which exercises to perform."
           },
           "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b": {
@@ -5486,9 +5501,7 @@
               "width": 420,
               "height": 70
             },
-            "bodies": [
-              "ad226172-93d8-4644-80c5-62825565dd24"
-            ],
+            "bodies": ["ad226172-93d8-4644-80c5-62825565dd24"],
             "fallbackBodies": []
           },
           "ad226172-93d8-4644-80c5-62825565dd24": {
@@ -5606,9 +5619,7 @@
               "width": 180,
               "height": 70
             },
-            "bodies": [
-              "6a3aeb02-bb44-4472-8489-595e8dc8ceb1"
-            ],
+            "bodies": ["6a3aeb02-bb44-4472-8489-595e8dc8ceb1"],
             "fallbackBodies": []
           },
           "6a3aeb02-bb44-4472-8489-595e8dc8ceb1": {
@@ -5636,9 +5647,7 @@
               "width": 630,
               "height": 100
             },
-            "bodies": [
-              "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0"
-            ],
+            "bodies": ["f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0"],
             "intent_description": "Question about nutrition in gym."
           },
           "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0": {
@@ -5746,8 +5755,14 @@
               "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
             },
             "isManuallyLayouted": false,
-            "condition": "when_intent_matched",
-            "conditionValue": "Muscles_intent"
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "when_intent_matched",
+              "intentName": "Muscles_intent"
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "7d65df96-e669-4fc6-a882-dbfe92a57073": {
             "id": "7d65df96-e669-4fc6-a882-dbfe92a57073",
@@ -5779,8 +5794,14 @@
               "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
             },
             "isManuallyLayouted": false,
-            "condition": "auto",
-            "conditionValue": ""
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31": {
             "id": "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31",
@@ -5824,8 +5845,14 @@
               "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
             },
             "isManuallyLayouted": true,
-            "condition": "when_intent_matched",
-            "conditionValue": "Other"
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "when_intent_matched",
+              "intentName": "Other"
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e": {
             "id": "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e",
@@ -5865,8 +5892,14 @@
               "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
             },
             "isManuallyLayouted": false,
-            "condition": "auto",
-            "conditionValue": ""
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32": {
             "id": "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32",
@@ -5910,8 +5943,14 @@
               "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
             },
             "isManuallyLayouted": false,
-            "condition": "auto",
-            "conditionValue": ""
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "3564da62-bea0-4489-81b2-fda2effddd02": {
             "id": "3564da62-bea0-4489-81b2-fda2effddd02",
@@ -5955,8 +5994,14 @@
               "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
             },
             "isManuallyLayouted": false,
-            "condition": "auto",
-            "conditionValue": ""
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "b696a5f6-f328-42fb-bdbc-83569b2beb06": {
             "id": "b696a5f6-f328-42fb-bdbc-83569b2beb06",
@@ -5988,8 +6033,14 @@
               "element": "7610bbda-21ef-4637-a188-1da1352bea17"
             },
             "isManuallyLayouted": false,
-            "condition": "when_intent_matched",
-            "conditionValue": "Nutrition_intent"
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "when_intent_matched",
+              "intentName": "Nutrition_intent"
+            },
+            "custom": {
+              "condition": []
+            }
           }
         },
         "assessments": {}
@@ -6029,12 +6080,8 @@
               "width": 420,
               "height": 100
             },
-            "bodies": [
-              "63a2c160-ebbb-457b-953a-93fd2e643224"
-            ],
-            "fallbackBodies": [
-              "1f369122-06c2-4050-ba54-4ea160f95a8c"
-            ]
+            "bodies": ["63a2c160-ebbb-457b-953a-93fd2e643224"],
+            "fallbackBodies": ["1f369122-06c2-4050-ba54-4ea160f95a8c"]
           },
           "63a2c160-ebbb-457b-953a-93fd2e643224": {
             "id": "63a2c160-ebbb-457b-953a-93fd2e643224",
@@ -6075,9 +6122,7 @@
               "width": 630,
               "height": 100
             },
-            "bodies": [
-              "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b"
-            ],
+            "bodies": ["a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b"],
             "intent_description": "Question about how to become muscular and which exercises to perform."
           },
           "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b": {
@@ -6163,9 +6208,7 @@
               "width": 420,
               "height": 70
             },
-            "bodies": [
-              "ad226172-93d8-4644-80c5-62825565dd24"
-            ],
+            "bodies": ["ad226172-93d8-4644-80c5-62825565dd24"],
             "fallbackBodies": []
           },
           "ad226172-93d8-4644-80c5-62825565dd24": {
@@ -6283,9 +6326,7 @@
               "width": 180,
               "height": 70
             },
-            "bodies": [
-              "6a3aeb02-bb44-4472-8489-595e8dc8ceb1"
-            ],
+            "bodies": ["6a3aeb02-bb44-4472-8489-595e8dc8ceb1"],
             "fallbackBodies": []
           },
           "6a3aeb02-bb44-4472-8489-595e8dc8ceb1": {
@@ -6313,9 +6354,7 @@
               "width": 630,
               "height": 100
             },
-            "bodies": [
-              "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0"
-            ],
+            "bodies": ["f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0"],
             "intent_description": "Question about nutrition in gym."
           },
           "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0": {
@@ -6423,8 +6462,14 @@
               "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
             },
             "isManuallyLayouted": false,
-            "condition": "when_intent_matched",
-            "conditionValue": "Muscles_intent"
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "when_intent_matched",
+              "intentName": "Muscles_intent"
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "7d65df96-e669-4fc6-a882-dbfe92a57073": {
             "id": "7d65df96-e669-4fc6-a882-dbfe92a57073",
@@ -6456,8 +6501,14 @@
               "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
             },
             "isManuallyLayouted": false,
-            "condition": "auto",
-            "conditionValue": ""
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31": {
             "id": "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31",
@@ -6501,8 +6552,14 @@
               "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
             },
             "isManuallyLayouted": true,
-            "condition": "when_intent_matched",
-            "conditionValue": "Other"
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "when_intent_matched",
+              "intentName": "Other"
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e": {
             "id": "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e",
@@ -6542,8 +6599,14 @@
               "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
             },
             "isManuallyLayouted": false,
-            "condition": "auto",
-            "conditionValue": ""
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32": {
             "id": "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32",
@@ -6587,8 +6650,14 @@
               "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
             },
             "isManuallyLayouted": false,
-            "condition": "auto",
-            "conditionValue": ""
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "3564da62-bea0-4489-81b2-fda2effddd02": {
             "id": "3564da62-bea0-4489-81b2-fda2effddd02",
@@ -6632,8 +6701,14 @@
               "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
             },
             "isManuallyLayouted": false,
-            "condition": "auto",
-            "conditionValue": ""
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "auto",
+              "conditionValue": ""
+            },
+            "custom": {
+              "condition": []
+            }
           },
           "b696a5f6-f328-42fb-bdbc-83569b2beb06": {
             "id": "b696a5f6-f328-42fb-bdbc-83569b2beb06",
@@ -6665,8 +6740,14 @@
               "element": "7610bbda-21ef-4637-a188-1da1352bea17"
             },
             "isManuallyLayouted": false,
-            "condition": "when_intent_matched",
-            "conditionValue": "Nutrition_intent"
+            "transitionType": "predefined",
+            "predefined": {
+              "predefinedType": "when_intent_matched",
+              "intentName": "Nutrition_intent"
+            },
+            "custom": {
+              "condition": []
+            }
           }
         },
         "assessments": {}
@@ -6706,9 +6787,7 @@
               "width": 160,
               "height": 100
             },
-            "bodies": [
-              "6b718df7-70ef-4e1c-8c6b-c82133964f86"
-            ],
+            "bodies": ["6b718df7-70ef-4e1c-8c6b-c82133964f86"],
             "intent_description": "Question about how to become muscular and which exercises to perform."
           },
           "192db72d-4d0e-49b0-b49c-5050fb0dbb68": {
@@ -6734,9 +6813,7 @@
               "width": 160,
               "height": 100
             },
-            "bodies": [
-              "192db72d-4d0e-49b0-b49c-5050fb0dbb68"
-            ],
+            "bodies": ["192db72d-4d0e-49b0-b49c-5050fb0dbb68"],
             "intent_description": "Question about nutrition in gym."
           },
           "90d28305-378e-4bad-b3ea-61c3ddaa5921": {
@@ -6776,9 +6853,7 @@
               "width": 160,
               "height": 100
             },
-            "bodies": [
-              "82783f5d-8ef3-47f7-8feb-9651bdf73d63"
-            ],
+            "bodies": ["82783f5d-8ef3-47f7-8feb-9651bdf73d63"],
             "fallbackBodies": []
           },
           "f03a1ef0-33cd-4e7e-a9d0-76989314eaa8": {
@@ -6792,12 +6867,8 @@
               "width": 160,
               "height": 100
             },
-            "bodies": [
-              "d91b1fe8-cd6c-4b20-928c-70021c0f044d"
-            ],
-            "fallbackBodies": [
-              "10a044fe-f0bd-41e8-ae27-0f2c2afc2cac"
-            ]
+            "bodies": ["d91b1fe8-cd6c-4b20-928c-70021c0f044d"],
+            "fallbackBodies": ["10a044fe-f0bd-41e8-ae27-0f2c2afc2cac"]
           },
           "aa0bf687-2e08-4cba-aa98-335bcce5ecc7": {
             "id": "aa0bf687-2e08-4cba-aa98-335bcce5ecc7",
@@ -6848,9 +6919,7 @@
               "width": 160,
               "height": 100
             },
-            "bodies": [
-              "3721c5e6-19b1-4811-8b00-17415913c3aa"
-            ],
+            "bodies": ["3721c5e6-19b1-4811-8b00-17415913c3aa"],
             "fallbackBodies": []
           },
           "82783f5d-8ef3-47f7-8feb-9651bdf73d63": {
@@ -7110,7 +7179,6 @@
               "conditionValue": ""
             },
             "custom": {
-              "event": "None",
               "condition": []
             }
           },
@@ -7170,7 +7238,6 @@
               "intentName": "Muscles_intent"
             },
             "custom": {
-              "event": "None",
               "condition": []
             }
           },
@@ -7230,7 +7297,6 @@
               "intentName": "Other"
             },
             "custom": {
-              "event": "None",
               "condition": []
             }
           },
@@ -7290,7 +7356,6 @@
               "intentName": "Nutrition_intent"
             },
             "custom": {
-              "event": "None",
               "condition": []
             }
           },
@@ -7350,7 +7415,6 @@
               "conditionValue": ""
             },
             "custom": {
-              "event": "None",
               "condition": []
             }
           },
@@ -7410,7 +7474,6 @@
               "conditionValue": ""
             },
             "custom": {
-              "event": "None",
               "condition": []
             }
           },
@@ -7470,7 +7533,6 @@
               "conditionValue": ""
             },
             "custom": {
-              "event": "None",
               "condition": []
             }
           },
@@ -8137,12 +8199,8 @@
             "width": 420,
             "height": 100
           },
-          "bodies": [
-            "63a2c160-ebbb-457b-953a-93fd2e643224"
-          ],
-          "fallbackBodies": [
-            "1f369122-06c2-4050-ba54-4ea160f95a8c"
-          ]
+          "bodies": ["63a2c160-ebbb-457b-953a-93fd2e643224"],
+          "fallbackBodies": ["1f369122-06c2-4050-ba54-4ea160f95a8c"]
         },
         "63a2c160-ebbb-457b-953a-93fd2e643224": {
           "id": "63a2c160-ebbb-457b-953a-93fd2e643224",
@@ -8183,9 +8241,7 @@
             "width": 630,
             "height": 100
           },
-          "bodies": [
-            "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b"
-          ],
+          "bodies": ["a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b"],
           "intent_description": "Question about how to become muscular and which exercises to perform."
         },
         "a0a69f3a-bb64-42ee-b9e6-a8bacdf2818b": {
@@ -8271,9 +8327,7 @@
             "width": 420,
             "height": 70
           },
-          "bodies": [
-            "ad226172-93d8-4644-80c5-62825565dd24"
-          ],
+          "bodies": ["ad226172-93d8-4644-80c5-62825565dd24"],
           "fallbackBodies": []
         },
         "ad226172-93d8-4644-80c5-62825565dd24": {
@@ -8391,9 +8445,7 @@
             "width": 180,
             "height": 70
           },
-          "bodies": [
-            "6a3aeb02-bb44-4472-8489-595e8dc8ceb1"
-          ],
+          "bodies": ["6a3aeb02-bb44-4472-8489-595e8dc8ceb1"],
           "fallbackBodies": []
         },
         "6a3aeb02-bb44-4472-8489-595e8dc8ceb1": {
@@ -8421,9 +8473,7 @@
             "width": 630,
             "height": 100
           },
-          "bodies": [
-            "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0"
-          ],
+          "bodies": ["f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0"],
           "intent_description": "Question about nutrition in gym."
         },
         "f1fc7bc1-016d-404f-90a8-c2c8f4a8dad0": {
@@ -8531,8 +8581,14 @@
             "element": "68ccb630-b264-41a0-b70e-1e369bd5706c"
           },
           "isManuallyLayouted": false,
-          "condition": "when_intent_matched",
-          "conditionValue": "Muscles_intent"
+          "transitionType": "predefined",
+          "predefined": {
+            "predefinedType": "when_intent_matched",
+            "intentName": "Muscles_intent"
+          },
+          "custom": {
+            "condition": []
+          }
         },
         "7d65df96-e669-4fc6-a882-dbfe92a57073": {
           "id": "7d65df96-e669-4fc6-a882-dbfe92a57073",
@@ -8564,8 +8620,14 @@
             "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
           },
           "isManuallyLayouted": false,
-          "condition": "auto",
-          "conditionValue": ""
+          "transitionType": "predefined",
+          "predefined": {
+            "predefinedType": "auto",
+            "conditionValue": ""
+          },
+          "custom": {
+            "condition": []
+          }
         },
         "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31": {
           "id": "6ae258b8-3d74-4e45-bdb7-98cbcfc7ca31",
@@ -8609,8 +8671,14 @@
             "element": "8c760b7d-7e72-4cd7-a92a-d5491c021a5b"
           },
           "isManuallyLayouted": true,
-          "condition": "when_intent_matched",
-          "conditionValue": "Other"
+          "transitionType": "predefined",
+          "predefined": {
+            "predefinedType": "when_intent_matched",
+            "intentName": "Other"
+          },
+          "custom": {
+            "condition": []
+          }
         },
         "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e": {
           "id": "c0d4d1e9-bfd1-408e-a6b6-a64a9df6f88e",
@@ -8650,8 +8718,14 @@
             "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
           },
           "isManuallyLayouted": false,
-          "condition": "auto",
-          "conditionValue": ""
+          "transitionType": "predefined",
+          "predefined": {
+            "predefinedType": "auto",
+            "conditionValue": ""
+          },
+          "custom": {
+            "condition": []
+          }
         },
         "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32": {
           "id": "6fb943ba-3cb3-4a6a-9494-2b7c96dabf32",
@@ -8695,8 +8769,14 @@
             "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
           },
           "isManuallyLayouted": false,
-          "condition": "auto",
-          "conditionValue": ""
+          "transitionType": "predefined",
+          "predefined": {
+            "predefinedType": "auto",
+            "conditionValue": ""
+          },
+          "custom": {
+            "condition": []
+          }
         },
         "3564da62-bea0-4489-81b2-fda2effddd02": {
           "id": "3564da62-bea0-4489-81b2-fda2effddd02",
@@ -8740,8 +8820,14 @@
             "element": "0cba5357-2c30-414b-8d74-ac74ac4ab158"
           },
           "isManuallyLayouted": false,
-          "condition": "auto",
-          "conditionValue": ""
+          "transitionType": "predefined",
+          "predefined": {
+            "predefinedType": "auto",
+            "conditionValue": ""
+          },
+          "custom": {
+            "condition": []
+          }
         },
         "b696a5f6-f328-42fb-bdbc-83569b2beb06": {
           "id": "b696a5f6-f328-42fb-bdbc-83569b2beb06",
@@ -8773,8 +8859,14 @@
             "element": "7610bbda-21ef-4637-a188-1da1352bea17"
           },
           "isManuallyLayouted": false,
-          "condition": "when_intent_matched",
-          "conditionValue": "Nutrition_intent"
+          "transitionType": "predefined",
+          "predefined": {
+            "predefinedType": "when_intent_matched",
+            "intentName": "Nutrition_intent"
+          },
+          "custom": {
+            "condition": []
+          }
         }
       },
       "assessments": {}


### PR DESCRIPTION
Sync `develop` → `main` for BESSER v7.8.3.

## Summary
- **Agent transitions preserved on import**: agent models are normalized to the canonical nested transition shape at the storage boundary (reusing `AgentStateTransition`), so importing the Personalized Gym Agent project no longer collapses every transition to `when_no_intent_matched` on Save & Apply. Includes a one-time `v4` localStorage migration and purges the flat shape from the bundled templates.
- **Variant edits persist across base ⇄ variant switches**: the switch handler writes the live canvas model back into its source before loading the target.
- **BAF "Personalization (all)" generation** ships the un-personalized base, not the active variant.

Merged via #139.

## Test plan
- [ ] Unit tests pass (`normalizeAgentModel` + storage normalization suites).
- [ ] Import Personalized Gym Agent → Save & Apply → transitions intact.
- [ ] Edit a variant → switch to base → switch back → edits persist.
- [ ] Generate → BAF Agent → "Personalization (all)" → variants derive from the base.