### PR TITLE
fix(deps): restore editor's pinned postcss entry so npm ci works

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -880,6 +880,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -896,6 +897,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -912,6 +914,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -928,6 +931,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -944,6 +948,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -960,6 +965,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -976,6 +982,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -992,6 +999,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1008,6 +1016,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1024,6 +1033,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1040,6 +1050,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1056,6 +1067,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1072,6 +1084,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1088,6 +1101,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1104,6 +1118,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1120,6 +1135,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1136,6 +1152,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1152,6 +1169,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1168,6 +1186,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1184,6 +1203,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1200,6 +1220,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1216,6 +1237,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1232,6 +1254,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1248,6 +1271,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1264,6 +1288,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1280,6 +1305,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25395,6 +25421,35 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/editor/node_modules/postcss": {
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
     },
     "packages/editor/node_modules/prettier": {
       "version": "3.2.5",


### PR DESCRIPTION
## Problem

`npm ci` fails on a clean checkout of `develop`:

```
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: postcss@8.4.38 from lock file
```

This breaks clean installs for everyone, and any CI job that uses `npm ci`.

## Cause

`packages/editor` pins postcss to **exactly** `8.4.38` in `devDependencies`. The hoisted root entry is `8.4.49`, which an exact pin cannot satisfy, so the editor needs its own nested entry — and `packages/editor/node_modules/postcss` had been dropped from the lockfile. With nothing able to satisfy the pin, `npm ci` aborts. `npm install` hides it by re-resolving from scratch, which is why this went unnoticed.

For reference, `packages/webapp` has the same shape and is fine: it declares `^8.5.6` and keeps its own nested `8.5.12`.

## Fix

Regenerated with `npm install --package-lock-only`. The change is purely additive — **55 insertions, 0 deletions**:

- the missing `packages/editor/node_modules/postcss` entry (8.4.38)
- 26 `"dev": true` flags that were lost at the same time

Nothing is removed. In particular the stale `packages/webapp2` block stays gone, since that workspace was renamed to `packages/webapp` back in April.

## Verification

- `npm ci` completes — 1913 packages
- `packages/editor` resolves postcss **8.4.38**; root keeps **8.4.49**
- Regenerating a second time is a **no-op**, so the lockfile is stable rather than flip-flopping between npm versions
- `i18n-check.mjs` and `i18n-validate-strict.mjs` both pass

## One side effect worth knowing about

The broken lockfile was masking test failures. On a correct `npm ci` install the webapp suite goes from **85 failures to 32** — the previous workaround (`npm install --no-package-lock`) was producing a different dependency set than intended.

The remaining 32 are all `localStorage is undefined` and are unrelated to this change. They track the Node version: `.nvmrc` pins **v20.18.0**, and on newer Node the built-in `localStorage` is inert unless `--localstorage-file` is passed. Worth a separate look, but it isn't a lockfile problem.
