### PR TITLE
feat(server): POST /api/svg — headless model→SVG render endpoint

### DIFF
--- a/packages/server/src/main/resources/svg-export-resource.ts
+++ b/packages/server/src/main/resources/svg-export-resource.ts
@@ -1,0 +1,31 @@
+import { Request, Response } from 'express';
+import { UMLModel } from '@besser/wme';
+import { ConversionService } from '../services/conversion-service/conversion-service';
+
+/**
+ * Renders a UML model to SVG headlessly (jsdom + Apollon), optionally running
+ * ELK auto-layout first. This is the render half of the "B-UML -> SVG" path;
+ * the editor's Python backend converts B-UML to the editor JSON model and POSTs
+ * it here.
+ */
+export class SvgExportResource {
+  private readonly conversionService = new ConversionService();
+
+  exportSvg = async (req: Request, res: Response): Promise<void> => {
+    const model = req.body?.model as UMLModel | undefined;
+    const autoLayout = req.body?.autoLayout !== false; // default true
+
+    if (!model || typeof model !== 'object' || !('elements' in model)) {
+      res.status(400).json({ error: 'Request body must include a "model" (UML model JSON).' });
+      return;
+    }
+
+    try {
+      const svg = await this.conversionService.convertToSvg(model, autoLayout);
+      res.status(200).json({ svg: svg.svg, clip: svg.clip });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      res.status(500).json({ error: `SVG export failed: ${message}` });
+    }
+  };
+}

--- a/packages/server/src/main/routes.ts
+++ b/packages/server/src/main/routes.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import cors from 'cors';
 import { UmlAgentRateLimiterResource } from './resources/uml-agent-rate-limiter-resource';
+import { SvgExportResource } from './resources/svg-export-resource';
 
 // options for cors midddleware
 const options: cors.CorsOptions = {
@@ -12,11 +13,13 @@ const options: cors.CorsOptions = {
 
 export const register = (app: express.Application) => {
   const umlAgentRateLimiterResource = new UmlAgentRateLimiterResource();
+  const svgExportResource = new SvgExportResource();
   const router = express.Router();
   router.use(cors(options));
 
   // routes
   router.post('/uml-agent/rate-limit/check', (req, res) => umlAgentRateLimiterResource.checkRateLimit(req, res));
   router.delete('/uml-agent/rate-limit/check', (req, res) => umlAgentRateLimiterResource.resetRateLimit(req, res));
+  router.post('/svg', (req, res) => svgExportResource.exportSvg(req, res));
   app.use('/api', router);
 };


### PR DESCRIPTION
## Summary
Exposes the existing headless renderer via `POST /api/svg`. Body `{ model, autoLayout? }` → `{ svg, clip }`. Renders with jsdom + Apollon and runs ELK auto-layout by default.

This is the **render half** of a B-UML → SVG pipeline: the editor's Python backend (`besser_api`) converts B-UML → editor JSON and POSTs it here.

## Notes
- Additive (new route + resource); existing routes unchanged.
- Type-checks clean. ELK layout is verified to run headless in Node; the Apollon SVG render is the pre-existing `ConversionService` path (works in the built server).
- Full HTTP round-trip best verified against the webpack-built server.