### PR TITLE
feat: ELK auto-layout for headless SVG export

### DIFF
--- a/packages/editor/src/main/index.ts
+++ b/packages/editor/src/main/index.ts
@@ -19,6 +19,9 @@ export * from './typings';
 // This is the primary entry point for users who want to embed the UML editor
 export * from './apollon-editor';
 
+// Export the headless ELK auto-layout helper (pure model -> laid-out model)
+export { layoutModel } from './services/layouter/model-layout';
+
 // Export compatibility helper functions
 // These utilities help with backward compatibility and cross-version support
 export * from './compat/helpers';

--- a/packages/editor/src/main/services/layouter/model-layout.ts
+++ b/packages/editor/src/main/services/layouter/model-layout.ts
@@ -1,0 +1,88 @@
+import { UMLModel } from '../../typings';
+import { computeElkLayout, LayoutEdge, LayoutNode } from './elk-layouter';
+
+/**
+ * Lays out a UML class model with ELK and returns a NEW model whose elements
+ * are repositioned accordingly. Pure and fully awaitable (no editor instance,
+ * no Redux, no DOM) — intended for headless use such as server-side SVG export.
+ *
+ * Top-level elements (classes/enums, `owner === null`) are placed by ELK; their
+ * child members (attributes/methods) are shifted by the same delta so they stay
+ * attached. The layout is recentered onto the model's current center so it does
+ * not jump toward the origin. Relationship paths are left untouched — the editor
+ * recomputes non-manually-layouted relationships when the model is rendered.
+ */
+export async function layoutModel(model: UMLModel): Promise<UMLModel> {
+  const topLevel = Object.values(model.elements).filter((element) => element.owner === null);
+  if (topLevel.length === 0) {
+    return model;
+  }
+
+  const nodes: LayoutNode[] = topLevel.map((element) => ({
+    id: element.id,
+    width: element.bounds.width,
+    height: element.bounds.height,
+  }));
+
+  const edges: LayoutEdge[] = Object.values(model.relationships)
+    .filter((rel) => Boolean(rel.source?.element && rel.target?.element))
+    .map((rel) => ({ id: rel.id, sourceId: rel.source.element, targetId: rel.target.element }));
+
+  const positions = await computeElkLayout(nodes, edges);
+  if (positions.length === 0) {
+    return model;
+  }
+
+  // Recenter the ELK result onto the model's current bounding-box center.
+  let newMinX = Infinity;
+  let newMinY = Infinity;
+  let newMaxX = -Infinity;
+  let newMaxY = -Infinity;
+  let curMinX = Infinity;
+  let curMinY = Infinity;
+  let curMaxX = -Infinity;
+  let curMaxY = -Infinity;
+  const sizeById = new Map(nodes.map((node) => [node.id, node]));
+  for (const position of positions) {
+    const size = sizeById.get(position.id);
+    const current = model.elements[position.id];
+    if (!size || !current) {
+      continue;
+    }
+    newMinX = Math.min(newMinX, position.x);
+    newMinY = Math.min(newMinY, position.y);
+    newMaxX = Math.max(newMaxX, position.x + size.width);
+    newMaxY = Math.max(newMaxY, position.y + size.height);
+    curMinX = Math.min(curMinX, current.bounds.x);
+    curMinY = Math.min(curMinY, current.bounds.y);
+    curMaxX = Math.max(curMaxX, current.bounds.x + current.bounds.width);
+    curMaxY = Math.max(curMaxY, current.bounds.y + current.bounds.height);
+  }
+  const offset = Number.isFinite(newMinX)
+    ? { x: (curMinX + curMaxX) / 2 - (newMinX + newMaxX) / 2, y: (curMinY + curMaxY) / 2 - (newMinY + newMaxY) / 2 }
+    : { x: 0, y: 0 };
+
+  // Per-top-level delta = target position - current position.
+  const deltaById = new Map<string, { x: number; y: number }>();
+  for (const position of positions) {
+    const current = model.elements[position.id];
+    if (!current) {
+      continue;
+    }
+    deltaById.set(position.id, {
+      x: position.x + offset.x - current.bounds.x,
+      y: position.y + offset.y - current.bounds.y,
+    });
+  }
+
+  const elements: UMLModel['elements'] = {};
+  for (const [id, element] of Object.entries(model.elements)) {
+    // A node moves by its own delta; a child moves by its owner's delta.
+    const delta = deltaById.get(id) ?? (element.owner ? deltaById.get(element.owner) : undefined);
+    elements[id] = delta
+      ? { ...element, bounds: { ...element.bounds, x: element.bounds.x + delta.x, y: element.bounds.y + delta.y } }
+      : element;
+  }
+
+  return { ...model, elements };
+}

--- a/packages/server/src/main/services/conversion-service/conversion-service.ts
+++ b/packages/server/src/main/services/conversion-service/conversion-service.ts
@@ -1,8 +1,14 @@
 import 'global-jsdom/register';
-import { ApollonEditor, SVG, UMLModel } from '@besser/wme';
+import { ApollonEditor, layoutModel, SVG, UMLModel } from '@besser/wme';
 
 export class ConversionService {
-  convertToSvg = async (model: UMLModel): Promise<SVG> => {
+  /**
+   * @param model the UML model to render
+   * @param autoLayout when true (default), runs ELK auto-layout on the model
+   *   before rendering, so imported/headless models get a clean layout instead
+   *   of whatever positions they arrived with.
+   */
+  convertToSvg = async (model: UMLModel, autoLayout = true): Promise<SVG> => {
     document.body.innerHTML = '<!doctype html><html lang="en"><body><div></div></body></html>';
     // JSDOM does not support getBBox so we have to mock it here
     // @ts-ignore
@@ -12,10 +18,11 @@ export class ConversionService {
       width: 10,
       height: 10,
     });
+    const layoutedModel = autoLayout ? await layoutModel(model) : model;
     const container = document.querySelector('div')!;
     const editor = new ApollonEditor(container, {});
     await editor.nextRender;
-    editor.model = model;
+    editor.model = layoutedModel;
     await editor.nextRender;
     return editor.exportAsSVG();
   };


### PR DESCRIPTION
## Summary

Makes the server's headless model→SVG render produce a **clean layout**, by running ELK auto-layout on the model before rendering. This is the core of headless model→image (BESSER#553).

## Changes
- **`layoutModel(model)`** (new, exported from `@besser/wme`) — a *pure, awaitable* helper: runs ELK `layered` layout on a UML class model and returns a repositioned model. No editor instance, no Redux, no DOM — safe to call server-side. Top-level classes/enums are placed by ELK; child members shift with their parent; the result is recentered onto the model's current center. Reuses the same `computeElkLayout` engine as the in-canvas auto-layout button.
- **`ConversionService.convertToSvg(model, autoLayout = true)`** now lays the model out before rendering.

## Notes / risk
- Additive and low-risk: `convertToSvg` is **not currently wired to any route**, so this only affects that (presently unused) service path — nothing live changes.
- Type-checks clean in `editor` and `server` packages.
- **Not yet runtime-verified** (requires running the Node server). One assumption to confirm when wired: the editor recomputes non-manually-laid-out relationship paths when the repositioned model is rendered.

## Next (separate work)
Wire `convertToSvg` to a route + a B-UML→editor-JSON bridge (Python `class_buml_to_json`) for a single `B-UML → SVG` endpoint. That completes (and closes) BESSER#553.