### PR TITLE
fix: raise paste-to-attachment threshold in assistant chat input

### DIFF
--- a/packages/webapp/src/components/chatbot-kit/ui/message-input.tsx
+++ b/packages/webapp/src/components/chatbot-kit/ui/message-input.tsx
@@ -124,7 +124,14 @@ export function MessageInput({
     if (!items) return
 
     const text = event.clipboardData.getData("text")
-    if (text && text.length > 500 && props.allowAttachments) {
+    // Threshold high enough that a multi-sentence natural-language request (e.g.
+    // "the customer places an order, then the system checks stock, then...", a
+    // typical BPMN/state-machine process description) stays as normal chat text
+    // and goes through intent routing, instead of being silently rerouted into
+    // file-conversion (a different code path with much narrower diagram-type
+    // detection). Still catches genuinely large pastes (JSON dumps, full
+    // PlantUML/CSV files, etc.).
+    if (text && text.length > 3000 && props.allowAttachments) {
       event.preventDefault()
       const blob = new Blob([text], { type: "text/plain" })
       const file = new File([blob], "Pasted text", {


### PR DESCRIPTION
## Summary
- Pasting a multi-sentence process description (>500 chars) into the
  assistant chat was silently converted into a synthetic file
  attachment instead of staying as chat text, rerouting it through
  file-conversion instead of normal intent routing. Raise the
  threshold to 3000 chars.

## Test plan
- [x] ESLint clean (0 new errors/warnings)
- [x] Typecheck: no new errors vs. baseline