### PR TITLE
chore(i18n): self-descriptive view keys + lb JSON fix + French translation corrections

### DIFF
--- a/packages/editor/src/main/components/sidebar/sidebar-component.tsx
+++ b/packages/editor/src/main/components/sidebar/sidebar-component.tsx
@@ -102,7 +102,7 @@ class SidebarComponent extends Component<Props, SidebarComponentState> {
               color="primary"
             >
               <option value={ApollonView.Modelling}>{translate('views.modelling')}</option>
-              <option value={ApollonView.Exporting}>{translate('views.exporting')}</option>
+              <option value={ApollonView.Exporting}>{translate('views.interactive')}</option>
             </select>
           </div>
         )}

--- a/packages/editor/src/main/components/sidebar/sidebar-component.tsx
+++ b/packages/editor/src/main/components/sidebar/sidebar-component.tsx
@@ -101,7 +101,7 @@ class SidebarComponent extends Component<Props, SidebarComponentState> {
               onChange={e => changeView(e.target.value as ApollonView)}
               color="primary"
             >
-              <option value={ApollonView.Modelling}>{translate('views.modelling')}</option>
+              <option value={ApollonView.Modelling}>{translate('views.modeling')}</option>
               <option value={ApollonView.Exporting}>{translate('views.interactive')}</option>
             </select>
           </div>

--- a/packages/i18n/ca/editor.json
+++ b/packages/i18n/ca/editor.json
@@ -1,7 +1,7 @@
 {
   "views": {
     "modelling": "Modelatge",
-    "exporting": "Interactiu",
+    "interactive": "Interactiu",
     "highlight": "Mostra els elements interactius",
     "iconMode": "Mostra el diagrama d'objectes en mode icona"
   },

--- a/packages/i18n/ca/editor.json
+++ b/packages/i18n/ca/editor.json
@@ -1,6 +1,6 @@
 {
   "views": {
-    "modelling": "Modelatge",
+    "modeling": "Modelatge",
     "interactive": "Interactiu",
     "highlight": "Mostra els elements interactius",
     "iconMode": "Mostra el diagrama d'objectes en mode icona"

--- a/packages/i18n/de/editor.json
+++ b/packages/i18n/de/editor.json
@@ -1,7 +1,7 @@
 {
   "views": {
     "modelling": "Modellierung",
-    "exporting": "Interaktiv",
+    "interactive": "Interaktiv",
     "highlight": "Interaktive Elemente anzeigen",
     "iconMode": "Objektdiagramm im Symbolmodus anzeigen"
   },

--- a/packages/i18n/de/editor.json
+++ b/packages/i18n/de/editor.json
@@ -1,6 +1,6 @@
 {
   "views": {
-    "modelling": "Modellierung",
+    "modeling": "Modellierung",
     "interactive": "Interaktiv",
     "highlight": "Interaktive Elemente anzeigen",
     "iconMode": "Objektdiagramm im Symbolmodus anzeigen"

--- a/packages/i18n/en/editor.json
+++ b/packages/i18n/en/editor.json
@@ -1,7 +1,7 @@
 {
   "views": {
     "modelling": "Modeling",
-    "exporting": "Interactive",
+    "interactive": "Interactive",
     "highlight": "Show interactive elements",
     "iconMode": "Display Object Diagram in Icon Mode"
   },

--- a/packages/i18n/en/editor.json
+++ b/packages/i18n/en/editor.json
@@ -1,6 +1,6 @@
 {
   "views": {
-    "modelling": "Modeling",
+    "modeling": "Modeling",
     "interactive": "Interactive",
     "highlight": "Show interactive elements",
     "iconMode": "Display Object Diagram in Icon Mode"

--- a/packages/i18n/es/editor.json
+++ b/packages/i18n/es/editor.json
@@ -1,7 +1,7 @@
 {
   "views": {
     "modelling": "Modelado",
-    "exporting": "Interactivo",
+    "interactive": "Interactivo",
     "highlight": "Mostrar elementos interactivos",
     "iconMode": "Mostrar diagrama de objetos en modo icono"
   },

--- a/packages/i18n/es/editor.json
+++ b/packages/i18n/es/editor.json
@@ -1,6 +1,6 @@
 {
   "views": {
-    "modelling": "Modelado",
+    "modeling": "Modelado",
     "interactive": "Interactivo",
     "highlight": "Mostrar elementos interactivos",
     "iconMode": "Mostrar diagrama de objetos en modo icono"

--- a/packages/i18n/fr/editor.json
+++ b/packages/i18n/fr/editor.json
@@ -1,6 +1,6 @@
 {
   "views": {
-    "modelling": "Modélisation",
+    "modeling": "Modélisation",
     "interactive": "Interactif",
     "highlight": "Afficher les éléments interactifs",
     "iconMode": "Afficher le diagramme d'objets en mode icône"

--- a/packages/i18n/fr/editor.json
+++ b/packages/i18n/fr/editor.json
@@ -1,7 +1,7 @@
 {
   "views": {
     "modelling": "Modélisation",
-    "exporting": "Interactif",
+    "interactive": "Interactif",
     "highlight": "Afficher les éléments interactifs",
     "iconMode": "Afficher le diagramme d'objets en mode icône"
   },

--- a/packages/i18n/lb/editor.json
+++ b/packages/i18n/lb/editor.json
@@ -300,7 +300,7 @@
       "BPMNLinkIntermediateThrowEvent": "Ausléissend Link-Zwëschenevenement (Throw)",
       "BPMNCompensationIntermediateThrowEvent": "Ausléissend Kompensatiouns-Zwëschenevenement (Throw)",
       "BPMNSignalIntermediateCatchEvent": "Empfaangend Signal-Zwëschenevenement (Catch)",
-      "BPMNSignalIntermediateThrowEvent": "Sendend Signal-Zwëschenevenement (Throw)"
+      "BPMNSignalIntermediateThrowEvent": "Sendend Signal-Zwëschenevenement (Throw)",
       "BPMNEndEvent": "Endevenement",
       "BPMNMessageEndEvent": "Message-Endevenement",
       "BPMNEscalationEndEvent": "Eskalatioun-Endevenement",

--- a/packages/i18n/lb/editor.json
+++ b/packages/i18n/lb/editor.json
@@ -1,6 +1,6 @@
 {
   "views": {
-    "modelling": "Modelléierung",
+    "modeling": "Modelléierung",
     "interactive": "Interaktiv",
     "highlight": "Interaktiv Elementer uweisen",
     "iconMode": "Objektdiagramm am Ikonmodus uweisen"

--- a/packages/i18n/lb/editor.json
+++ b/packages/i18n/lb/editor.json
@@ -1,7 +1,7 @@
 {
   "views": {
     "modelling": "Modelléierung",
-    "exporting": "Interaktiv",
+    "interactive": "Interaktiv",
     "highlight": "Interaktiv Elementer uweisen",
     "iconMode": "Objektdiagramm am Ikonmodus uweisen"
   },


### PR DESCRIPTION
i18n cleanup on the `feature/multilingual-editor` branch. Started as a single misleading-key rename, expanded (per review) into a full self-descriptiveness audit, a cross-locale value check, and a French translation-quality review. Grouped into separable commits.

## 1 — `views.exporting` → `views.interactive` (misleading key)
The key was named `exporting` but its value is the **Interactive** view label (stale name from a repurposed view). Renamed across all 6 locales (`ca/de/en/es/fr/lb`); translation values unchanged; updated the single `translate()` ref in `sidebar-component.tsx`. The `ApollonView.Exporting` enum (a serialized view id) is intentionally left alone. A full agent audit of both English files confirmed this was the **only** genuinely misleading key.

## 2 — `lb/editor.json` missing comma (pre-existing bug)
Luxembourgish `editor.json` failed JSON parse — line 303 (`BPMNSignalIntermediateThrowEvent`) was missing its trailing comma, so the whole `lb` file wouldn't load. Fixed the one comma (only error; file parses fully afterward). Unrelated to the renames — droppable on its own.

## 3 — `views.modelling` → `views.modeling` (spelling alignment)
The key used British spelling while its value and the rest of the codebase use American "Modeling" (11 value occurrences, 0 "Modelling"; sibling key `modelingAssistant` also American). Renamed across all 6 locales + the single `translate()` ref. Values and the `ApollonView.Modelling` enum unchanged.

## 4 — French translation corrections in `webapp.json`
A French quality review (both `editor.json` + `webapp.json`, verdict: high quality) surfaced four fixable issues, all **French-value-only**:
- `editors.quantum.editorTitle`: **"Quantum Editor"** was untranslated → **"Éditeur quantique"** (the real bug).
- `generation.agent.sourceLanguage`: gender agreement "(optionnel)" → "(facultative)" for feminine "langue".
- `editors.diagramTabs.allClassesHaveInstance_one`: dropped `{{count}}` in the i18next singular ("La 1 classe" was ungrammatical).
- `agentConfig` subtitle/noTabs/createFirst/statusLine: "User Diagram" left in English → "diagramme d'utilisateur" (matches `diagramTypes.UserDiagram`).

## Not done (left for a decision)
- **Cross-locale value drift** `sidebar.enumAttribute`: EN "Case" vs everyone-else "Value", but the UML term used elsewhere is "literal/littéral" — needs a cross-language decision on the canonical label, so left untouched.
- **Minor FR terminology nits** (analytics, feedback, "e.g.", "Diagramme d'IUG") — defensible, not applied.
- A final **native-speaker glance** on non-English locales before merge remains advisable.

## Test plan
- [x] All 6 `editor.json` + `fr/webapp.json` parse as valid JSON
- [x] No `views.exporting` / `views.modelling` references remain
- [x] Renamed keys present in every locale with original values preserved
- [ ] Visual smoke: sidebar view dropdown + French quantum-editor title