### PR TITLE
chore(i18n): remove dead 'sidebar' keys + tidy new-literal placeholder

### DIFF
--- a/packages/i18n/ca/editor.json
+++ b/packages/i18n/ca/editor.json
@@ -5,12 +5,6 @@
     "highlight": "Mostra els elements interactius",
     "iconMode": "Mostra el diagrama d'objectes en mode icona"
   },
-  "sidebar": {
-    "classAttribute": "atribut",
-    "classMethod": "+ mètode()",
-    "enumAttribute": "Valor",
-    "objectAttribute": "atribut = valor"
-  },
   "popup": {
     "attributes": "Atributs",
     "methods": "Mètodes",
@@ -152,7 +146,7 @@
       "moveDown": "Mou avall",
       "moveUp": "Mou amunt",
       "codeButton": "Codi",
-      "newLiteralPlaceholder": "+ literal",
+      "newLiteralPlaceholder": "literal",
       "newAttributePlaceholder": "+ atribut: str"
     },
     "attribute": {

--- a/packages/i18n/de/editor.json
+++ b/packages/i18n/de/editor.json
@@ -5,12 +5,6 @@
     "highlight": "Interaktive Elemente anzeigen",
     "iconMode": "Objektdiagramm im Symbolmodus anzeigen"
   },
-  "sidebar": {
-    "classAttribute": "attribut",
-    "classMethod": "+ methode()",
-    "enumAttribute": "Wert",
-    "objectAttribute": "attribut = wert"
-  },
   "popup": {
     "attributes": "Attribute",
     "methods": "Methoden",
@@ -152,7 +146,7 @@
       "moveDown": "Nach unten verschieben",
       "moveUp": "Nach oben verschieben",
       "codeButton": "Code",
-      "newLiteralPlaceholder": "+ Literal",
+      "newLiteralPlaceholder": "Literal",
       "newAttributePlaceholder": "+ Attribut: str"
     },
     "attribute": {

--- a/packages/i18n/en/editor.json
+++ b/packages/i18n/en/editor.json
@@ -5,12 +5,6 @@
     "highlight": "Show interactive elements",
     "iconMode": "Display Object Diagram in Icon Mode"
   },
-  "sidebar": {
-    "classAttribute": "attribute",
-    "classMethod": "+ method()",
-    "enumAttribute": "Case",
-    "objectAttribute": "attribute = value"
-  },
   "popup": {
     "attributes": "Attributes",
     "methods": "Methods",
@@ -152,7 +146,7 @@
       "moveDown": "Move down",
       "moveUp": "Move up",
       "codeButton": "Code",
-      "newLiteralPlaceholder": "+ literal",
+      "newLiteralPlaceholder": "literal",
       "newAttributePlaceholder": "+ attribute: str"
     },
     "attribute": {

--- a/packages/i18n/es/editor.json
+++ b/packages/i18n/es/editor.json
@@ -5,12 +5,6 @@
     "highlight": "Mostrar elementos interactivos",
     "iconMode": "Mostrar diagrama de objetos en modo icono"
   },
-  "sidebar": {
-    "classAttribute": "atributo",
-    "classMethod": "+ método()",
-    "enumAttribute": "Valor",
-    "objectAttribute": "atributo = valor"
-  },
   "popup": {
     "attributes": "Atributos",
     "methods": "Métodos",
@@ -152,7 +146,7 @@
       "moveDown": "Mover abajo",
       "moveUp": "Mover arriba",
       "codeButton": "Código",
-      "newLiteralPlaceholder": "+ literal",
+      "newLiteralPlaceholder": "literal",
       "newAttributePlaceholder": "+ atributo: str"
     },
     "attribute": {

--- a/packages/i18n/fr/editor.json
+++ b/packages/i18n/fr/editor.json
@@ -5,12 +5,6 @@
     "highlight": "Afficher les éléments interactifs",
     "iconMode": "Afficher le diagramme d'objets en mode icône"
   },
-  "sidebar": {
-    "classAttribute": "attribut",
-    "classMethod": "+ méthode()",
-    "enumAttribute": "Valeur",
-    "objectAttribute": "attribut = valeur"
-  },
   "popup": {
     "attributes": "Attributs",
     "methods": "Méthodes",
@@ -152,7 +146,7 @@
       "moveDown": "Déplacer vers le bas",
       "moveUp": "Déplacer vers le haut",
       "codeButton": "Code",
-      "newLiteralPlaceholder": "+ littéral",
+      "newLiteralPlaceholder": "littéral",
       "newAttributePlaceholder": "+ attribut : str"
     },
     "attribute": {

--- a/packages/i18n/lb/editor.json
+++ b/packages/i18n/lb/editor.json
@@ -5,12 +5,6 @@
     "highlight": "Interaktiv Elementer uweisen",
     "iconMode": "Objektdiagramm am Ikonmodus uweisen"
   },
-  "sidebar": {
-    "classAttribute": "attribut",
-    "classMethod": "+ method()",
-    "enumAttribute": "Wäert",
-    "objectAttribute": "attribut = wäert"
-  },
   "popup": {
     "attributes": "Attributer",
     "methods": "Methoden",
@@ -152,7 +146,7 @@
       "moveDown": "No ënnen réckelen",
       "moveUp": "No uewen réckelen",
       "codeButton": "Code",
-      "newLiteralPlaceholder": "+ Literal",
+      "newLiteralPlaceholder": "Literal",
       "newAttributePlaceholder": "+ Attribut: str"
     },
     "attribute": {


### PR DESCRIPTION
Follow-up to the i18n self-descriptiveness pass.

## Delete the dead `sidebar` section
An orphan check found `sidebar` is the only top-level `editor.json` section with **0 code references** — nothing calls `translate('sidebar.*')`. The four keys (`classAttribute`, `classMethod`, `enumAttribute`, `objectAttribute`) are leftovers; the live new-element placeholders live under `popup.*`. Removed from all 6 locales.

Bonus: those keys were where the `enumAttribute` **"Case" (en) vs "Value" (all other locales)** discrepancy lived, so deleting the dead section **resolves that open item** — no Case-vs-Value decision needed.

## Tidy the new-literal placeholder
`popup.classifier.newLiteralPlaceholder` was `"+ literal"`; enum literals have no visibility prefix (unlike methods, which keep `"+ method()"`), so the leading `"+ "` is dropped → `"literal"`. Translated word preserved in every locale (`Literal` / `littéral`).

`packages.NNDiagram.NNContainer` = `"Neural_Network"` is intentionally **left as-is** — the underscore is a deliberate parser-safe token (the parser breaks on spaces).

## Test plan
- [x] All 6 `editor.json` parse as valid JSON
- [x] Zero remaining `sidebar.*` references in the codebase
- [x] `newLiteralPlaceholder` keeps its translated word in each locale