### PR TITLE
release: v7.9.1 — object diagram attributes in PNG/SVG export

### DIFF
--- a/packages/editor/src/main/scenes/svg.tsx
+++ b/packages/editor/src/main/scenes/svg.tsx
@@ -20,6 +20,7 @@ import { ModelState } from '../components/store/model-state';
 import { ThemeProvider } from 'styled-components';
 import { UMLClassifierComponent } from '../packages/common/uml-classifier/uml-classifier-component';
 import { UMLClassifierMemberComponent } from '../packages/common/uml-classifier/uml-classifier-member-component';
+import { UMLObjectNameComponent } from '../packages/uml-object-diagram/uml-object-name/uml-object-name-component';
 
 type Props = {
   model: Apollon.UMLModel;
@@ -230,8 +231,11 @@ export class Svg extends Component<Props, State> {
               const ElementComponent = Components[element.type as UMLElementType | UMLRelationshipType];
               switch (ElementComponent) {
                 case UMLClassifierComponent:
-                  // If the ElementComponent is of type UMLClassifierComponent, create an array of all members (attributes and methods) for that component.
-                  // Unlike other components, the UMLClassifierComponent needs its members to be children within the component to avoid border rendering issues.
+                case UMLObjectNameComponent:
+                  // UMLClassifierComponent (classes/enumerations) and UMLObjectNameComponent (object diagrams)
+                  // both need their members (attributes/methods) nested as children within the component, so the
+                  // border rectangle and dividers render after them. Without this, an object box exports as an
+                  // empty header with its attributes dropped entirely (they fall into the skipped member case below).
                   const members = elements.filter((member) => member.owner === element.id);
                   return (
                     <svg

--- a/packages/editor/src/main/services/layouter/auto-layout-saga.ts
+++ b/packages/editor/src/main/services/layouter/auto-layout-saga.ts
@@ -7,7 +7,7 @@ import { MoveAction, MovingActionTypes } from '../uml-element/movable/moving-typ
 import { UMLElement } from '../uml-element/uml-element';
 import { IUMLRelationship, UMLRelationship } from '../uml-relationship/uml-relationship';
 import { AutoLayoutActionTypes } from './auto-layout-types';
-import { computeElkLayout, LayoutEdge, LayoutNode, LayoutPosition } from './elk-layouter';
+import { computeElkLayout, ElkLayoutResult, LayoutEdge, LayoutNode, LayoutPosition } from './elk-layouter';
 import { LayouterRepository } from './layouter-repository';
 
 export function* AutoLayouter() {
@@ -37,7 +37,9 @@ function* autoLayout(): SagaIterator {
     .filter((rel): rel is IUMLRelationship => Boolean(rel && UMLRelationship.isUMLRelationship(rel) && rel.source && rel.target))
     .map((rel) => ({ id: rel.id, sourceId: rel.source.element, targetId: rel.target.element }));
 
-  const positions: LayoutPosition[] = yield call(computeElkLayout, nodes, edges);
+  // The interactive layouter only needs node positions here; it re-routes
+  // relationships through the editor's own layouter saga below.
+  const { nodes: positions }: ElkLayoutResult = yield call(computeElkLayout, nodes, edges);
   if (!positions.length) {
     return;
   }

--- a/packages/editor/src/main/services/layouter/elk-layouter.ts
+++ b/packages/editor/src/main/services/layouter/elk-layouter.ts
@@ -32,6 +32,28 @@ export interface LayoutPosition {
   y: number;
 }
 
+export interface LayoutPoint {
+  x: number;
+  y: number;
+}
+
+export interface LayoutEdgeRoute {
+  id: string;
+  /**
+   * Absolute waypoints in the layout's coordinate space (same origin as the
+   * node positions), ordered source-border → bend points → target-border.
+   * Always at least two points.
+   */
+  points: LayoutPoint[];
+}
+
+export interface ElkLayoutResult {
+  /** New top-left position for every laid-out node. */
+  nodes: LayoutPosition[];
+  /** ELK's orthogonal route for every edge it was able to lay out. */
+  edges: LayoutEdgeRoute[];
+}
+
 export interface ElkLayoutOptions {
   /** Layer flow direction. Defaults to DOWN (top-to-bottom). */
   direction?: LayoutDirection;
@@ -41,16 +63,22 @@ const elk = new ELK();
 
 /**
  * Computes new top-left positions for every node using ELK's layered
- * algorithm. Returns absolute positions (relative to the layout origin);
- * the caller maps them onto its own coordinate/move API.
+ * algorithm, plus ELK's orthogonal route for every edge. Returns absolute
+ * coordinates (relative to the layout origin); the caller maps them onto its
+ * own coordinate/move API.
+ *
+ * Edge routes are returned alongside the node positions because ELK computes
+ * both in a single pass — a headless renderer can write the routes straight
+ * into relationship paths instead of relying on the editor's layouter saga to
+ * re-route them at render time.
  */
 export async function computeElkLayout(
   nodes: LayoutNode[],
   edges: LayoutEdge[],
   options: ElkLayoutOptions = {},
-): Promise<LayoutPosition[]> {
+): Promise<ElkLayoutResult> {
   if (nodes.length === 0) {
-    return [];
+    return { nodes: [], edges: [] };
   }
 
   const nodeIds = new Set(nodes.map((node) => node.id));
@@ -75,9 +103,29 @@ export async function computeElkLayout(
 
   const laidOut = await elk.layout(graph);
 
-  return (laidOut.children ?? []).map((child) => ({
+  const nodePositions: LayoutPosition[] = (laidOut.children ?? []).map((child) => ({
     id: child.id,
     x: child.x ?? 0,
     y: child.y ?? 0,
   }));
+
+  // Flatten each edge's first section (start → bends → end) into an absolute
+  // polyline. Edges ELK could not route (no sections) are dropped so the caller
+  // falls back to whatever path the edge already had.
+  const edgeRoutes: LayoutEdgeRoute[] = (laidOut.edges ?? [])
+    .map((edge) => {
+      const section = edge.sections?.[0];
+      if (!section) {
+        return { id: edge.id, points: [] as LayoutPoint[] };
+      }
+      const points: LayoutPoint[] = [
+        section.startPoint,
+        ...(section.bendPoints ?? []),
+        section.endPoint,
+      ].map((point) => ({ x: point.x, y: point.y }));
+      return { id: edge.id, points };
+    })
+    .filter((route) => route.points.length >= 2);
+
+  return { nodes: nodePositions, edges: edgeRoutes };
 }

--- a/packages/editor/src/main/services/layouter/model-layout.ts
+++ b/packages/editor/src/main/services/layouter/model-layout.ts
@@ -1,5 +1,8 @@
 import { UMLModel } from '../../typings';
-import { computeElkLayout, LayoutEdge, LayoutNode } from './elk-layouter';
+import { IBoundary } from '../../utils/geometry/boundary';
+import { IPath } from '../../utils/geometry/path';
+import { Direction } from '../uml-element/uml-element-port';
+import { computeElkLayout, LayoutEdge, LayoutNode, LayoutPoint } from './elk-layouter';
 
 /**
  * Lays out a UML class model with ELK and returns a NEW model whose elements
@@ -9,8 +12,10 @@ import { computeElkLayout, LayoutEdge, LayoutNode } from './elk-layouter';
  * Top-level elements (classes/enums, `owner === null`) are placed by ELK; their
  * child members (attributes/methods) are shifted by the same delta so they stay
  * attached. The layout is recentered onto the model's current center so it does
- * not jump toward the origin. Relationship paths are left untouched — the editor
- * recomputes non-manually-layouted relationships when the model is rendered.
+ * not jump toward the origin. Relationships are re-routed using ELK's own edge
+ * geometry and marked `isManuallyLayouted` so the rendered model is internally
+ * consistent without depending on the editor's layouter saga (which does not run
+ * reliably in a headless/jsdom editor).
  */
 export async function layoutModel(model: UMLModel): Promise<UMLModel> {
   const topLevel = Object.values(model.elements).filter((element) => element.owner === null);
@@ -28,7 +33,7 @@ export async function layoutModel(model: UMLModel): Promise<UMLModel> {
     .filter((rel) => Boolean(rel.source?.element && rel.target?.element))
     .map((rel) => ({ id: rel.id, sourceId: rel.source.element, targetId: rel.target.element }));
 
-  const positions = await computeElkLayout(nodes, edges);
+  const { nodes: positions, edges: routes } = await computeElkLayout(nodes, edges);
   if (positions.length === 0) {
     return model;
   }
@@ -84,5 +89,64 @@ export async function layoutModel(model: UMLModel): Promise<UMLModel> {
       : element;
   }
 
-  return { ...model, elements };
+  // Re-route relationships from ELK's edge geometry. ELK's coordinates share the
+  // layout origin, so the same recentering `offset` maps them onto the moved
+  // boxes. Each route becomes the relationship's path (relative to its own
+  // bounds, the Apollon convention) with anchors derived from where the route
+  // meets each box. Marking the relationship manually-layouted keeps the
+  // editor's layouter saga from overwriting it on import.
+  const routeById = new Map(routes.map((route) => [route.id, route.points]));
+  const relationships: UMLModel['relationships'] = {};
+  for (const [id, relationship] of Object.entries(model.relationships)) {
+    const elkPoints = routeById.get(id);
+    if (!elkPoints || elkPoints.length < 2) {
+      relationships[id] = relationship;
+      continue;
+    }
+
+    const absolute = elkPoints.map((point) => ({ x: point.x + offset.x, y: point.y + offset.y }));
+    const xs = absolute.map((point) => point.x);
+    const ys = absolute.map((point) => point.y);
+    const minX = Math.min(...xs);
+    const minY = Math.min(...ys);
+    const bounds: IBoundary = { x: minX, y: minY, width: Math.max(...xs) - minX, height: Math.max(...ys) - minY };
+    const path = absolute.map((point) => ({ x: point.x - minX, y: point.y - minY })) as IPath;
+
+    relationships[id] = {
+      ...relationship,
+      path,
+      bounds,
+      source: {
+        ...relationship.source,
+        direction: borderDirection(absolute[0], elements[relationship.source.element]?.bounds) ?? relationship.source.direction,
+      },
+      target: {
+        ...relationship.target,
+        direction:
+          borderDirection(absolute[absolute.length - 1], elements[relationship.target.element]?.bounds) ??
+          relationship.target.direction,
+      },
+      isManuallyLayouted: true,
+    };
+  }
+
+  return { ...model, elements, relationships };
+}
+
+/**
+ * Classifies which side of `box` a routed endpoint sits on, so the relationship
+ * anchor (and its marker/labels) faces the correct border. Returns `undefined`
+ * when the connected box is missing so the caller keeps the existing anchor.
+ */
+function borderDirection(point: LayoutPoint, box?: IBoundary): Direction | undefined {
+  if (!box) {
+    return undefined;
+  }
+  const candidates: Array<[Direction, number]> = [
+    [Direction.Up, Math.abs(point.y - box.y)],
+    [Direction.Down, Math.abs(point.y - (box.y + box.height))],
+    [Direction.Left, Math.abs(point.x - box.x)],
+    [Direction.Right, Math.abs(point.x - (box.x + box.width))],
+  ];
+  return candidates.reduce((closest, current) => (current[1] < closest[1] ? current : closest))[0];
 }

--- a/packages/editor/src/main/services/layouter/model-layout.ts
+++ b/packages/editor/src/main/services/layouter/model-layout.ts
@@ -103,34 +103,67 @@ export async function layoutModel(model: UMLModel): Promise<UMLModel> {
       relationships[id] = relationship;
       continue;
     }
-
     const absolute = elkPoints.map((point) => ({ x: point.x + offset.x, y: point.y + offset.y }));
-    const xs = absolute.map((point) => point.x);
-    const ys = absolute.map((point) => point.y);
-    const minX = Math.min(...xs);
-    const minY = Math.min(...ys);
-    const bounds: IBoundary = { x: minX, y: minY, width: Math.max(...xs) - minX, height: Math.max(...ys) - minY };
-    const path = absolute.map((point) => ({ x: point.x - minX, y: point.y - minY })) as IPath;
+    relationships[id] = routedRelationship(relationship, absolute, elements);
+  }
 
-    relationships[id] = {
-      ...relationship,
-      path,
-      bounds,
-      source: {
-        ...relationship.source,
-        direction: borderDirection(absolute[0], elements[relationship.source.element]?.bounds) ?? relationship.source.direction,
-      },
-      target: {
-        ...relationship.target,
-        direction:
-          borderDirection(absolute[absolute.length - 1], elements[relationship.target.element]?.bounds) ??
-          relationship.target.direction,
-      },
-      isManuallyLayouted: true,
-    };
+  // Second pass: relationships whose endpoint is ANOTHER relationship — e.g. the
+  // dashed link from an association class to its association. ELK only routes
+  // node-to-node edges, so these are still unrouted above (and the headless
+  // saga can't re-route them reliably). Anchor them from the class node's border
+  // to the midpoint of the already-routed relationship they attach to.
+  for (const [id, relationship] of Object.entries(model.relationships)) {
+    if (routeById.has(id)) {
+      continue;
+    }
+    const sourceIsRel = Boolean(model.relationships[relationship.source.element]);
+    const targetIsRel = Boolean(model.relationships[relationship.target.element]);
+    if (sourceIsRel === targetIsRel) {
+      continue; // need exactly one relationship end and one node end
+    }
+    const anchor = relationships[sourceIsRel ? relationship.source.element : relationship.target.element];
+    const nodeBox = elements[sourceIsRel ? relationship.target.element : relationship.source.element]?.bounds;
+    if (!anchor || !nodeBox) {
+      continue; // keep the first-pass (untouched) value
+    }
+    const mid = pathMidpoint(anchor);
+    const nodePoint = nearestBorderPoint(nodeBox, mid);
+    const absolute = sourceIsRel ? [mid, nodePoint] : [nodePoint, mid];
+    relationships[id] = routedRelationship(relationship, absolute, elements);
   }
 
   return { ...model, elements, relationships };
+}
+
+/** Builds a relationship whose geometry comes from absolute waypoints. */
+function routedRelationship(
+  relationship: UMLModel['relationships'][string],
+  absolute: LayoutPoint[],
+  elements: UMLModel['elements'],
+): UMLModel['relationships'][string] {
+  const xs = absolute.map((point) => point.x);
+  const ys = absolute.map((point) => point.y);
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  const bounds: IBoundary = { x: minX, y: minY, width: Math.max(...xs) - minX, height: Math.max(...ys) - minY };
+  const path = absolute.map((point) => ({ x: point.x - minX, y: point.y - minY })) as IPath;
+  return {
+    ...relationship,
+    path,
+    bounds,
+    source: {
+      ...relationship.source,
+      direction:
+        borderDirection(absolute[0], elements[relationship.source.element]?.bounds) ?? relationship.source.direction,
+    },
+    target: {
+      ...relationship.target,
+      direction:
+        borderDirection(absolute[absolute.length - 1], elements[relationship.target.element]?.bounds) ??
+        relationship.target.direction,
+    },
+    isManuallyLayouted: true,
+  };
 }
 
 /**
@@ -149,4 +182,49 @@ function borderDirection(point: LayoutPoint, box?: IBoundary): Direction | undef
     [Direction.Right, Math.abs(point.x - (box.x + box.width))],
   ];
   return candidates.reduce((closest, current) => (current[1] < closest[1] ? current : closest))[0];
+}
+
+/** Absolute midpoint (by arc length) of a routed relationship's path. */
+function pathMidpoint(relationship: UMLModel['relationships'][string]): LayoutPoint {
+  const points = relationship.path.map((point) => ({
+    x: point.x + relationship.bounds.x,
+    y: point.y + relationship.bounds.y,
+  }));
+  if (points.length < 2) {
+    return points[0] ?? { x: relationship.bounds.x, y: relationship.bounds.y };
+  }
+  const segments = points.slice(1).map((point, index) => Math.hypot(point.x - points[index].x, point.y - points[index].y));
+  let remaining = segments.reduce((sum, length) => sum + length, 0) / 2;
+  for (let index = 0; index < segments.length; index++) {
+    if (remaining <= segments[index]) {
+      const t = segments[index] ? remaining / segments[index] : 0;
+      return {
+        x: points[index].x + (points[index + 1].x - points[index].x) * t,
+        y: points[index].y + (points[index + 1].y - points[index].y) * t,
+      };
+    }
+    remaining -= segments[index];
+  }
+  return points[points.length - 1];
+}
+
+/** Closest point on `box`'s border to `target`. */
+function nearestBorderPoint(box: IBoundary, target: LayoutPoint): LayoutPoint {
+  const right = box.x + box.width;
+  const bottom = box.y + box.height;
+  const inside = target.x > box.x && target.x < right && target.y > box.y && target.y < bottom;
+  if (!inside) {
+    return { x: clamp(target.x, box.x, right), y: clamp(target.y, box.y, bottom) };
+  }
+  const edges: Array<[LayoutPoint, number]> = [
+    [{ x: box.x, y: target.y }, target.x - box.x],
+    [{ x: right, y: target.y }, right - target.x],
+    [{ x: target.x, y: box.y }, target.y - box.y],
+    [{ x: target.x, y: bottom }, bottom - target.y],
+  ];
+  return edges.reduce((closest, current) => (current[1] < closest[1] ? current : closest))[0];
+}
+
+function clamp(value: number, low: number, high: number): number {
+  return Math.max(low, Math.min(high, value));
 }


### PR DESCRIPTION
Sync `develop` → `main` for BESSER v7.9.1.

## Summary
- Object diagrams (and user-model diagrams) now export their attribute rows to **PNG** and **SVG**. Previously the exported box was an empty header.
- Root cause: `scenes/svg.tsx` only nested member children for `UMLClassifierComponent`. Object boxes use `UMLObjectNameComponent`, which fell to the default (box-only) branch, and their `ObjectAttribute`/`ObjectMethod` members were dropped on the assumption they had already been nested in a classifier.
- Fix: route `UMLObjectNameComponent` through the same member-nesting branch. Matching on the component also covers `UserModelName`. PNG export rasterizes `exportAsSVG`, so both formats are fixed by one change.

## Test plan
- [ ] Unit tests pass.
- [ ] Visual smoke: open an object diagram with attribute values → Export → PNG and SVG both show the attribute slots inside each object box.
- [ ] Class/enumeration export unchanged (no regression).