### PR TITLE
fix(agent): agent editor follow-ups from #141 review

### DIFF
--- a/packages/editor/src/main/packages/agent-state-diagram/agent-state/agent-state-update.tsx
+++ b/packages/editor/src/main/packages/agent-state-diagram/agent-state/agent-state-update.tsx
@@ -756,7 +756,16 @@ class StateUpdate extends Component<Props, State> {
               onDrop={(e) => {
                 e.preventDefault();
                 const fromIndex = parseInt(e.dataTransfer.getData('text/plain'), 10);
-                if (!Number.isNaN(fromIndex) && fromIndex !== index) {
+                // Only reorder within the same section. Without this guard a card
+                // dragged from the body list and dropped on the fallback list (or
+                // vice versa) calls swapActions with an index from the other list,
+                // dereferencing an out-of-range member and crashing.
+                if (
+                  this.state.draggingPrefix === prefix &&
+                  !Number.isNaN(fromIndex) &&
+                  fromIndex !== index &&
+                  fromIndex < actions.length
+                ) {
                   this.swapActions(actions, fromIndex, index);
                 }
                 this.setState({ draggingIndex: null, draggingPrefix: null, dragOverIndex: null, dragOverPrefix: null });

--- a/packages/webapp/src/main/features/agent-config/AgentConfigYamlEditor.tsx
+++ b/packages/webapp/src/main/features/agent-config/AgentConfigYamlEditor.tsx
@@ -97,9 +97,17 @@ export const DEFAULT_AGENT_CONFIG_FORM: AgentConfigFormData = {
 // YAML generation
 // ─────────────────────────────────────────────────────────────
 
-function numOrStr(v: string): string {
+// Render a user-supplied scalar safely for YAML. Bare numbers pass through
+// unquoted and a conservative set of plain tokens stays unquoted (so default
+// values are emitted exactly as before); anything containing YAML-significant
+// characters, a leading indicator, or whitespace is single-quoted so values
+// like passwords or tokens can't break or inject structure into the config.
+function yamlValue(v: string): string {
   const t = v.trim();
-  return t !== '' && !isNaN(Number(t)) ? t : t;
+  if (t === '') return "''";
+  if (!isNaN(Number(t))) return t;
+  if (/^[A-Za-z0-9][A-Za-z0-9_.\-/]*$/.test(t)) return t;
+  return `'${t.replace(/'/g, "''")}'`;
 }
 
 export function agentConfigFormToYaml(form: AgentConfigFormData): string {
@@ -108,19 +116,19 @@ export function agentConfigFormToYaml(form: AgentConfigFormData): string {
   // ── Agent ──────────────────────────────────
   lines.push('agent:');
   if (form.agent.check_transitions_delay.trim())
-    lines.push(`  check_transitions_delay: ${numOrStr(form.agent.check_transitions_delay)}`);
+    lines.push(`  check_transitions_delay: ${yamlValue(form.agent.check_transitions_delay)}`);
   lines.push('');
 
   // ── NLP ────────────────────────────────────
   lines.push('nlp:');
-  if (form.nlp.language) lines.push(`  language: ${form.nlp.language}`);
-  if (form.nlp.region) lines.push(`  region: ${form.nlp.region}`);
-  if (form.nlp.timezone) lines.push(`  timezone: ${form.nlp.timezone}`);
+  if (form.nlp.language) lines.push(`  language: ${yamlValue(form.nlp.language)}`);
+  if (form.nlp.region) lines.push(`  region: ${yamlValue(form.nlp.region)}`);
+  if (form.nlp.timezone) lines.push(`  timezone: ${yamlValue(form.nlp.timezone)}`);
   lines.push(`  pre_processing: ${form.nlp.pre_processing ? 'True' : 'False'}`);
-  if (form.nlp.intent_threshold.trim()) lines.push(`  intent_threshold: ${numOrStr(form.nlp.intent_threshold)}`);
-  if (form.nlp.huggingface_token) { lines.push('  huggingface:'); lines.push(`    token: ${form.nlp.huggingface_token}`); }
-  if (form.nlp.openai_api_key) { lines.push('  openai:'); lines.push(`    api_key: ${form.nlp.openai_api_key}`); }
-  if (form.nlp.replicate_api_key) { lines.push('  replicate:'); lines.push(`    api_key: ${form.nlp.replicate_api_key}`); }
+  if (form.nlp.intent_threshold.trim()) lines.push(`  intent_threshold: ${yamlValue(form.nlp.intent_threshold)}`);
+  if (form.nlp.huggingface_token) { lines.push('  huggingface:'); lines.push(`    token: ${yamlValue(form.nlp.huggingface_token)}`); }
+  if (form.nlp.openai_api_key) { lines.push('  openai:'); lines.push(`    api_key: ${yamlValue(form.nlp.openai_api_key)}`); }
+  if (form.nlp.replicate_api_key) { lines.push('  replicate:'); lines.push(`    api_key: ${yamlValue(form.nlp.replicate_api_key)}`); }
   lines.push('');
 
   // ── Platforms ──────────────────────────────
@@ -130,38 +138,38 @@ export function agentConfigFormToYaml(form: AgentConfigFormData): string {
     lines.push('platforms:');
     if (ws.enabled) {
       lines.push('  websocket:');
-      if (ws.host) lines.push(`    host: ${ws.host}`);
-      if (ws.port.trim()) lines.push(`    port: ${numOrStr(ws.port)}`);
+      if (ws.host) lines.push(`    host: ${yamlValue(ws.host)}`);
+      if (ws.port.trim()) lines.push(`    port: ${yamlValue(ws.port)}`);
       lines.push('    streamlit:');
-      if (ws.streamlit_host) lines.push(`      host: ${ws.streamlit_host}`);
-      if (ws.streamlit_port.trim()) lines.push(`      port: ${numOrStr(ws.streamlit_port)}`);
+      if (ws.streamlit_host) lines.push(`      host: ${yamlValue(ws.streamlit_host)}`);
+      if (ws.streamlit_port.trim()) lines.push(`      port: ${yamlValue(ws.streamlit_port)}`);
       lines.push('      chat:');
-      if (ws.chat_size.trim()) lines.push(`        size: ${numOrStr(ws.chat_size)}`);
-      if (ws.chat_font) lines.push(`        font: ${ws.chat_font}`);
-      if (ws.chat_line_spacing.trim()) lines.push(`        line_spacing: ${numOrStr(ws.chat_line_spacing)}`);
-      if (ws.chat_alignment) lines.push(`        alignment: ${ws.chat_alignment}`);
-      if (ws.chat_color) lines.push(`        color: ${ws.chat_color}`);
-      if (ws.chat_contrast) lines.push(`        contrast: ${ws.chat_contrast}`);
+      if (ws.chat_size.trim()) lines.push(`        size: ${yamlValue(ws.chat_size)}`);
+      if (ws.chat_font) lines.push(`        font: ${yamlValue(ws.chat_font)}`);
+      if (ws.chat_line_spacing.trim()) lines.push(`        line_spacing: ${yamlValue(ws.chat_line_spacing)}`);
+      if (ws.chat_alignment) lines.push(`        alignment: ${yamlValue(ws.chat_alignment)}`);
+      if (ws.chat_color) lines.push(`        color: ${yamlValue(ws.chat_color)}`);
+      if (ws.chat_contrast) lines.push(`        contrast: ${yamlValue(ws.chat_contrast)}`);
     }
     if (telegram.enabled) {
       lines.push('  telegram:');
-      if (telegram.token) lines.push(`    token: ${telegram.token}`);
+      if (telegram.token) lines.push(`    token: ${yamlValue(telegram.token)}`);
     }
     if (github.enabled) {
       lines.push('  github:');
-      if (github.personal_token) lines.push(`    personal_token: ${github.personal_token}`);
-      if (github.webhook_token) lines.push(`    webhook_token: ${github.webhook_token}`);
-      if (github.webhook_port.trim()) lines.push(`    webhook_port: ${numOrStr(github.webhook_port)}`);
+      if (github.personal_token) lines.push(`    personal_token: ${yamlValue(github.personal_token)}`);
+      if (github.webhook_token) lines.push(`    webhook_token: ${yamlValue(github.webhook_token)}`);
+      if (github.webhook_port.trim()) lines.push(`    webhook_port: ${yamlValue(github.webhook_port)}`);
     }
     if (gitlab.enabled) {
       lines.push('  gitlab:');
-      if (gitlab.personal_token) lines.push(`    personal_token: ${gitlab.personal_token}`);
-      if (gitlab.webhook_token) lines.push(`    webhook_token: ${gitlab.webhook_token}`);
-      if (gitlab.webhook_port.trim()) lines.push(`    webhook_port: ${numOrStr(gitlab.webhook_port)}`);
+      if (gitlab.personal_token) lines.push(`    personal_token: ${yamlValue(gitlab.personal_token)}`);
+      if (gitlab.webhook_token) lines.push(`    webhook_token: ${yamlValue(gitlab.webhook_token)}`);
+      if (gitlab.webhook_port.trim()) lines.push(`    webhook_port: ${yamlValue(gitlab.webhook_port)}`);
     }
     if (a2a.enabled) {
       lines.push('  a2a:');
-      if (a2a.port.trim()) lines.push(`    port: ${numOrStr(a2a.port)}`);
+      if (a2a.port.trim()) lines.push(`    port: ${yamlValue(a2a.port)}`);
     }
     lines.push('');
   }
@@ -173,22 +181,22 @@ export function agentConfigFormToYaml(form: AgentConfigFormData): string {
     if (monitoring.enabled) {
       lines.push('  monitoring:');
       lines.push(`    enabled: True`);
-      if (monitoring.dialect) lines.push(`    dialect: ${monitoring.dialect}`);
-      if (monitoring.host) lines.push(`    host: ${monitoring.host}`);
-      if (monitoring.port.trim()) lines.push(`    port: ${numOrStr(monitoring.port)}`);
-      if (monitoring.database) lines.push(`    database: ${monitoring.database}`);
-      if (monitoring.username) lines.push(`    username: ${monitoring.username}`);
-      if (monitoring.password) lines.push(`    password: ${monitoring.password}`);
+      if (monitoring.dialect) lines.push(`    dialect: ${yamlValue(monitoring.dialect)}`);
+      if (monitoring.host) lines.push(`    host: ${yamlValue(monitoring.host)}`);
+      if (monitoring.port.trim()) lines.push(`    port: ${yamlValue(monitoring.port)}`);
+      if (monitoring.database) lines.push(`    database: ${yamlValue(monitoring.database)}`);
+      if (monitoring.username) lines.push(`    username: ${yamlValue(monitoring.username)}`);
+      if (monitoring.password) lines.push(`    password: ${yamlValue(monitoring.password)}`);
     }
     if (streamlit_db.enabled) {
       lines.push('  streamlit:');
       lines.push(`    enabled: True`);
-      if (streamlit_db.dialect) lines.push(`    dialect: ${streamlit_db.dialect}`);
-      if (streamlit_db.host) lines.push(`    host: ${streamlit_db.host}`);
-      if (streamlit_db.port.trim()) lines.push(`    port: ${numOrStr(streamlit_db.port)}`);
-      if (streamlit_db.database) lines.push(`    database: ${streamlit_db.database}`);
-      if (streamlit_db.username) lines.push(`    username: ${streamlit_db.username}`);
-      if (streamlit_db.password) lines.push(`    password: ${streamlit_db.password}`);
+      if (streamlit_db.dialect) lines.push(`    dialect: ${yamlValue(streamlit_db.dialect)}`);
+      if (streamlit_db.host) lines.push(`    host: ${yamlValue(streamlit_db.host)}`);
+      if (streamlit_db.port.trim()) lines.push(`    port: ${yamlValue(streamlit_db.port)}`);
+      if (streamlit_db.database) lines.push(`    database: ${yamlValue(streamlit_db.database)}`);
+      if (streamlit_db.username) lines.push(`    username: ${yamlValue(streamlit_db.username)}`);
+      if (streamlit_db.password) lines.push(`    password: ${yamlValue(streamlit_db.password)}`);
     }
   }
 

--- a/packages/webapp/src/main/features/generation/useGeneratorExecution.ts
+++ b/packages/webapp/src/main/features/generation/useGeneratorExecution.ts
@@ -15,7 +15,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { ApollonEditor, UMLDiagramType, UMLModel } from '@besser/wme';
+import { ApollonEditor, UMLDiagramType, UMLModel, normalizeAgentModel } from '@besser/wme';
 import { toast } from 'react-toastify';
 
 import { useAppDispatch } from '../../app/store/hooks';
@@ -1013,7 +1013,12 @@ export function useGeneratorExecution(editor: ApollonEditor | undefined): UseGen
             name: profile.name,
             configuration: structuredClone(config.config),
             user_profile: structuredClone(profile.model),
-            agent_model: structuredClone(agentModel),
+            // Normalize to the canonical nested transition shape before sending.
+            // Variant/config snapshots can bypass the editor (e.g. imported
+            // projects) and still carry the legacy flat shape, which the backend
+            // collapses to when_no_intent_matched. normalizeAgentModel is pure
+            // and idempotent and returns a fresh clone.
+            agent_model: normalizeAgentModel(agentModel as UMLModel) as Record<string, any>,
           };
         })
         .filter((entry): entry is {


### PR DESCRIPTION
Follow-up fixes from the review of #141 (agent editor expansion).

### Fixes
- **Action drag-drop crash** (`agent-state-update.tsx`): `onDrop` only checked `fromIndex !== index`, not that the drag started in the same section. Dragging a card from the **body** list onto a **fallback** card (or vice versa) called `swapActions` with an index from the other list, dereferencing an out-of-range member → `Cannot read properties of undefined`. Now guarded by `draggingPrefix === prefix` and an in-range check.
- **config.yaml scalar quoting** (`AgentConfigYamlEditor.tsx`): the `numOrStr` helper was a no-op (both ternary branches returned the same value) and user values were interpolated raw, so a password/token containing `:`, `#`, a leading indicator, etc. produced malformed YAML that was never validated before shipping to the backend. Replaced with a `yamlValue` helper that emits numbers/safe tokens bare and single-quotes anything else. Default output is unchanged.
- **Personalization model normalization** (`useGeneratorExecution.ts`): each `agent_model` in `personalizationMapping` was sent raw. Variant/config snapshots can bypass the editor (e.g. imported projects) and still carry the legacy flat transition shape, which the backend collapses to `when_no_intent_matched`. Now normalized via `normalizeAgentModel` (pure, idempotent) at the send point, matching the base-model normalization added in #141.

Pairs with backend BESSER#550 (which adds `stateType`/new action-type/RAG handling and now emits reasoning states as `AgentState`+`stateType`).