### PR TITLE
fix(gui): stop inherited OCL and non-association links surfacing as table fields

### DIFF
--- a/packages/webapp/src/main/features/editors/gui/__tests__/diagram-helpers.test.ts
+++ b/packages/webapp/src/main/features/editors/gui/__tests__/diagram-helpers.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { getAgentOptions } from '../diagram-helpers';
+import { getAgentOptions, getEndsByClassId, getInheritedEndsByClassId } from '../diagram-helpers';
 import { ProjectStorageRepository } from '../../../../shared/services/storage/ProjectStorageRepository';
 import { BesserProject, createDefaultProject, ProjectDiagram } from '../../../../shared/types/project';
 
@@ -75,5 +75,82 @@ describe('getAgentOptions', () => {
 
     const options = getAgentOptions();
     expect(options).toEqual([{ value: 'Alpha', label: 'Alpha' }]);
+  });
+});
+
+describe('getEndsByClassId / getInheritedEndsByClassId', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    ProjectStorageRepository.revision = 0;
+    (ProjectStorageRepository as any).changeListeners = [];
+    (ProjectStorageRepository as any).suppressDepth = 0;
+  });
+
+  // Mirrors the hotel-booking benchmark model: Guest and Employee inherit from
+  // Person; Person has a real association to Booking, an OCL constraint attached
+  // via ClassOCLLink, and a non-association ClassLinkRel.
+  function setHotelLikeProject() {
+    const model = {
+      version: '3.0.0',
+      type: 'ClassDiagram',
+      elements: {
+        person: { id: 'person', type: 'Class', name: 'Person' },
+        guest: { id: 'guest', type: 'Class', name: 'Guest' },
+        employee: { id: 'employee', type: 'Class', name: 'Employee' },
+        booking: { id: 'booking', type: 'Class', name: 'Booking' },
+        admin: { id: 'admin', type: 'Class', name: 'Admin' },
+        ocl1: { id: 'ocl1', type: 'ClassOCLConstraint', name: '', constraint: 'context Person inv: self.age >= 0' },
+      },
+      relationships: {
+        inh1: { id: 'inh1', type: 'ClassInheritance', source: { element: 'guest' }, target: { element: 'person' } },
+        inh2: { id: 'inh2', type: 'ClassInheritance', source: { element: 'employee' }, target: { element: 'person' } },
+        assoc1: {
+          id: 'assoc1',
+          type: 'ClassBidirectional',
+          source: { element: 'person', role: 'holder' },
+          target: { element: 'booking', role: 'bookings' },
+        },
+        oclLink: { id: 'oclLink', type: 'ClassOCLLink', source: { element: 'ocl1' }, target: { element: 'person' } },
+        linkRel: { id: 'linkRel', type: 'ClassLinkRel', source: { element: 'person' }, target: { element: 'admin' } },
+        uni1: {
+          id: 'uni1',
+          type: 'ClassUnidirectional',
+          source: { element: 'admin', role: '' },
+          target: { element: 'person', role: 'managedPersons' },
+        },
+      },
+    };
+    const project = createDefaultProject('Test', '', 'user');
+    project.diagrams.ClassDiagram = [
+      { id: 'cd1', title: 'Classes', model: model as any, lastUpdate: new Date().toISOString() },
+    ];
+    setCurrentProject(project);
+  }
+
+  it('returns direct association ends without OCL constraints', () => {
+    setHotelLikeProject();
+    const ends = getEndsByClassId('person', false);
+    expect(ends).toEqual([{ value: 'booking', label: 'bookings' }]);
+  });
+
+  it('does not leak OCL links attached to a parent class into children (hotel-booking bug)', () => {
+    setHotelLikeProject();
+    const inherited = getInheritedEndsByClassId('guest');
+    expect(inherited.map((e) => e.value)).not.toContain('ocl1');
+    expect(inherited).toEqual([{ value: 'booking', label: 'bookings' }]);
+  });
+
+  it('does not leak non-association relationships of a parent into children', () => {
+    setHotelLikeProject();
+    const ends = getEndsByClassId('employee');
+    // ClassLinkRel and the incoming ClassUnidirectional (not navigable from
+    // target) must not surface; only the inherited Booking association does.
+    expect(ends).toEqual([{ value: 'booking', label: 'bookings' }]);
+  });
+
+  it('keeps unidirectional navigability when the class is the source', () => {
+    setHotelLikeProject();
+    const ends = getEndsByClassId('admin', false);
+    expect(ends).toEqual([{ value: 'person', label: 'managedPersons' }]);
   });
 });

--- a/packages/webapp/src/main/features/editors/gui/diagram-helpers.ts
+++ b/packages/webapp/src/main/features/editors/gui/diagram-helpers.ts
@@ -166,6 +166,42 @@ export function getClassMetadata(classId: string, includeInherited: boolean = tr
   };
 }
 
+/**
+ * Map a relationship to the association end navigable from any of the given classes.
+ * Only real association types (bidirectional, unidirectional, composition, aggregation)
+ * produce ends — inheritance, OCL links and any other relationship kinds never do,
+ * and an end pointing at an OCL constraint element is never navigable.
+ */
+function getNavigableEndForClassIds(
+  relationship: any,
+  classIds: string[],
+  elements: any,
+): { value: string; label: string } | null {
+  const endFor = (other: any): { value: string; label: string } | null => {
+    const otherElementId = other?.element;
+    const otherElement = elements?.[otherElementId];
+    if (otherElement?.type === 'ClassOCLConstraint') return null;
+    let label = other?.role;
+    if (!label || label.trim() === '') label = otherElement?.name || '';
+    return { value: otherElementId, label };
+  };
+
+  // For bidirectional and composition/aggregation, both ends are navigable
+  if (
+    relationship?.type === 'ClassBidirectional' ||
+    relationship?.type === 'ClassComposition' ||
+    relationship?.type === 'ClassAggregation'
+  ) {
+    if (classIds.includes(relationship.source?.element)) return endFor(relationship.target);
+    if (classIds.includes(relationship.target?.element)) return endFor(relationship.source);
+  }
+  // For unidirectional, only source can navigate to target
+  if (relationship?.type === 'ClassUnidirectional') {
+    if (classIds.includes(relationship.source?.element)) return endFor(relationship.target);
+  }
+  return null;
+}
+
 export function getEndsByClassId(classId: string, includeInherited: boolean = true): { value: string; label: string }[] {
   const classDiagram = getClassDiagramModel();
 
@@ -175,66 +211,7 @@ export function getEndsByClassId(classId: string, includeInherited: boolean = tr
 
   // Only return association ends with navigability from the given class
   const directEnds = Object.values(classDiagram.relationships)
-    .filter((relationship: any) => relationship?.type !== 'ClassInheritance')
-    .map((relationship: any) => {
-      // For bidirectional, both ends are navigable
-      if (relationship.type === 'ClassBidirectional') {
-        if (relationship.source.element === classId) {
-          // Navigable from source to target
-          const otherElementId = relationship.target.element;
-          const role = relationship.target.role;
-          const otherElement = classDiagram.elements?.[otherElementId];
-          if (otherElement?.type === 'ClassOCLConstraint') return null;
-          let label = role;
-          if (!label || label.trim() === '') label = otherElement?.name || '';
-          return { value: otherElementId, label };
-        }
-        if (relationship.target.element === classId) {
-          // Navigable from target to source
-          const otherElementId = relationship.source.element;
-          const role = relationship.source.role;
-          const otherElement = classDiagram.elements?.[otherElementId];
-          if (otherElement?.type === 'ClassOCLConstraint') return null;
-          let label = role;
-          if (!label || label.trim() === '') label = otherElement?.name || '';
-          return { value: otherElementId, label };
-        }
-      }
-      // For unidirectional, only source can navigate to target
-      if (relationship.type === 'ClassUnidirectional') {
-        if (relationship.source.element === classId) {
-          const otherElementId = relationship.target.element;
-          const role = relationship.target.role;
-          const otherElement = classDiagram.elements?.[otherElementId];
-          if (otherElement?.type === 'ClassOCLConstraint') return null;
-          let label = role;
-          if (!label || label.trim() === '') label = otherElement?.name || '';
-          return { value: otherElementId, label };
-        }
-      }
-      // For composition/aggregation, both ends are navigable (same as bidirectional)
-      if (relationship.type === 'ClassComposition' || relationship.type === 'ClassAggregation') {
-        if (relationship.source.element === classId) {
-          const otherElementId = relationship.target.element;
-          const role = relationship.target.role;
-          const otherElement = classDiagram.elements?.[otherElementId];
-          if (otherElement?.type === 'ClassOCLConstraint') return null;
-          let label = role;
-          if (!label || label.trim() === '') label = otherElement?.name || '';
-          return { value: otherElementId, label };
-        }
-        if (relationship.target.element === classId) {
-          const otherElementId = relationship.source.element;
-          const role = relationship.source.role;
-          const otherElement = classDiagram.elements?.[otherElementId];
-          if (otherElement?.type === 'ClassOCLConstraint') return null;
-          let label = role;
-          if (!label || label.trim() === '') label = otherElement?.name || '';
-          return { value: otherElementId, label };
-        }
-      }
-      return null;
-    })
+    .map((relationship: any) => getNavigableEndForClassIds(relationship, [classId], classDiagram.elements))
     .filter((end): end is { value: string; label: string } => end !== null);
 
   // Add inherited association ends if requested
@@ -324,17 +301,11 @@ export function getInheritedEndsByClassId(classId: string): { value: string; lab
   const parentIds = getParentClassIds(classId);
   if (parentIds.length === 0) return [];
 
-  // Collect relationships from all parent classes (excluding inheritance relationships)
-  const inheritedEnds: { value: string; label: string }[] = [];
-  Object.values((classDiagram as any).relationships)
-    .filter((rel: any) => rel?.type !== 'ClassInheritance')
-    .forEach((rel: any) => {
-      if (parentIds.includes(rel?.source?.element)) {
-        inheritedEnds.push({ value: rel.target.element, label: rel.target.role });
-      } else if (parentIds.includes(rel?.target?.element)) {
-        inheritedEnds.push({ value: rel.source.element, label: rel.source.role });
-      }
-    });
+  // Collect association ends from all parent classes — same navigability and
+  // OCL filtering as the direct ends in getEndsByClassId
+  const inheritedEnds = Object.values((classDiagram as any).relationships)
+    .map((rel: any) => getNavigableEndForClassIds(rel, parentIds, (classDiagram as any).elements))
+    .filter((end: any): end is { value: string; label: string } => end !== null);
 
   return inheritedEnds;
 }


### PR DESCRIPTION
## What

When an OCL constraint (or any non-association relationship, e.g. a ClassLinkRel) is attached to a parent class, the GUI No-Code editor's autogenerated tables gave every child class a bogus lookup column for it — the inherited-relationships helper treated any non-inheritance relationship of a parent as a navigable association.

Reproducible with the hotel-booking model from the Agentic-Low-Code-Benchmark repo (`hotel-booking/3-complex-bahavior/low-code-model`): `Person` has an OCL constraint attached; `Guest` and `Employee` each got a spurious table column for it.

## How

`getInheritedEndsByClassId` re-implemented the relationship-to-end mapping without any of the guards the direct path in `getEndsByClassId` has. Instead of patching the copy, the four duplicated association branches are now one shared `getNavigableEndForClassIds` helper used by both paths, so direct and inherited ends get identical semantics:

- only real association types (bidirectional, unidirectional, composition, aggregation) produce ends — OCL links, ClassLinkRel etc. never do;
- ends pointing at a `ClassOCLConstraint` element are never navigable;
- unidirectional associations are only navigable from the source side (previously inherited ends leaked the reverse direction too);
- empty roles now fall back to the class name for inherited ends, same as direct ends.

This transitively fixes autogenerated tables (`GraphicalUIEditor`), the table/chart/metric-card component registrars and the columns/series trait managers, which all consume `getEndsByClassId`.

## Testing

Extended `diagram-helpers.test.ts` with a hotel-booking-shaped fixture (Person ← Guest/Employee, OCL link, ClassLinkRel, bidirectional and unidirectional associations): 4 new tests, 9/9 passing.

Note for running the suite locally on Node >= 25: `NODE_OPTIONS=--no-experimental-webstorage`, otherwise Node's built-in `localStorage` global shadows jsdom's.