### PR TITLE
Adding Ollama LLM support to the BAF agent config frontend

### DIFF
--- a/packages/editor/src/main/packages/agent-state-diagram/agent-llm/agent-llm.ts
+++ b/packages/editor/src/main/packages/agent-state-diagram/agent-llm/agent-llm.ts
@@ -9,7 +9,7 @@ import { assign } from '../../../utils/fx/assign';
 import { IBoundary } from '../../../utils/geometry/boundary';
 import { UMLElementType } from '../../uml-element-type';
 
-export type AgentLLMProviderType = 'openai' | 'huggingface' | 'huggingface_api' | 'replicate';
+export type AgentLLMProviderType = 'openai' | 'huggingface' | 'huggingface_api' | 'replicate' | 'ollama';
 
 export interface IAgentLLM extends IUMLElement {
   provider: AgentLLMProviderType;

--- a/packages/editor/src/main/packages/agent-state-diagram/agent-rag-element/agent-rag-element-update.tsx
+++ b/packages/editor/src/main/packages/agent-state-diagram/agent-rag-element/agent-rag-element-update.tsx
@@ -92,6 +92,41 @@ const AgentRagElementUpdateComponent: React.FC<Props> = ({ element, update, elem
           }
         />
       </Section>
+      <Section>
+        <Header>Embedding Provider</Header>
+        <Select
+          value={element.embedding_provider || 'openai'}
+          onChange={(event) => {
+            const provider = event.target.value as 'openai' | 'ollama';
+            const updates: Partial<AgentRagElement> = { embedding_provider: provider };
+            if (provider === 'ollama' && !element.embedding_base_url) {
+              updates.embedding_base_url = 'http://localhost:11434';
+            }
+            update<AgentRagElement>(element.id, updates);
+          }}
+        >
+          <option value="openai">OpenAI</option>
+          <option value="ollama">Ollama (local)</option>
+        </Select>
+      </Section>
+      {(element.embedding_provider === 'ollama') && (
+        <>
+          <Section>
+            <Header>Embedding Base URL</Header>
+            <Textfield
+              value={element.embedding_base_url || 'http://localhost:11434'}
+              onChange={(embedding_base_url) => update<AgentRagElement>(element.id, { embedding_base_url })}
+            />
+          </Section>
+          <Section>
+            <Header>Embedding Model</Header>
+            <Textfield
+              value={element.embedding_model || ''}
+              onChange={(embedding_model) => update<AgentRagElement>(element.id, { embedding_model })}
+            />
+          </Section>
+        </>
+      )}
     </div>
   );
 };

--- a/packages/editor/src/main/packages/agent-state-diagram/agent-rag-element/agent-rag-element.ts
+++ b/packages/editor/src/main/packages/agent-state-diagram/agent-rag-element/agent-rag-element.ts
@@ -15,11 +15,16 @@ const AGENT_RAG_DEFAULT_WIDTH = 140;
 const AGENT_RAG_MAX_AUTO_WIDTH = 340;
 const AGENT_RAG_MIN_HEIGHT = 70;
 
+export type AgentRagEmbeddingProvider = 'openai' | 'ollama';
+
 export interface IAgentRagElement extends IUMLElement {
   llm_name: string;
   llm_prompt: string;
   k: number;
   num_previous_messages: number;
+  embedding_provider: AgentRagEmbeddingProvider;
+  embedding_base_url: string;
+  embedding_model: string;
 }
 
 export class AgentRagElement extends UMLElement implements IAgentRagElement {
@@ -34,6 +39,9 @@ export class AgentRagElement extends UMLElement implements IAgentRagElement {
   llm_prompt: string = '';
   k: number = 4;
   num_previous_messages: number = 0;
+  embedding_provider: AgentRagEmbeddingProvider = 'openai';
+  embedding_base_url: string = '';
+  embedding_model: string = '';
 
   bounds: IBoundary = {
     ...this.bounds,
@@ -63,6 +71,15 @@ export class AgentRagElement extends UMLElement implements IAgentRagElement {
     ) {
       this.num_previous_messages = 0;
     }
+    if (!this.embedding_provider || !['openai', 'ollama'].includes(this.embedding_provider)) {
+      this.embedding_provider = 'openai';
+    }
+    if (!this.embedding_base_url) {
+      this.embedding_base_url = '';
+    }
+    if (!this.embedding_model) {
+      this.embedding_model = '';
+    }
   }
 
   serialize(children: UMLElement[] = []): Apollon.UMLModelElement {
@@ -73,6 +90,9 @@ export class AgentRagElement extends UMLElement implements IAgentRagElement {
       llm_prompt: this.llm_prompt,
       k: this.k,
       num_previous_messages: this.num_previous_messages,
+      embedding_provider: this.embedding_provider,
+      embedding_base_url: this.embedding_base_url,
+      embedding_model: this.embedding_model,
     } as Apollon.UMLModelElement & { llm_name: string };
   }
 
@@ -82,6 +102,9 @@ export class AgentRagElement extends UMLElement implements IAgentRagElement {
       llm_prompt?: string;
       k?: number;
       num_previous_messages?: number;
+      embedding_provider?: string;
+      embedding_base_url?: string;
+      embedding_model?: string;
     },
     children?: Apollon.UMLModelElement[],
   ): void {
@@ -93,6 +116,10 @@ export class AgentRagElement extends UMLElement implements IAgentRagElement {
       typeof values.num_previous_messages === 'number' && values.num_previous_messages >= 0
         ? values.num_previous_messages
         : 0;
+    this.embedding_provider =
+      values.embedding_provider === 'ollama' ? 'ollama' : 'openai';
+    this.embedding_base_url = values.embedding_base_url || '';
+    this.embedding_model = values.embedding_model || '';
   }
 
   render(layer: ILayer): ILayoutable[] {

--- a/packages/webapp/src/main/features/agent-config/AgentConfigurationPanel.tsx
+++ b/packages/webapp/src/main/features/agent-config/AgentConfigurationPanel.tsx
@@ -361,7 +361,7 @@ const flattenStructuredConfig = (raw: any): Partial<AgentConfigurationPayload> =
 
 const cloneModel = (model: UMLModel): UMLModel => JSON.parse(JSON.stringify(model)) as UMLModel;
 
-type AgentLLMElementProvider = 'openai' | 'huggingface' | 'huggingface_api' | 'replicate';
+type AgentLLMElementProvider = 'openai' | 'huggingface' | 'huggingface_api' | 'replicate' | 'ollama';
 
 type AgentLLMElement = {
   id: string;
@@ -380,6 +380,7 @@ const AGENT_LLM_PROVIDER_OPTIONS: Array<{ value: AgentLLMElementProvider; label:
   { value: 'huggingface', label: 'Hugging Face' },
   { value: 'huggingface_api', label: 'Hugging Face API' },
   { value: 'replicate', label: 'Replicate' },
+  { value: 'ollama', label: 'Ollama (local)' },
 ];
 
 const generateAgentLLMId = (): string => {
@@ -396,7 +397,7 @@ const isAgentLLMElement = (value: unknown): value is AgentLLMElement => {
 };
 
 const normalizeAgentLLMElement = (raw: any, fallbackId: string): AgentLLMElement => {
-  const provider = (['openai', 'huggingface', 'huggingface_api', 'replicate'].includes(raw?.provider)
+  const provider = (['openai', 'huggingface', 'huggingface_api', 'replicate', 'ollama'].includes(raw?.provider)
     ? raw.provider
     : 'openai') as AgentLLMElementProvider;
   const parameters =
@@ -654,6 +655,13 @@ const AgentLLMRow: React.FC<AgentLLMRowProps> = ({
     setParametersError('');
   }, [element.id]);
 
+  const updateOllamaParam = (key: string, value: string) => {
+    const updated = { ...element.parameters, [key]: value };
+    onChange(element.id, { parameters: updated });
+    setParametersText(formatAgentLLMParameters(updated));
+    setParametersError('');
+  };
+
   const commitParameters = (raw: string) => {
     if (!raw.trim()) {
       setParametersError('');
@@ -711,9 +719,21 @@ const AgentLLMRow: React.FC<AgentLLMRowProps> = ({
                 id={`agent-llm-provider-${element.id}`}
                 className="h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors hover:border-brand/30 focus:border-brand/40 focus:outline-none focus:ring-2 focus:ring-brand/20"
                 value={element.provider}
-                onChange={(event) =>
-                  onChange(element.id, { provider: event.target.value as AgentLLMElementProvider })
-                }
+                onChange={(event) => {
+                  const newProvider = event.target.value as AgentLLMElementProvider;
+                  const updates: Partial<AgentLLMElement> = { provider: newProvider };
+                  if (newProvider === 'ollama') {
+                    const seeded = {
+                      ...element.parameters,
+                      base_url: (element.parameters.base_url as string) || 'http://localhost:11434',
+                      model: (element.parameters.model as string) || '',
+                    };
+                    updates.parameters = seeded;
+                    setParametersText(formatAgentLLMParameters(seeded));
+                    setParametersError('');
+                  }
+                  onChange(element.id, updates);
+                }}
               >
                 {AGENT_LLM_PROVIDER_OPTIONS.map((opt) => (
                   <option key={opt.value} value={opt.value}>
@@ -739,6 +759,28 @@ const AgentLLMRow: React.FC<AgentLLMRowProps> = ({
               />
             </div>
           </div>
+          {element.provider === 'ollama' && (
+            <div className="grid gap-3 md:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label htmlFor={`agent-llm-ollama-url-${element.id}`}>Base URL</Label>
+                <Input
+                  id={`agent-llm-ollama-url-${element.id}`}
+                  value={(element.parameters.base_url as string) ?? 'http://localhost:11434'}
+                  placeholder="http://localhost:11434"
+                  onChange={(event) => updateOllamaParam('base_url', event.target.value)}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor={`agent-llm-ollama-model-${element.id}`}>Model</Label>
+                <Input
+                  id={`agent-llm-ollama-model-${element.id}`}
+                  value={(element.parameters.model as string) ?? ''}
+                  placeholder="e.g. llama3, mistral, qwen2.5"
+                  onChange={(event) => updateOllamaParam('model', event.target.value)}
+                />
+              </div>
+            </div>
+          )}
           <div className="space-y-1.5">
             <Label htmlFor={`agent-llm-parameters-${element.id}`}>Parameters (JSON)</Label>
             <textarea

--- a/packages/webapp/src/main/shared/services/storage/local-storage-repository.ts
+++ b/packages/webapp/src/main/shared/services/storage/local-storage-repository.ts
@@ -54,7 +54,8 @@ export const normalizeAgentRuntimeConfig = (
     raw.agentLlmProvider === 'openai' ||
     raw.agentLlmProvider === 'huggingface' ||
     raw.agentLlmProvider === 'huggingfaceapi' ||
-    raw.agentLlmProvider === 'replicate'
+    raw.agentLlmProvider === 'replicate' ||
+    raw.agentLlmProvider === 'ollama'
       ? raw.agentLlmProvider
       : '';
   const intent: IntentRecognitionTechnology =

--- a/packages/webapp/src/main/shared/types/agent-config.ts
+++ b/packages/webapp/src/main/shared/types/agent-config.ts
@@ -14,7 +14,7 @@ export type VoiceStyleSetting = {
 
 export type IntentRecognitionTechnology = 'classical' | 'llm-based';
 
-export type AgentLLMProvider = 'openai' | 'huggingface' | 'huggingfaceapi' | 'replicate' | '';
+export type AgentLLMProvider = 'openai' | 'huggingface' | 'huggingfaceapi' | 'replicate' | 'ollama' | '';
 
 export type AgentLanguageComplexity = 'original' | 'simple' | 'medium' | 'complex';
 


### PR DESCRIPTION
## Summary

This PR adds Ollama configuration support to the BESSER Web Modeling Editor for BAF agents.

Users can now select Ollama as the LLM provider, configure the local Ollama server and model, and choose Ollama as the embedding provider for RAG elements.

## Changes

### Agent LLM configuration

* Added `ollama` as a supported agent LLM provider.
* Added Ollama to the provider selection menu.
* Added dedicated configuration fields for:

  * Ollama base URL
  * Ollama model
* Uses `http://localhost:11434` as the default Ollama base URL.
* Stores the Ollama settings in the LLM parameters object.
* Preserves Ollama as a valid provider when loading saved agent configurations.

### RAG embedding configuration

* Added support for selecting either OpenAI or Ollama as the embedding provider.
* Added Ollama-specific RAG fields for:

  * Embedding base URL
  * Embedding model
* Uses `http://localhost:11434` as the default embedding server URL.
* Added serialization and deserialization of the embedding provider, base URL and model.
* Defaults existing or invalid RAG configurations to OpenAI embeddings for backward compatibility.

## Motivation

BAF supports locally hosted language models through Ollama. This PR exposes the required settings in the Web Modeling Editor so users can visually configure Ollama-backed agents and RAG pipelines.

This makes it possible to configure local LLM and embedding deployments without manually editing the generated agent configuration.

## Related changes

This frontend change is part of the wider Ollama integration across:

* BESSER Agentic Framework [PR 190](https://github.com/BESSER-PEARL/BESSER-Agentic-Framework/pull/190)
* BESSER (metamodel and code generation) [PR 565](https://github.com/BESSER-PEARL/BESSER/pull/565)

The corresponding BESSER and BAF changes are required to generate and run the configured Ollama-backed agents.